### PR TITLE
GFX: route the CP command stream through the XF and add XF register r…

### DIFF
--- a/src/cp.cpp
+++ b/src/cp.cpp
@@ -1,4 +1,4 @@
-﻿// CP - command processor
+// CP - command processor
 #include "pch.h"
 
 // TODO: It's a bit crooked right now after refactoring, but will settle with time
@@ -285,11 +285,11 @@ namespace Flipper
 			case CP_FRCLK_CNTH:
 				return 0;
 			case CP_XF_ADDR:
-				return 0;
+				return (uint16_t)cpregs.xfAddr;
 			case CP_XF_DATAL:
-				return 0;
+				return (uint16_t)cpregs.xfData;
 			case CP_XF_DATAH:
-				return 0;
+				return (uint16_t)(cpregs.xfData >> 16);
 		}
 
 		return 0;
@@ -416,10 +416,14 @@ namespace Flipper
 			case CP_FRCLK_CNTH:
 				break;
 			case CP_XF_ADDR:
+				// Writing the register address starts a read of the XF register space over the
+				// CP -> XF read-back path; the answer is left in CP_XF_DATAL / CP_XF_DATAH.
+				cpregs.xfAddr = value;
+				ReadXFReg(value);
 				break;
 			case CP_XF_DATAL:
-				break;
 			case CP_XF_DATAH:
+				// Read-back data, read-only.
 				break;
 		}
 	}
@@ -591,6 +595,38 @@ namespace Flipper
 				Report(Channel::GP, "Unknown CP load, index: 0x%02X\n", index);
 			}
 		}
+	}
+
+	// The CP -> XF handshake (gfx-xf.md 2.1). The CP may only push a word into the XF while the XF
+	// is ready; the only thing that makes the XF busy in this emulator is a read-back word that the
+	// CP has not taken yet, and taking it (XFrdValid / XFrdData) releases the XF again. The word
+	// that the CP takes this way is latched in CP_XF_DATAL / CP_XF_DATAH, where the CPU sees it.
+
+	void CommandProcessor::XFSync()
+	{
+		while (!HW->gfx->xf->CPReady())
+		{
+			uint32_t value;
+
+			if (!HW->gfx->xf->CPTakeReadData(&value))
+			{
+				break;
+			}
+
+			cpregs.xfData = value;
+		}
+	}
+
+	// Read an XF register over the CP -> XF read-back path (xf_cmd_regread). The XF puts the value
+	// of its own register state on the read-back line, and the CP latches it.
+
+	uint32_t CommandProcessor::ReadXFReg(size_t index)
+	{
+		XFSync();									// wait for XFready, then request the register
+		HW->gfx->xf->CPRegRead(index);
+		XFSync();									// take the value the XF answered with
+
+		return cpregs.xfData;
 	}
 
 	#pragma endregion "Dealing with registers"
@@ -1612,18 +1648,11 @@ namespace Flipper
 	}
 
 	// collect vertex data
-	void CommandProcessor::FifoWalk(unsigned vatnum, GFX::Vertex* vtx, FifoProcessor* gxfifo)
+	void CommandProcessor::FifoWalk(unsigned vatnum, GFX::Vertex* vtx, FifoProcessor* gxfifo, const GFX::MatrixIndex0& matIdx0, const GFX::MatrixIndex1& matIdx1)
 	{
-		// overrided by 'mtxidx' attributes
-		vtx->matIdx0.PosNrmMatIdx = HW->gfx->xf->xf.matIdxA.PosNrmMatIdx;
-		vtx->matIdx0.Tex0MatIdx = HW->gfx->xf->xf.matIdxA.Tex0MatIdx;
-		vtx->matIdx0.Tex1MatIdx = HW->gfx->xf->xf.matIdxA.Tex1MatIdx;
-		vtx->matIdx0.Tex2MatIdx = HW->gfx->xf->xf.matIdxA.Tex2MatIdx;
-		vtx->matIdx0.Tex3MatIdx = HW->gfx->xf->xf.matIdxA.Tex3MatIdx;
-		vtx->matIdx1.Tex4MatIdx = HW->gfx->xf->xf.matIdxB.Tex4MatIdx;
-		vtx->matIdx1.Tex5MatIdx = HW->gfx->xf->xf.matIdxB.Tex5MatIdx;
-		vtx->matIdx1.Tex6MatIdx = HW->gfx->xf->xf.matIdxB.Tex6MatIdx;
-		vtx->matIdx1.Tex7MatIdx = HW->gfx->xf->xf.matIdxB.Tex7MatIdx;
+		// The XF matrix index registers hold the defaults; the 'mtxidx' attributes override them.
+		vtx->matIdx0 = matIdx0;
+		vtx->matIdx1 = matIdx1;
 
 		// Matrix Index
 
@@ -1804,6 +1833,57 @@ namespace Flipper
 			ArrayId::Tex7Coord);
 	}
 
+	// Execute one draw command. The CP owns the vertex fetch (VCD/VAT and the attribute arrays), so
+	// it unpacks the vertex data and pushes the resulting vertex rows into the XF, which is the
+	// entry point of the graphics pipeline.
+
+	void CommandProcessor::DrawPrimitive(uint8_t command, FifoProcessor* gxfifo, GFX::RAS_Primitive prim)
+	{
+		unsigned vatnum = command & 7;
+		unsigned vtxnum = gxfifo->Read16();
+
+		if (logDrawCommands)
+		{
+			Report(Channel::GP, "Draw: cmd: 0x%02X, vtxnum: %i, vat: %i\n", command, vtxnum, vatnum);
+		}
+
+		if (vtxnum == 0)
+			return;
+
+		switch (prim)
+		{
+			case GFX::RAS_QUAD:				tris += (vtxnum / 4) / 2; break;
+			case GFX::RAS_QUAD_STRIP:		tris += (vtxnum / 2 - 1) / 2; break;
+			case GFX::RAS_TRIANGLE:			tris += vtxnum / 3; break;
+			case GFX::RAS_TRIANGLE_STRIP:	tris += vtxnum - 2; break;
+			case GFX::RAS_TRIANGLE_FAN:		tris += vtxnum - 2; break;
+			case GFX::RAS_LINE:				lines += vtxnum / 2; break;
+			case GFX::RAS_LINE_STRIP:		lines += vtxnum - 1; break;
+			case GFX::RAS_POINT:			pts += vtxnum; break;
+		}
+
+		// The default matrix indexes live in the XF; read them over the CP -> XF read-back path.
+
+		GFX::MatrixIndex0 matIdx0{};
+		matIdx0.bits = ReadXFReg(GFX::XF_MATINDEX_A_ID);
+
+		GFX::MatrixIndex1 matIdx1{};
+		matIdx1.bits = ReadXFReg(GFX::XF_MATINDEX_B_ID);
+
+		XFSync();
+		HW->gfx->xf->CPDrawBegin(prim, vtxnum);
+
+		GFX::Vertex vtx;
+
+		while (vtxnum--)
+		{
+			FifoWalk(vatnum, &vtx, gxfifo, matIdx0, matIdx1);
+			HW->gfx->xf->CPVertex(&vtx);
+		}
+
+		HW->gfx->xf->CPDrawEnd();
+	}
+
 	void CommandProcessor::GxBadFifo(uint8_t command)
 	{
 		Halt(
@@ -1934,7 +2014,9 @@ namespace Flipper
 					Report(Channel::GP, "Load reg: index: 0x%02X, data: 0x%08X\n", index, value);
 				}
 
-				HW->gfx->su->loadSUReg(index, value);
+				// The bypass load goes through the XF, which forwards it to the SU.
+				XFSync();
+				HW->gfx->xf->CPSuCommand(index, value);
 				break;
 			}
 
@@ -1974,7 +2056,14 @@ namespace Flipper
 					Report(Channel::GP, "XF load, start index: %04X, n : %i\n", index, len);
 				}
 
-				HW->gfx->xf->loadXFRegs(index, len, gxfifo);
+				// Push the block write into the XF: the load header, then one word per register.
+				XFSync();
+				HW->gfx->xf->CPRegLoadBegin(index, len);
+
+				for (size_t i = 0; i < len; i++)
+				{
+					HW->gfx->xf->CPRegLoadData(gxfifo->Read32());
+				}
 				break;
 			}
 
@@ -2062,28 +2151,8 @@ namespace Flipper
 			case CP_CMD_DRAW_QUAD | 5:
 			case CP_CMD_DRAW_QUAD | 6:
 			case CP_CMD_DRAW_QUAD | 7:
-			{
-				unsigned vatnum = cmd & 7;
-				unsigned vtxnum = gxfifo->Read16();
-				if (logDrawCommands)
-				{
-					Report(Channel::GP, "CP_CMD_DRAW_QUAD: vtxnum: %i, vat: %i\n", vtxnum, vatnum);
-				}
-
-				if (vtxnum != 0) {
-					tris += (vtxnum / 4) / 2;
-
-					HW->gfx->ras->RAS_Begin(GFX::RAS_QUAD, vtxnum);
-					GFX::Vertex vtx;
-					while (vtxnum--) {
-
-						FifoWalk(vatnum, &vtx, gxfifo);
-						HW->gfx->ras->RAS_SendVertex(&vtx);
-					}
-					HW->gfx->ras->RAS_End();
-				}
+				DrawPrimitive(cmd, gxfifo, GFX::RAS_QUAD);
 				break;
-			}
 
 			// 0x88
 			case CP_CMD_DRAW_QUAD_STRIP | 0:
@@ -2094,28 +2163,8 @@ namespace Flipper
 			case CP_CMD_DRAW_QUAD_STRIP | 5:
 			case CP_CMD_DRAW_QUAD_STRIP | 6:
 			case CP_CMD_DRAW_QUAD_STRIP | 7:
-			{
-				unsigned vatnum = cmd & 7;
-				unsigned vtxnum = gxfifo->Read16();
-				if (logDrawCommands)
-				{
-					Report(Channel::GP, "CP_CMD_DRAW_QUAD_STRIP: vtxnum: %i, vat: %i\n", vtxnum, vatnum);
-				}
-
-				if (vtxnum != 0) {
-					tris += (vtxnum / 2 - 1) / 2;
-
-					HW->gfx->ras->RAS_Begin(GFX::RAS_QUAD_STRIP, vtxnum);
-					GFX::Vertex vtx;
-					while (vtxnum--) {
-
-						FifoWalk(vatnum, &vtx, gxfifo);
-						HW->gfx->ras->RAS_SendVertex(&vtx);
-					}
-					HW->gfx->ras->RAS_End();
-				}
+				DrawPrimitive(cmd, gxfifo, GFX::RAS_QUAD_STRIP);
 				break;
-			}
 
 			// 0x90
 			case CP_CMD_DRAW_TRIANGLE | 0:
@@ -2126,28 +2175,8 @@ namespace Flipper
 			case CP_CMD_DRAW_TRIANGLE | 5:
 			case CP_CMD_DRAW_TRIANGLE | 6:
 			case CP_CMD_DRAW_TRIANGLE | 7:
-			{
-				unsigned vatnum = cmd & 7;
-				unsigned vtxnum = gxfifo->Read16();
-				if (logDrawCommands)
-				{
-					Report(Channel::GP, "CP_CMD_DRAW_TRIANGLE: vtxnum: %i, vat: %i\n", vtxnum, vatnum);
-				}
-
-				if (vtxnum != 0) {
-					tris += vtxnum / 3;
-
-					HW->gfx->ras->RAS_Begin(GFX::RAS_TRIANGLE, vtxnum);
-					GFX::Vertex vtx;
-					while (vtxnum--) {
-
-						FifoWalk(vatnum, &vtx, gxfifo);
-						HW->gfx->ras->RAS_SendVertex(&vtx);
-					}
-					HW->gfx->ras->RAS_End();
-				}
+				DrawPrimitive(cmd, gxfifo, GFX::RAS_TRIANGLE);
 				break;
-			}
 
 			// 0x98 
 			case CP_CMD_DRAW_STRIP | 0:
@@ -2158,28 +2187,8 @@ namespace Flipper
 			case CP_CMD_DRAW_STRIP | 5:
 			case CP_CMD_DRAW_STRIP | 6:
 			case CP_CMD_DRAW_STRIP | 7:
-			{
-				unsigned vatnum = cmd & 7;
-				unsigned vtxnum = gxfifo->Read16();
-				if (logDrawCommands)
-				{
-					Report(Channel::GP, "CP_CMD_DRAW_STRIP: vtxnum: %i, vat: %i\n", vtxnum, vatnum);
-				}
-
-				if (vtxnum != 0) {
-					tris += vtxnum - 2;
-
-					HW->gfx->ras->RAS_Begin(GFX::RAS_TRIANGLE_STRIP, vtxnum);
-					GFX::Vertex vtx;
-					while (vtxnum--) {
-
-						FifoWalk(vatnum, &vtx, gxfifo);
-						HW->gfx->ras->RAS_SendVertex(&vtx);
-					}
-					HW->gfx->ras->RAS_End();
-				}
+				DrawPrimitive(cmd, gxfifo, GFX::RAS_TRIANGLE_STRIP);
 				break;
-			}
 
 			// 0xA0
 			case CP_CMD_DRAW_FAN | 0:
@@ -2190,28 +2199,8 @@ namespace Flipper
 			case CP_CMD_DRAW_FAN | 5:
 			case CP_CMD_DRAW_FAN | 6:
 			case CP_CMD_DRAW_FAN | 7:
-			{
-				unsigned vatnum = cmd & 7;
-				unsigned vtxnum = gxfifo->Read16();
-				if (logDrawCommands)
-				{
-					Report(Channel::GP, "CP_CMD_DRAW_FAN: vtxnum: %i, vat: %i\n", vtxnum, vatnum);
-				}
-
-				if (vtxnum != 0) {
-					tris += vtxnum - 2;
-
-					HW->gfx->ras->RAS_Begin(GFX::RAS_TRIANGLE_FAN, vtxnum);
-					GFX::Vertex vtx;
-					while (vtxnum--) {
-
-						FifoWalk(vatnum, &vtx, gxfifo);
-						HW->gfx->ras->RAS_SendVertex(&vtx);
-					}
-					HW->gfx->ras->RAS_End();
-				}
+				DrawPrimitive(cmd, gxfifo, GFX::RAS_TRIANGLE_FAN);
 				break;
-			}
 
 			// 0xA8
 			case CP_CMD_DRAW_LINE | 0:
@@ -2222,28 +2211,8 @@ namespace Flipper
 			case CP_CMD_DRAW_LINE | 5:
 			case CP_CMD_DRAW_LINE | 6:
 			case CP_CMD_DRAW_LINE | 7:
-			{
-				unsigned vatnum = cmd & 7;
-				unsigned vtxnum = gxfifo->Read16();
-				if (logDrawCommands)
-				{
-					Report(Channel::GP, "CP_CMD_DRAW_LINE: vtxnum: %i, vat: %i\n", vtxnum, vatnum);
-				}
-
-				if (vtxnum != 0) {
-					lines += vtxnum / 2;
-
-					HW->gfx->ras->RAS_Begin(GFX::RAS_LINE, vtxnum);
-					GFX::Vertex vtx;
-					while (vtxnum--) {
-
-						FifoWalk(vatnum, &vtx, gxfifo);
-						HW->gfx->ras->RAS_SendVertex(&vtx);
-					}
-					HW->gfx->ras->RAS_End();
-				}
+				DrawPrimitive(cmd, gxfifo, GFX::RAS_LINE);
 				break;
-			}
 
 			// 0xB0
 			case CP_CMD_DRAW_LINESTRIP | 0:
@@ -2254,28 +2223,8 @@ namespace Flipper
 			case CP_CMD_DRAW_LINESTRIP | 5:
 			case CP_CMD_DRAW_LINESTRIP | 6:
 			case CP_CMD_DRAW_LINESTRIP | 7:
-			{
-				unsigned vatnum = cmd & 7;
-				unsigned vtxnum = gxfifo->Read16();
-				if (logDrawCommands)
-				{
-					Report(Channel::GP, "CP_CMD_DRAW_LINESTRIP: vtxnum: %i, vat: %i\n", vtxnum, vatnum);
-				}
-
-				if (vtxnum != 0) {
-					lines += vtxnum - 1;
-
-					HW->gfx->ras->RAS_Begin(GFX::RAS_LINE_STRIP, vtxnum);
-					GFX::Vertex vtx;
-					while (vtxnum--) {
-
-						FifoWalk(vatnum, &vtx, gxfifo);
-						HW->gfx->ras->RAS_SendVertex(&vtx);
-					}
-					HW->gfx->ras->RAS_End();
-				}
+				DrawPrimitive(cmd, gxfifo, GFX::RAS_LINE_STRIP);
 				break;
-			}
 
 			// 0xB8
 			case CP_CMD_DRAW_POINT | 0:
@@ -2286,28 +2235,8 @@ namespace Flipper
 			case CP_CMD_DRAW_POINT | 5:
 			case CP_CMD_DRAW_POINT | 6:
 			case CP_CMD_DRAW_POINT | 7:
-			{
-				unsigned vatnum = cmd & 7;
-				unsigned vtxnum = gxfifo->Read16();
-				if (logDrawCommands)
-				{
-					Report(Channel::GP, "CP_CMD_DRAW_POINT: vtxnum: %i, vat: %i\n", vtxnum, vatnum);
-				}
-
-				if (vtxnum != 0) {
-					pts += vtxnum;
-
-					HW->gfx->ras->RAS_Begin(GFX::RAS_POINT, vtxnum);
-					GFX::Vertex vtx;
-					while (vtxnum--) {
-
-						FifoWalk(vatnum, &vtx, gxfifo);
-						HW->gfx->ras->RAS_SendVertex(&vtx);
-					}
-					HW->gfx->ras->RAS_End();
-				}
+				DrawPrimitive(cmd, gxfifo, GFX::RAS_POINT);
 				break;
-			}
 
 			// ---------------------------------------------------------------
 			// Unknown/unsupported fifo command

--- a/src/cp.h
+++ b/src/cp.h
@@ -178,6 +178,8 @@ namespace Flipper
 			};
 			volatile uint32_t     bpptr;
 		};
+		uint32_t     xfAddr;     // XF register address (CP_XF_ADDR) for the CP -> XF read-back path
+		uint32_t     xfData;     // XF register read-back data (CP_XF_DATAL / CP_XF_DATAH)
 	};
 
 	#pragma pack(pop)
@@ -546,9 +548,20 @@ namespace Flipper
 		void FetchComp(float* comp, int count, int type, int fmt, int shft, FifoProcessor* gxfifo, ArrayId arrayId);
 		void FetchNorm(float* comp, int count, int type, int fmt, int shft, FifoProcessor* gxfifo, ArrayId arrayId, bool nrmidx3);
 		GFX::Color FetchColor(int type, int fmt, FifoProcessor* gxfifo, ArrayId arrayId);
-		void FifoWalk(unsigned vatnum, GFX::Vertex* vtx, FifoProcessor* gxfifo);
+		void FifoWalk(unsigned vatnum, GFX::Vertex* vtx, FifoProcessor* gxfifo, const GFX::MatrixIndex0& matIdx0, const GFX::MatrixIndex1& matIdx1);
 		void GxBadFifo(uint8_t command);
 		void GxCommand(FifoProcessor* gxfifo);
+
+		//! The CP -> XF handshake: every word the CP pushes into the XF goes through here, which
+		//! picks up XF read-back data while the XF is busy (see xf.h)
+		void XFSync();
+
+		//! Read an XF register over the CP -> XF read-back path. The value is also latched in
+		//! CP_XF_DATAL / CP_XF_DATAH, where the CPU can pick it up
+		uint32_t ReadXFReg(size_t index);
+
+		//! Execute one draw command: unpack its vertices and push them into the XF
+		void DrawPrimitive(uint8_t command, FifoProcessor* gxfifo, GFX::RAS_Primitive prim);
 
 		static void CPRegRead(uint32_t addr, uint32_t* reg, void* context);
 		static void CPRegWrite(uint32_t addr, uint32_t data, void* context);

--- a/src/ras.h
+++ b/src/ras.h
@@ -24,18 +24,6 @@ namespace GFX
 	#define RAS1_TREF6_ID 0x2E
 	#define RAS1_TREF7_ID 0x2F
 
-	enum RAS_Primitive : size_t
-	{
-		RAS_QUAD = 0,
-		RAS_QUAD_STRIP,
-		RAS_TRIANGLE,
-		RAS_TRIANGLE_STRIP,
-		RAS_TRIANGLE_FAN,
-		RAS_LINE,
-		RAS_LINE_STRIP,
-		RAS_POINT,
-	};
-
 	// Texture coordinate scale (RAS1_SS0/SS1). Only the scale factors are used (for texcoord scale emulation).
 	union RAS1_SS
 	{

--- a/src/su.cpp
+++ b/src/su.cpp
@@ -157,4 +157,25 @@ namespace GFX
 	SetupUnit::~SetupUnit()
 	{
 	}
+
+	//
+	// The vertex stream coming from the XF. In this emulator the setup work (the primitive
+	// assembly) happens in the GL backend, so the SU just drives the rasterizers with the
+	// primitives and vertex rows the XF hands over.
+	//
+
+	void SetupUnit::BeginPrimitive(RAS_Primitive prim, size_t vtx_num)
+	{
+		gfx->ras->RAS_Begin(prim, vtx_num);
+	}
+
+	void SetupUnit::SendVertex(const Vertex* v)
+	{
+		gfx->ras->RAS_SendVertex(v);
+	}
+
+	void SetupUnit::EndPrimitive()
+	{
+		gfx->ras->RAS_End();
+	}
 }

--- a/src/su.h
+++ b/src/su.h
@@ -205,5 +205,12 @@ namespace GFX
 		~SetupUnit();
 
 		void loadSUReg(size_t index, uint32_t value);
+
+		// The vertex stream that the XF produces (gfx-xf.md 2.2): the SU parses it and drives the
+		// rasterizers with it.
+
+		void BeginPrimitive(RAS_Primitive prim, size_t vtx_num);
+		void SendVertex(const Vertex* v);
+		void EndPrimitive();
 	};
 }

--- a/src/xf.cpp
+++ b/src/xf.cpp
@@ -564,230 +564,154 @@ void main()
 		glDepthRange(znear, zfar);
 	}
 
-	// index range = 0000..FFFF
-	// reg size = 32 bit
-	void TransformUnit::loadXFRegs(size_t startIdx, size_t amount, Flipper::FifoProcessor* gxfifo)
+	// -------------------------------------------------------------------------------------------
+	// The XF register space (gfx-xf.md 4)
+	//
+	// The CP addresses the XF registers one word at a time over the CP -> XF interface. The matrix
+	// RAMs and the light records are addressed word by word, so both a block write and a write of a
+	// single register work on any register of the space.
+	// -------------------------------------------------------------------------------------------
+
+	// Write one word of the XF register space.
+	void TransformUnit::WriteXFReg(size_t index, uint32_t value)
 	{
-		// load geometry matrix
-		if ((startIdx >= XF_MATRIX_MEMORY_ID) && (startIdx < (XF_MATRIX_MEMORY_ID + XF_MATRIX_MEMORY_SIZE)))
+		//
+		// ModelView / Texture matrix RAM (0x0000-0x00FF)
+		//
+
+		if (index < XF_MATRIX_MEMORY_SIZE)
 		{
-			for (size_t i = 0; i < amount; i++)
-			{
-				xf.mvTexMtx[(startIdx - XF_MATRIX_MEMORY_ID) + i] = gxfifo->ReadFloat();
-			}
+			xf.mvTexMtx[index] = *(float*)&value;
+			return;
 		}
-		// load normal matrix
-		else if ((startIdx >= XF_NORMAL_MATRIX_MEMORY_ID) && (startIdx < (XF_NORMAL_MATRIX_MEMORY_ID + XF_NORMAL_MATRIX_MEMORY_SIZE)))
+
+		//
+		// Normal matrix RAM (0x0400-0x045F)
+		//
+
+		if (index >= XF_NORMAL_MATRIX_MEMORY_ID && index < (XF_NORMAL_MATRIX_MEMORY_ID + XF_NORMAL_MATRIX_MEMORY_SIZE))
 		{
-			for (size_t i = 0; i < amount; i++)
-			{
-				xf.nrmMtx[(startIdx - XF_NORMAL_MATRIX_MEMORY_ID) + i] = gxfifo->ReadFloat();
-			}
+			xf.nrmMtx[index - XF_NORMAL_MATRIX_MEMORY_ID] = *(float*)&value;
+			return;
 		}
-		// load post-trans matrix
-		else if ((startIdx >= XF_DUALTEX_MATRIX_MEMORY_ID) && (startIdx < (XF_DUALTEX_MATRIX_MEMORY_ID + XF_DUALTEX_MATRIX_MEMORY_SIZE)))
+
+		//
+		// Dual texture transform matrix RAM (0x0500-0x05FF)
+		//
+
+		if (index >= XF_DUALTEX_MATRIX_MEMORY_ID && index < (XF_DUALTEX_MATRIX_MEMORY_ID + XF_DUALTEX_MATRIX_MEMORY_SIZE))
 		{
-			for (size_t i = 0; i < amount; i++)
-			{
-				xf.dualTexMtx[(startIdx - XF_DUALTEX_MATRIX_MEMORY_ID) + i] = gxfifo->ReadFloat();
-			}
+			xf.dualTexMtx[index - XF_DUALTEX_MATRIX_MEMORY_ID] = *(float*)&value;
+			return;
 		}
-		else switch (startIdx)
+
+		//
+		// Light records (0x0600-0x067F), XF_LIGHT_DATA_SIZE words per light
+		//
+
+		if (index >= XF_LIGHT_MEMORY_ID && index < (XF_LIGHT_MEMORY_ID + XF_LIGHT_MEMORY_SIZE))
 		{
-			case XF_ERROR_ID:
-				xf.error = gxfifo->Read32();
-				break;
-			case XF_DIAGNOSTICS_ID:
-				xf.diagnostics = gxfifo->Read32();
-				break;
-			case XF_STATE0_ID:
-				xf.state[0] = gxfifo->Read32();
-				break;
-			case XF_STATE1_ID:
-				xf.state[1] = gxfifo->Read32();
-				break;
-			case XF_CLOCK_ID:
-				xf.clock = gxfifo->Read32();
-				break;
+			Light* light = &xf.light[(index - XF_LIGHT_MEMORY_ID) / XF_LIGHT_DATA_SIZE];
+			size_t ofs = (index - XF_LIGHT_MEMORY_ID) % XF_LIGHT_DATA_SIZE;
+
+			if (ofs < 3)
+				light->Reserved[ofs] = value;
+			else if (ofs == 3)
+				light->rgba.RGBA = value;
+			else if (ofs < 7)
+				light->a[ofs - 4] = *(float*)&value;
+			else if (ofs < 0xa)
+				light->k[ofs - 7] = *(float*)&value;
+			else if (ofs < 0xd)
+				light->lpx[ofs - 0xa] = *(float*)&value;
+			else
+				light->dhx[ofs - 0xd] = *(float*)&value;
+
+			return;
+		}
+
+		switch (index)
+		{
+			case XF_ERROR_ID:			xf.error = value; break;
+			case XF_DIAGNOSTICS_ID:		xf.diagnostics = value; break;
+			case XF_STATE0_ID:			xf.state[0] = value; break;
+			case XF_STATE1_ID:			xf.state[1] = value; break;
+			case XF_CLOCK_ID:			xf.clock = value; break;
+
 			case XF_CLIP_DISABLE_ID:
 				// TODO: How does this affect Culling in the Setup Unit?
-				xf.clipDisable.bits = gxfifo->Read32();
+				xf.clipDisable.bits = value;
 				break;
-			case XF_PERF0_ID:
-				xf.perf[0] = gxfifo->Read32();
-				break;
-			case XF_PERF1_ID:
-				xf.perf[1] = gxfifo->Read32();
-				break;
+
+			case XF_PERF0_ID:			xf.perf[0] = value; break;
+			case XF_PERF1_ID:			xf.perf[1] = value; break;
 
 			//
 			// set matrix index
 			//
 
-			case XF_MATINDEX_A_ID:
-				xf.matIdxA.bits = gxfifo->Read32();
+			case XF_MATINDEX_A_ID:		xf.matIdxA.bits = value; break;
+			case XF_MATINDEX_B_ID:		xf.matIdxB.bits = value; break;
+
+			//
+			// viewport configuration. The emulator viewport is refreshed on every word, so a
+			// viewport programmed with several block writes also ends up correct.
+			//
+
+			case XF_VIEWPORT_SCALE_X_ID:
+			case XF_VIEWPORT_SCALE_Y_ID:
+			case XF_VIEWPORT_SCALE_Z_ID:
+				xf.viewportScale[index - XF_VIEWPORT_SCALE_X_ID] = *(float*)&value;
+				ApplyViewport();
 				break;
 
-			case XF_MATINDEX_B_ID:
-				xf.matIdxB.bits = gxfifo->Read32();
+			case XF_VIEWPORT_OFFSET_X_ID:
+			case XF_VIEWPORT_OFFSET_Y_ID:
+			case XF_VIEWPORT_OFFSET_Z_ID:
+				xf.viewportOffset[index - XF_VIEWPORT_OFFSET_X_ID] = *(float*)&value;
+				ApplyViewport();
 				break;
 
 			//
-			// load projection matrix (TODO: unaligned writes)
+			// projection matrix
 			//
 
 			case XF_PROJECTION_A_ID:
-			{
-				if (amount != 7) {
-					Halt("Partial loading of the projection matrix is not implemented\n");
-				}
+			case XF_PROJECTION_B_ID:
+			case XF_PROJECTION_C_ID:
+			case XF_PROJECTION_D_ID:
+			case XF_PROJECTION_E_ID:
+			case XF_PROJECTION_F_ID:
+				xf.projectionParam[index - XF_PROJECTION_A_ID] = *(float*)&value;
+				break;
 
-				xf.projectionParam[0] = gxfifo->ReadFloat();
-				xf.projectionParam[1] = gxfifo->ReadFloat();
-				xf.projectionParam[2] = gxfifo->ReadFloat();
-				xf.projectionParam[3] = gxfifo->ReadFloat();
-				xf.projectionParam[4] = gxfifo->ReadFloat();
-				xf.projectionParam[5] = gxfifo->ReadFloat();
-				xf.projectOrtho = gxfifo->ReadFloat() != 0.0f;
-			}
-			return;
-
-			//
-			// load viewport configuration (TODO: unaligned writes)
-			// 
-
-			case XF_VIEWPORT_SCALE_X_ID:
-			{
-				float w, h, x, y, zf, zn;
-
-				if (amount != 6) {
-					Halt("Partial loading of the viewport settings is not implemented\n");
-				}
-
-				//
-				// read coefficients
-				//
-
-				xf.viewportScale[0] = gxfifo->ReadFloat();   // w / 2
-				xf.viewportScale[1] = gxfifo->ReadFloat();   // -h / 2
-				xf.viewportScale[2] = gxfifo->ReadFloat();   // ZMAX * (zfar - znear)
-
-				xf.viewportOffset[0] = gxfifo->ReadFloat();    // x + w/2 + 342
-				xf.viewportOffset[1] = gxfifo->ReadFloat();    // y + h/2 + 342
-				xf.viewportOffset[2] = gxfifo->ReadFloat();    // ZMAX * zfar
-
-				//
-				// convert them to human usable form
-				//
-
-				w = xf.viewportScale[0] * 2;
-				h = -xf.viewportScale[1] * 2;
-				x = xf.viewportOffset[0] - xf.viewportScale[0] - 342;
-				y = xf.viewportOffset[1] + xf.viewportScale[1] - 342;
-				zf = xf.viewportOffset[2] / 16777215.0f;
-				zn = -((xf.viewportScale[2] / 16777215.0f) - zf);
-
-				GL_SetViewport((int)x, (int)y, (int)w, (int)h, zn, zf);
-			}
-			return;
-
-			//
-			// load light object (TODO: unaligned writes not supported)
-			//
-
-			case XF_LIGHT0_ID:
-			case XF_LIGHT1_ID:
-			case XF_LIGHT2_ID:
-			case XF_LIGHT3_ID:
-			case XF_LIGHT4_ID:
-			case XF_LIGHT5_ID:
-			case XF_LIGHT6_ID:
-			case XF_LIGHT7_ID:
-			{
-				unsigned lnum = (startIdx >> 4) & 7;
-
-				if (amount != 16) {
-					Halt("Partial loading of the light object memory is not implemented\n");
-				}
-
-				xf.light[lnum].Reserved[0] = gxfifo->Read32();
-				xf.light[lnum].Reserved[1] = gxfifo->Read32();
-				xf.light[lnum].Reserved[2] = gxfifo->Read32();
-				xf.light[lnum].rgba.RGBA = gxfifo->Read32();
-
-				xf.light[lnum].a[0] = gxfifo->ReadFloat();
-				xf.light[lnum].a[1] = gxfifo->ReadFloat();
-				xf.light[lnum].a[2] = gxfifo->ReadFloat();
-
-				xf.light[lnum].k[0] = gxfifo->ReadFloat();
-				xf.light[lnum].k[1] = gxfifo->ReadFloat();
-				xf.light[lnum].k[2] = gxfifo->ReadFloat();
-
-				xf.light[lnum].lpx[0] = gxfifo->ReadFloat();
-				xf.light[lnum].lpx[1] = gxfifo->ReadFloat();
-				xf.light[lnum].lpx[2] = gxfifo->ReadFloat();
-
-				xf.light[lnum].dhx[0] = gxfifo->ReadFloat();
-				xf.light[lnum].dhx[1] = gxfifo->ReadFloat();
-				xf.light[lnum].dhx[2] = gxfifo->ReadFloat();
-			}
-			return;
-
-			case XF_INVTXSPEC_ID:
-			{
-				xf.vtxSpec.bits = gxfifo->Read32();
-			}
-			return;
+			case XF_PROJECT_ORTHO_ID:
+				xf.projectOrtho = (*(float*)&value) != 0.0f;
+				break;
 
 			//
 			// channel constant color registers
 			//
 
-			case XF_AMBIENT0_ID:
-				xf.ambient[0].RGBA = gxfifo->Read32();
-				break;
-
-			case XF_AMBIENT1_ID:
-				xf.ambient[1].RGBA = gxfifo->Read32();
-				break;
-
-			case XF_MATERIAL0_ID:
-				xf.material[0].RGBA = gxfifo->Read32();
-				break;
-
-			case XF_MATERIAL1_ID:
-				xf.material[1].RGBA = gxfifo->Read32();
-				break;
+			case XF_AMBIENT0_ID:		xf.ambient[0].RGBA = value; break;
+			case XF_AMBIENT1_ID:		xf.ambient[1].RGBA = value; break;
+			case XF_MATERIAL0_ID:		xf.material[0].RGBA = value; break;
+			case XF_MATERIAL1_ID:		xf.material[1].RGBA = value; break;
 
 			//
 			// channel control registers
 			//
 
-			case XF_COLOR0CNTL_ID:
-				xf.colorControl[0].bits = gxfifo->Read32();
-				break;
-
-			case XF_COLOR1CNTL_ID:
-				xf.colorControl[1].bits = gxfifo->Read32();
-				break;
-
-			case XF_ALPHA0CNTL_ID:
-				xf.alphaControl[0].bits = gxfifo->Read32();
-				break;
-
-			case XF_ALPHA1CNTL_ID:
-				xf.alphaControl[1].bits = gxfifo->Read32();
-				break;
+			case XF_COLOR0CNTL_ID:		xf.colorControl[0].bits = value; break;
+			case XF_COLOR1CNTL_ID:		xf.colorControl[1].bits = value; break;
+			case XF_ALPHA0CNTL_ID:		xf.alphaControl[0].bits = value; break;
+			case XF_ALPHA1CNTL_ID:		xf.alphaControl[1].bits = value; break;
 
 			//
 			// set dualtex enable / disable
 			//
 
-			case XF_DUALTEX_ID:
-			{
-				xf.dualTexTran = gxfifo->Read32();
-			}
-			return;
+			case XF_DUALTEX_ID:			xf.dualTexTran = value; break;
 
 			case XF_DUALGEN0_ID:
 			case XF_DUALGEN1_ID:
@@ -797,29 +721,24 @@ void main()
 			case XF_DUALGEN5_ID:
 			case XF_DUALGEN6_ID:
 			case XF_DUALGEN7_ID:
-			{
-				size_t n = startIdx - XF_DUALGEN0_ID;
-				xf.dualTex[n].bits = gxfifo->Read32();
-			}
-			return;
+				xf.dualTex[index - XF_DUALGEN0_ID].bits = value;
+				break;
+
+			case XF_INVTXSPEC_ID:		xf.vtxSpec.bits = value; break;
 
 			//
 			// number of output colors
 			//
 
-			case XF_NUMCOLS_ID:
-				xf.numColors = gxfifo->Read32();
-				break;
+			case XF_NUMCOLS_ID:			xf.numColors = value; break;
 
 			//
 			// set number of texgens
 			//
 
-			case XF_NUMTEX_ID:
-				xf.numTex = gxfifo->Read32();
-				break;
+			case XF_NUMTEX_ID:			xf.numTex = value; break;
 
-			// 
+			//
 			// set texgen configuration
 			//
 
@@ -831,26 +750,252 @@ void main()
 			case XF_TEXGEN5_ID:
 			case XF_TEXGEN6_ID:
 			case XF_TEXGEN7_ID:
-			{
-				unsigned num = startIdx & 7;
-				xf.tex[num].bits = gxfifo->Read32();
-			}
-			return;
+				xf.tex[index - XF_TEXGEN0_ID].bits = value;
+				break;
 
 			//
 			// not implemented
 			//
 
 			default:
-			{
-				Report(Channel::GP, "Unknown XF load, start index: 0x%04X, count: %i\n", startIdx, amount);
-
-				while (amount--)
-				{
-					gxfifo->Read32();
-				}
-			}
+				Report(Channel::GP, "Unknown XF load, index: 0x%04X\n", index);
+				break;
 		}
+	}
+
+	// Read one word of the XF register space out of the current register state.
+	// The emulator keeps the matrix words as floats, so a read returns exactly what was written
+	// (in the hardware the normal matrix and the light parameters are 20-bit words).
+	uint32_t TransformUnit::ReadXFReg(size_t index)
+	{
+		float value;
+
+		//
+		// ModelView / Texture matrix RAM (0x0000-0x00FF)
+		//
+
+		if (index < XF_MATRIX_MEMORY_SIZE)
+		{
+			return *(uint32_t*)&xf.mvTexMtx[index];
+		}
+
+		//
+		// Normal matrix RAM (0x0400-0x045F)
+		//
+
+		if (index >= XF_NORMAL_MATRIX_MEMORY_ID && index < (XF_NORMAL_MATRIX_MEMORY_ID + XF_NORMAL_MATRIX_MEMORY_SIZE))
+		{
+			return *(uint32_t*)&xf.nrmMtx[index - XF_NORMAL_MATRIX_MEMORY_ID];
+		}
+
+		//
+		// Dual texture transform matrix RAM (0x0500-0x05FF)
+		//
+
+		if (index >= XF_DUALTEX_MATRIX_MEMORY_ID && index < (XF_DUALTEX_MATRIX_MEMORY_ID + XF_DUALTEX_MATRIX_MEMORY_SIZE))
+		{
+			return *(uint32_t*)&xf.dualTexMtx[index - XF_DUALTEX_MATRIX_MEMORY_ID];
+		}
+
+		//
+		// Light records (0x0600-0x067F), XF_LIGHT_DATA_SIZE words per light
+		//
+
+		if (index >= XF_LIGHT_MEMORY_ID && index < (XF_LIGHT_MEMORY_ID + XF_LIGHT_MEMORY_SIZE))
+		{
+			const Light* light = &xf.light[(index - XF_LIGHT_MEMORY_ID) / XF_LIGHT_DATA_SIZE];
+			size_t ofs = (index - XF_LIGHT_MEMORY_ID) % XF_LIGHT_DATA_SIZE;
+
+			if (ofs < 3)
+				return light->Reserved[ofs];
+			if (ofs == 3)
+				return light->rgba.RGBA;
+
+			if (ofs < 7)
+				value = light->a[ofs - 4];
+			else if (ofs < 0xa)
+				value = light->k[ofs - 7];
+			else if (ofs < 0xd)
+				value = light->lpx[ofs - 0xa];
+			else
+				value = light->dhx[ofs - 0xd];
+
+			return *(uint32_t*)&value;
+		}
+
+		switch (index)
+		{
+			case XF_ERROR_ID:			return xf.error;
+			case XF_DIAGNOSTICS_ID:		return xf.diagnostics;
+			case XF_STATE0_ID:			return xf.state[0];
+			case XF_STATE1_ID:			return xf.state[1];
+			case XF_CLOCK_ID:			return xf.clock;
+			case XF_CLIP_DISABLE_ID:	return xf.clipDisable.bits;
+			case XF_PERF0_ID:			return xf.perf[0];
+			case XF_PERF1_ID:			return xf.perf[1];
+			case XF_MATINDEX_A_ID:		return xf.matIdxA.bits;
+			case XF_MATINDEX_B_ID:		return xf.matIdxB.bits;
+
+			case XF_VIEWPORT_SCALE_X_ID:
+			case XF_VIEWPORT_SCALE_Y_ID:
+			case XF_VIEWPORT_SCALE_Z_ID:
+				return *(uint32_t*)&xf.viewportScale[index - XF_VIEWPORT_SCALE_X_ID];
+
+			case XF_VIEWPORT_OFFSET_X_ID:
+			case XF_VIEWPORT_OFFSET_Y_ID:
+			case XF_VIEWPORT_OFFSET_Z_ID:
+				return *(uint32_t*)&xf.viewportOffset[index - XF_VIEWPORT_OFFSET_X_ID];
+
+			case XF_PROJECTION_A_ID:
+			case XF_PROJECTION_B_ID:
+			case XF_PROJECTION_C_ID:
+			case XF_PROJECTION_D_ID:
+			case XF_PROJECTION_E_ID:
+			case XF_PROJECTION_F_ID:
+				return *(uint32_t*)&xf.projectionParam[index - XF_PROJECTION_A_ID];
+
+			case XF_PROJECT_ORTHO_ID:
+				value = xf.projectOrtho ? 1.0f : 0.0f;
+				return *(uint32_t*)&value;
+
+			case XF_AMBIENT0_ID:		return xf.ambient[0].RGBA;
+			case XF_AMBIENT1_ID:		return xf.ambient[1].RGBA;
+			case XF_MATERIAL0_ID:		return xf.material[0].RGBA;
+			case XF_MATERIAL1_ID:		return xf.material[1].RGBA;
+
+			case XF_COLOR0CNTL_ID:		return xf.colorControl[0].bits;
+			case XF_COLOR1CNTL_ID:		return xf.colorControl[1].bits;
+			case XF_ALPHA0CNTL_ID:		return xf.alphaControl[0].bits;
+			case XF_ALPHA1CNTL_ID:		return xf.alphaControl[1].bits;
+
+			case XF_DUALTEX_ID:			return xf.dualTexTran;
+
+			case XF_DUALGEN0_ID:
+			case XF_DUALGEN1_ID:
+			case XF_DUALGEN2_ID:
+			case XF_DUALGEN3_ID:
+			case XF_DUALGEN4_ID:
+			case XF_DUALGEN5_ID:
+			case XF_DUALGEN6_ID:
+			case XF_DUALGEN7_ID:
+				return xf.dualTex[index - XF_DUALGEN0_ID].bits;
+
+			case XF_INVTXSPEC_ID:		return xf.vtxSpec.bits;
+			case XF_NUMCOLS_ID:			return xf.numColors;
+			case XF_NUMTEX_ID:			return xf.numTex;
+
+			case XF_TEXGEN0_ID:
+			case XF_TEXGEN1_ID:
+			case XF_TEXGEN2_ID:
+			case XF_TEXGEN3_ID:
+			case XF_TEXGEN4_ID:
+			case XF_TEXGEN5_ID:
+			case XF_TEXGEN6_ID:
+			case XF_TEXGEN7_ID:
+				return xf.tex[index - XF_TEXGEN0_ID].bits;
+		}
+
+		Report(Channel::GP, "Unknown XF read, index: 0x%04X\n", index);
+		return 0;
+	}
+
+	// The XF viewport registers hold hardware units; convert them into a GL viewport and depth
+	// range. Called whenever one of 0x101A-0x101F is written.
+	void TransformUnit::ApplyViewport()
+	{
+		float w, h, x, y, zf, zn;
+
+		//
+		// convert the coefficients to human usable form
+		//
+
+		w = xf.viewportScale[0] * 2;									// w / 2
+		h = -xf.viewportScale[1] * 2;									// -h / 2
+		x = xf.viewportOffset[0] - xf.viewportScale[0] - 342;			// x + w/2 + 342
+		y = xf.viewportOffset[1] + xf.viewportScale[1] - 342;			// y + h/2 + 342
+		zf = xf.viewportOffset[2] / 16777215.0f;						// ZMAX * zfar
+		zn = -((xf.viewportScale[2] / 16777215.0f) - zf);				// ZMAX * (zfar - znear)
+
+		GL_SetViewport((int)x, (int)y, (int)w, (int)h, zn, zf);
+	}
+
+	// -------------------------------------------------------------------------------------------
+	// CP -> XF interface (gfx-xf.md 2.1)
+	//
+	// The CP pushes register loads, register read requests and vertex rows into the XF, and the XF
+	// answers register reads on the read-back line. The XF is the entry point of the graphics
+	// pipeline: the vertex stream that it produces leaves it towards the Setup Unit.
+	// -------------------------------------------------------------------------------------------
+
+	bool TransformUnit::CPReady()
+	{
+		// The XF takes a word every cycle; only a read-back value that the CP has not taken yet
+		// holds it off (XFready is deasserted while XFrdValid is asserted).
+		return !xfRdValid;
+	}
+
+	void TransformUnit::CPRegLoadBegin(size_t startIdx, size_t amount)
+	{
+		xfLoadIdx = startIdx;
+		xfLoadAmount = amount;
+	}
+
+	void TransformUnit::CPRegLoadData(uint32_t value)
+	{
+		if (xfLoadAmount == 0)
+		{
+			// The block write is over; further data words would spill into the register space.
+			Report(Channel::GP, "XF: unexpected register data word (address: 0x%04X)\n", xfLoadIdx);
+			return;
+		}
+
+		xfLoadAmount--;
+		WriteXFReg(xfLoadIdx++, value);
+	}
+
+	void TransformUnit::CPRegRead(size_t index)
+	{
+		xfRdData = ReadXFReg(index);
+		xfRdValid = true;
+	}
+
+	bool TransformUnit::CPTakeReadData(uint32_t* data)
+	{
+		if (!xfRdValid)
+			return false;
+
+		*data = xfRdData;
+		xfRdValid = false;
+		return true;
+	}
+
+	void TransformUnit::CPSuCommand(size_t index, uint32_t value)
+	{
+		// The XF does not interpret the bypass words: they are forwarded to the SU verbatim.
+		gfx->su->loadSUReg(index, value);
+	}
+
+	//
+	// XF -> SU: the vertex stream (gfx-xf.md 2.2)
+	//
+	// The transform itself is done by the XF vertex shader (the register state is uploaded to it as
+	// uniforms, see UploadUniforms), so the XF hands the vertex rows over to the Setup Unit, which
+	// drives the rasterizers with them.
+	//
+
+	void TransformUnit::CPDrawBegin(RAS_Primitive prim, size_t vtx_num)
+	{
+		gfx->su->BeginPrimitive(prim, vtx_num);
+	}
+
+	void TransformUnit::CPVertex(const Vertex* v)
+	{
+		gfx->su->SendVertex(v);
+	}
+
+	void TransformUnit::CPDrawEnd()
+	{
+		gfx->su->EndPrimitive();
 	}
 
 	TransformUnit::TransformUnit(HWConfig* config, GFXCore* parent_gfx)
@@ -867,3 +1012,4 @@ void main()
 	{
 	}
 }
+

--- a/src/xf.h
+++ b/src/xf.h
@@ -5,13 +5,12 @@
 // In the real Flipper XF is made from microcode ROM, but is still part of a fixed pipeline.
 // In this emulator the XF is emulated by a vertex shader: this module only holds the register state
 // and uploads it to the shader (see gfx.cpp for the shader source).
+//
+// The XF is the entry point of the graphics pipeline: the CP pushes the command stream (register
+// loads, register reads and the vertex rows of every draw command) into it, and what the XF
+// produces leaves it towards the Setup Unit and the rasterizers (gfx-xf.md 2.1, 2.2).
 
 #pragma once
-
-namespace Flipper
-{
-	class FifoProcessor;
-}
 
 namespace GFX
 {
@@ -137,6 +136,23 @@ namespace GFX
 		XF_DUALGEN5_ID = 0x1055,
 		XF_DUALGEN6_ID = 0x1056,
 		XF_DUALGEN7_ID = 0x1057,
+	};
+
+	// The primitive that a draw command renders. The CP passes it to the XF with the draw
+	// command (gfx-xf.md 2.1), and the XF hands it to the Setup Unit and the rasterizers on its
+	// output stream (gfx-xf.md 2.2). It is defined here because the XF is the entry point of the
+	// pipeline, and the SU/RAS consume what the XF produces.
+
+	enum RAS_Primitive : size_t
+	{
+		RAS_QUAD = 0,
+		RAS_QUAD_STRIP,
+		RAS_TRIANGLE,
+		RAS_TRIANGLE_STRIP,
+		RAS_TRIANGLE_FAN,
+		RAS_LINE,
+		RAS_LINE_STRIP,
+		RAS_POINT,
 	};
 
 #pragma pack(push, 1)
@@ -326,6 +342,22 @@ namespace GFX
 		//! Compiled XF (vertex) shader stage. The TEV fragment programs are linked against it.
 		GLuint vert_shader = 0;
 
+		// CP -> XF interface state
+
+		size_t xfLoadIdx = 0;			// Register address of the current block write
+		size_t xfLoadAmount = 0;		// Register words still expected by the current block write
+		uint32_t xfRdData = 0;			// XFrdData: register read-back value
+		bool xfRdValid = false;			// XFrdValid: XFrdData holds a value for the CP
+
+		//! Write one word of the XF register space (gfx-xf.md 4)
+		void WriteXFReg(size_t index, uint32_t value);
+
+		//! Read one word of the XF register space out of the current register state (gfx-xf.md 4)
+		uint32_t ReadXFReg(size_t index);
+
+		//! Recalculate the emulator viewport from the XF viewport registers (0x101A-0x101F)
+		void ApplyViewport();
+
 	public:
 
 		XFState xf{};
@@ -340,7 +372,46 @@ namespace GFX
 		//! Upload the whole XF register state to the XF vertex program.
 		void UploadUniforms(GLProgram& program);
 		void GL_SetViewport(int x, int y, int w, int h, float znear, float zfar);
-		void loadXFRegs(size_t startIdx, size_t amount, Flipper::FifoProcessor* gxfifo);
+
+		// -------------------------------------------------------------------------------------
+		// CP -> XF interface (gfx-xf.md 2.1)
+		//
+		// The CP is the source of the graphics command stream: it pushes register loads, register
+		// read requests and the vertex rows of every draw command into the XF, which is the entry
+		// point of the pipeline. The XF reports on the XFready line whether it can take another
+		// word, and answers register read requests on XFrdValid/XFrdData. The vertex stream that
+		// the XF produces goes to the Setup Unit (gfx-xf.md 2.2).
+		// -------------------------------------------------------------------------------------
+
+		//! XFready: the XF can accept another word from the CP.
+		bool CPReady();
+
+		//! xf_cmd_regload: begin a block write of `amount` words at XF register `startIdx`.
+		void CPRegLoadBegin(size_t startIdx, size_t amount);
+
+		//! xf_cmd_regdata: one data word of the block write in progress.
+		void CPRegLoadData(uint32_t value);
+
+		//! xf_cmd_regread: request XF register `index`. The XF answers on the read-back line,
+		//! see CPTakeReadData.
+		void CPRegRead(size_t index);
+
+		//! XFrdValid / XFrdData: take the value requested with CPRegRead.
+		//! Returns false when the XF has no read-back data for the CP.
+		bool CPTakeReadData(uint32_t* data);
+
+		//! xf_su_cmds: an SU (bypass) register load. The XF does not interpret these words, it
+		//! forwards them to the Setup Unit verbatim.
+		void CPSuCommand(size_t index, uint32_t value);
+
+		//! The first vertex of a primitive of which `vtx_num` vertices follow.
+		void CPDrawBegin(RAS_Primitive prim, size_t vtx_num);
+
+		//! One vertex row of the vertex stream.
+		void CPVertex(const Vertex* v);
+
+		//! All vertices of the current primitive have been pushed.
+		void CPDrawEnd();
 
 		TransformUnit(HWConfig* config, GFXCore* parent_gfx);
 		~TransformUnit();

--- a/wiki/gfx.md
+++ b/wiki/gfx.md
@@ -17,6 +17,22 @@ The graphics backend no longer uses the fixed-function OpenGL pipeline. The two 
 
 Both shaders are **static**: the whole register state of the corresponding block is passed as uniforms, so nothing has to be recompiled when the game reconfigures the GFX registers. The TEV shader walks up to 16 combine stages in a loop that is bounded by a `tevStages` uniform.
 
+### Command path
+
+The CP produces the command stream and owns the vertex fetch; the XF is the entry point of the pipeline, so
+every word the CP emits goes through it:
+
+```
+Gekko --PI FIFO--> CP --commands + vertex rows--> XF --> SU --> RAS --> TEV --> PE
+```
+
+The CP pushes the XF register block loads (`xf_cmd_regload` + `regdata`), register read requests
+(`xf_cmd_regread`), SU bypass register words and the vertex rows of every draw command into the XF
+(`xf.h`, the "CP -> XF interface" section), and observes the `XFready` line before each word. A register
+read is answered by the XF out of its own register state and latched in `CP_XF_DATAL` / `CP_XF_DATAH`,
+where the CPU sees it. The CP does not reach past the XF: the vertex stream leaves the XF towards the SU,
+which drives the rasterizers.
+
 ### XF (vertex shader)
 
 - geometry (modelview) and texture matrix multiplies against the matrix RAM (`matrixMem`, 64 rows x 4 words) and


### PR DESCRIPTION
…ead-back

The CP used to reach into the graphics blocks directly: it handed its FIFO to the XF for register loads, read the XF state fields to get the default matrix indexes and drove the rasterizers itself, bypassing the XF entirely. The XF is the entry point of the pipeline (gfx-xf.md 2.1), so the interaction is now the one the hardware describes.

CP -> XF (xf.h, "CP -> XF interface"):
- the CP pushes the command words instead of handing over the FIFO: CPRegLoadBegin/CPRegLoadData (xf_cmd_regload/regdata), CPRegRead (xf_cmd_regread), CPSuCommand (xf_su_cmds bypass words, forwarded verbatim) and CPDrawBegin/CPVertex/CPDrawEnd for the vertex rows of a draw command;
- CPReady (XFready) is the readiness response and CPTakeReadData (XFrdValid/XFrdData) hands the register read results back to the CP, which polls them in CommandProcessor::XFSync before every word it pushes.

XF register reads (was a stub returning 0):
- writing CP_XF_ADDR starts a read of the XF register space and CP_XF_DATAL/CP_XF_DATAH return the value; TransformUnit::ReadXFReg answers it out of the current register state (matrix RAMs, light records and the whole control block), mirroring the new word-wise TransformUnit::WriteXFReg. The default matrix indexes are read back over this path as well, instead of peeking at XFState fields from the CP.

Pipeline:
- the vertex stream goes CP -> XF -> SU -> RAS: SetupUnit::BeginPrimitive/ SendVertex/EndPrimitive drive the rasterizers, and the CP no longer calls the RAS (or the SU) directly, so every word it emits passes through the XF;
- the eight duplicated draw command cases collapse into DrawPrimitive.

Register loads are now word-wise, so partial loads no longer halt, and the emulator viewport is refreshed on any write to 0x101A-0x101F so a viewport programmed with several block writes also ends up correct.

Builds clean (MSVC v145, Release x64, /W3).