### PR TITLE
UI: move the selector cursor to the first game on a typed letter

### DIFF
--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -2999,12 +2999,19 @@ void NotifySelector(LPNMHDR pnmh)
 // set selected item, by first letter key pressed
 void ScrollSelector(int letter)
 {
-	letter = tolower(letter);
+	// opened ?
+	if (!usel.opened) return;
+
+	// Case folding is limited to the ASCII range on purpose: the locale dependent
+	// tolower() is undefined for characters outside of that range.
+	auto lower = [](wchar_t c) { return (c >= L'A' && c <= L'Z') ? (wchar_t)(c - L'A' + L'a') : c; };
+
+	letter = lower((wchar_t)letter);
+
 	for (size_t n = 0; n < usel.files.size(); n++)
 	{
 		UserFile* file = usel.files[n].get();
-		int c = tolower(file->title[0]);
-		if (c == letter)
+		if (lower(file->title[0]) == letter)
 		{
 			SelectorSetSelected(n);
 			break;
@@ -3127,6 +3134,23 @@ void SortSelector(SELECTOR_SORT sortBy)
 // need to check "active" flags for other calls, because if it is not "active"
 // it cannot be "opened".
 
+// A letter, typed over the filelist, sets the cursor to the first file whose
+// title begins with that letter. The listview cannot do it by itself, because
+// its first (Icon) column is filled with a stub text and the whole item is
+// drawn by DrawSelectorItem().
+static WNDPROC listViewProc;
+
+static LRESULT CALLBACK SelectorProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+	if (msg == WM_CHAR && (wchar_t)wParam >= L' ')
+	{
+		ScrollSelector((int)wParam);
+		return 0;
+	}
+
+	return CallWindowProc(listViewProc, hwnd, msg, wParam, lParam);
+}
+
 void CreateSelector()
 {
 	// allowed ?
@@ -3156,6 +3180,9 @@ void CreateSelector()
 	EnableWindow(usel.hSelectorWindow, TRUE);
 	ShowWindow(usel.hSelectorWindow, SW_SHOW);
 	SetFocus(usel.hSelectorWindow);
+
+	// intercept letters, typed over the filelist (see SelectorProc)
+	listViewProc = (WNDPROC)SetWindowLongPtr(usel.hSelectorWindow, GWLP_WNDPROC, (LONG_PTR)SelectorProc);
 
 	// retrieve icon size
 	bool iconSize = UI::Jdi->GetConfigBool(USER_SMALLICONS, USER_UI);


### PR DESCRIPTION
Issue #92 asks the game selection window to react to a typed letter: pressing T should move the cursor to the first game in the list whose name begins with T.

ScrollSelector() already did exactly that, but nothing ever called it, and the listview cannot do the search on its own: the incremental search of a listview matches the item label, and column 0 (Icon) returns a stub " " from getdispinfo(), because the whole row is drawn by DrawSelectorItem() anyway.

- the selector listview is subclassed (SelectorProc). A WM_CHAR that carries a printable character goes to ScrollSelector(), everything else still reaches the original procedure, so the keyboard navigation of the listview is untouched. The subclass is installed in CreateSelector(), so it also survives Options -> Disable/Enable Selector;
- ScrollSelector() now checks the "opened" flag and folds case over the ASCII range only: the locale dependent tolower() is undefined for characters outside of it, and a title (a DVD banner long title, or a file name) may contain any Unicode;
- the search follows the Title column, that is, what the user actually sees.

Verified on the Windows build (Release|x64 and Debug|x64 build clean) by driving the running emulator: a real WM_KEYDOWN is posted to the listview, the message pump of the application itself turns it into WM_CHAR, and the selected row is read back out of the control afterwards.

- with six dummy *.dol games, every tested letter (a, l, m, t, z) lands on the first title with that letter in the list order, exactly one row stays selected, an upper case letter behaves the same, a letter that matches nothing leaves the cursor alone, and Home/End/Up/Down still work;
- with a real ISO library, where the titles come from the DVD banners, 't' selects "The Legend of Zelda: The Wind Waker" and 'l' selects "Luigi's Mansion", so the file name ("Legend of Zelda, The - ...") is deliberately not what is matched.