### PR TITLE
UI: port the game selector to the SDL build

### DIFF
--- a/src/uisdl.cpp
+++ b/src/uisdl.cpp
@@ -6,6 +6,9 @@
 #include "../thirdparty/imgui-filebrowser/imfilebrowser.h"
 #include <codecvt>
 #include <locale>
+#include <algorithm>
+#include <filesystem>
+#include <memory>
 
 static bool ui_active = false;
 static bool show_demo_window = false;
@@ -29,6 +32,7 @@ enum class FileReaction
 	None = 0,
 	OpenFile_LoadFile,
 	ChooseDirectory_MountSdk,
+	ChooseDirectory_SelectorPath,
 	OpenFile_Bootrom,
 	OpenFile_DROM,
 	OpenFile_IROM,
@@ -242,6 +246,701 @@ void SetStatusText(STATUS_ENUM sbPart, const std::wstring& text, bool post)
 
 /*
 
+# Game selector
+
+The SDL port of the file selector (see ui.cpp): the list of executable files (DOL/ELF) and disk
+images (GCM/ISO) found in the configured paths, with the disk banners, titles, sizes and comments
+taken from the DVD banner file. The list of paths is stored in the PATH user variable and is
+extended with the directory of every loaded file.
+
+*/
+
+// Set by OnMainWindowOpened / OnMainWindowClosed
+static bool emu_running = false;
+
+/* File entry */
+struct SelectorFile
+{
+	SELECTOR_FILE   type;               // Executable or Dvd
+	size_t          size;               // File size
+	std::wstring    id;                 // GameID = DiskID
+	std::wstring    name;               // File path and name
+	std::wstring    title;              // Alternate file name (from the banner)
+	std::wstring    comment;            // Some notes (from the banner)
+	SDL_Texture* banner = nullptr;      // Banner texture (Dvd only)
+};
+
+/* All important data is placed here */
+class UserSelector
+{
+public:
+
+	bool            active = false;                     // 1, if enabled
+	bool            smallIcons = false;                 // show small icons
+	SELECTOR_SORT   sortBy = SELECTOR_SORT::Default;    // sort rule (one of SELECTOR_SORT_*)
+
+	std::vector<std::wstring> paths;                    // path list, where to search files
+	std::vector<std::unique_ptr<SelectorFile>> files;   // list of found files
+
+	int             selected = -1;                      // selected file, -1: none
+	bool            needUpdate = false;                 // the file list must be rescanned
+	bool            scrollToSelected = false;           // scroll the list to the selected file
+
+	~UserSelector()
+	{
+		clear();
+	}
+
+	void clear()
+	{
+		for (auto& file : files)
+		{
+			if (file->banner)
+			{
+				SDL_DestroyTexture(file->banner);
+			}
+		}
+
+		files.clear();
+		selected = -1;
+	}
+};
+
+static UserSelector usel;
+
+/* Make sure path have ending directory separator */
+static void fix_path(std::wstring& path)
+{
+	if (path.empty() || (path.back() != L'/' && path.back() != L'\\'))
+	{
+		path.push_back((wchar_t)std::filesystem::path::preferred_separator);
+	}
+}
+
+/* Remove all control symbols (below space) */
+static void fix_string(std::wstring& str)
+{
+	for (auto& c : str)
+	{
+		if (c < L' ') c = L' ';
+	}
+}
+
+/* Normalize the path, so that "./", ".\" and the same directory with or without the ending
+   separator are treated as the same directory */
+static std::wstring canonical_path(const std::wstring& path)
+{
+	std::error_code ec;
+	auto canon = std::filesystem::weakly_canonical(std::filesystem::path(path), ec);
+	return ec ? path : canon.wstring();
+}
+
+/* Load PATH user variable and cut it on pieces into "paths" list */
+static void load_path()
+{
+	auto var = Util::StringToWstring(UI::Jdi->GetConfigString(USER_PATH, USER_UI));
+
+	usel.paths.clear();
+
+	auto path = std::wstring();
+
+	for (auto& c : var)
+	{
+		if (c == L';')
+		{
+			if (!path.empty())
+			{
+				fix_path(path);
+				usel.paths.push_back(path);
+				path.clear();
+			}
+		}
+		else
+		{
+			path.push_back(c);
+		}
+	}
+
+	if (!path.empty())
+	{
+		fix_path(path);
+		usel.paths.push_back(path);
+	}
+}
+
+/* Add new path into the PATH user variable (called after loading of new file) */
+static void AddSelectorPath(const std::wstring& fullPath)
+{
+	if (fullPath.empty())
+	{
+		return;
+	}
+
+	load_path();
+
+	auto newPath = canonical_path(fullPath);
+
+	for (auto& path : usel.paths)
+	{
+		if (canonical_path(path) == newPath)
+		{
+			return;     // path duplicated
+		}
+	}
+
+	auto path = std::wstring(fullPath);
+	fix_path(path);
+
+	auto old = Util::StringToWstring(UI::Jdi->GetConfigString(USER_PATH, USER_UI));
+
+	UI::Jdi->SetConfigString(USER_PATH, Util::WstringToString(old.empty() ? path : (old + L";" + path)), USER_UI);
+
+	usel.paths.push_back(path);
+	usel.needUpdate = true;
+}
+
+/* Directory of the specified file, with the ending separator */
+static std::wstring ParentPath(const std::wstring& filename)
+{
+	auto path = std::filesystem::path(filename).parent_path().wstring();
+
+	if (!path.empty())
+	{
+		fix_path(path);
+	}
+
+	return path;
+}
+
+/* Copy the banner ANSI string (up to the zero terminator) into a wide string */
+static std::wstring CopyAnsiStringAsWcharString(const uint8_t* src, size_t maxLen)
+{
+	std::wstring res;
+
+	for (size_t i = 0; i < maxLen && src[i]; i++)
+	{
+		res.push_back((wchar_t)src[i]);
+	}
+
+	return res;
+}
+
+/* Convert the SJIS text of the Japanese banners to Unicode (see SjisToUnicode in ui.cpp) */
+static std::wstring SjisToWstring(const std::wstring& sjis)
+{
+	std::wstring res;
+	res.reserve(sjis.size());
+
+	for (size_t i = 0; i < sjis.size(); i++)
+	{
+		uint16_t c = (uint16_t)sjis[i];
+		uint16_t uchar = SjisTable[c];
+
+		if (uchar == 0xFFFF && (i + 1) < sjis.size())
+		{
+			i++;
+			c = (uint16_t)((c << 8) | (uint16_t)sjis[i]);
+			uchar = SjisTable[c];
+		}
+
+		res.push_back((wchar_t)uchar);
+	}
+
+	return res;
+}
+
+/* ImGui draws UTF-8 strings */
+static std::string ToUtf8(const std::wstring& wstr)
+{
+	std::wstring_convert<std::codecvt_utf8<wchar_t>> utf8_conv;
+	return utf8_conv.to_bytes(wstr);
+}
+
+/* Nice value of KB, MB or GB, for output (see UI::FileSmartSizeA in ui.cpp) */
+static std::string SmartSize(size_t size)
+{
+	char tempBuf[0x100];
+
+	if (size < 1024)
+	{
+		sprintf(tempBuf, "%zi byte", size);
+	}
+	else if (size < 1024 * 1024)
+	{
+		sprintf(tempBuf, "%zi KB", size / 1024);
+	}
+	else if (size < 1024 * 1024 * 1024)
+	{
+		sprintf(tempBuf, "%zi MB", size / 1024 / 1024);
+	}
+	else
+	{
+		sprintf(tempBuf, "%1.1f GB", (float)size / 1024 / 1024 / 1024);
+	}
+
+	return std::string(tempBuf);
+}
+
+/* Convert the DVD banner (RGB5A3 texture) into an RGBA texture.
+   The banner image is stored as 4x4 tiles (the same layout as in the GX texture), so the pixels of
+   a tile are scattered over the whole image (see add_banner in ui.cpp).
+   The Win32 selector pre-blends the banner with the item background, because the listview cannot
+   draw translucent bitmaps. Here the alpha channel is kept, so that ImGui blends the banner with
+   the row background (including the selection highlight) by itself. */
+static SDL_Texture* make_banner_texture(const uint8_t* image)
+{
+	const int tiles = (DVD_BANNER_WIDTH * DVD_BANNER_HEIGHT) / 16;
+	std::vector<uint32_t> pixels(DVD_BANNER_WIDTH * DVD_BANNER_HEIGHT);
+
+	const uint16_t* tile = (const uint16_t*)image;
+	int row = 0, col = 0;
+
+	for (int i = 0; i < tiles; i++, tile += 16)
+	{
+		for (int j = 0; j < 4; j++)
+		{
+			for (int k = 0; k < 4; k++)
+			{
+				uint16_t p = tile[j * 4 + k];
+				p = (p << 8) | (p >> 8);        // banner is always big-endian
+
+				uint8_t r, g, b, a;
+
+				if (p & 0x8000)                 // RGB555
+				{
+					r = (uint8_t)(((p >> 10) & 0x1f) * 255 / 31);
+					g = (uint8_t)(((p >> 5) & 0x1f) * 255 / 31);
+					b = (uint8_t)((p & 0x1f) * 255 / 31);
+					a = 255;
+				}
+				else                            // RGB4A3
+				{
+					r = (uint8_t)(((p >> 8) & 0x0f) * 17);
+					g = (uint8_t)(((p >> 4) & 0x0f) * 17);
+					b = (uint8_t)((p & 0x0f) * 17);
+					a = (uint8_t)(((p >> 12) & 0x07) * 255 / 7);
+				}
+
+				pixels[(row + j) * DVD_BANNER_WIDTH + (col + k)] =
+					((uint32_t)a << 24) | ((uint32_t)r << 16) | ((uint32_t)g << 8) | b;
+			}
+		}
+
+		col += 4;
+		if (col == DVD_BANNER_WIDTH)
+		{
+			col = 0;
+			row += 4;
+		}
+	}
+
+	SDL_Texture* texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_ARGB8888,
+		SDL_TEXTUREACCESS_STATIC, DVD_BANNER_WIDTH, DVD_BANNER_HEIGHT);
+	if (texture == nullptr)
+	{
+		return nullptr;
+	}
+
+	SDL_UpdateTexture(texture, nullptr, pixels.data(), DVD_BANNER_WIDTH * sizeof(uint32_t));
+	SDL_SetTextureBlendMode(texture, SDL_BLENDMODE_BLEND);
+	SDL_SetTextureScaleMode(texture, SDL_ScaleModeLinear);      // small icons are scaled down
+
+	return texture;
+}
+
+/* Insert new file into filelist */
+static void add_file(const std::wstring& file, size_t fsize, SELECTOR_FILE type)
+{
+	// check file size
+	if ((fsize < 0x1000) || (fsize > DVD_SIZE))
+	{
+		return;
+	}
+
+	// check already present
+	for (auto& entry : usel.files)
+	{
+		if (entry->name == file)
+		{
+			return;
+		}
+	}
+
+	auto item = std::make_unique<SelectorFile>();
+
+	/* Save file info */
+	item->type = type;
+	item->size = fsize;
+	item->name = file;
+
+	if (type == SELECTOR_FILE::Dvd)
+	{
+		// To get information from the disk, you have to remount it.
+		// If the user, for example, mounted DolphinSDK, it is necessary to restore the previous state
+		// of the mount so that he does not get upset.
+
+		/* Load DVD banner. */
+		std::vector<uint8_t> banner = DVDLoadBanner(file.c_str());
+		if (banner.empty())
+		{
+			return;
+		}
+
+		// Keep previous mount state
+
+		std::string path;
+		bool mountedAsIso = false;
+		bool mounted = UI::Jdi->DvdIsMounted(path, mountedAsIso);
+
+		// get DiskID
+
+		std::vector<uint8_t> diskIDRaw;
+		diskIDRaw.resize(4);
+		char diskID[0x10] = { 0 };
+		UI::Jdi->DvdMount(Util::WstringToString(file));
+		UI::Jdi->DvdSeek(0);
+		UI::Jdi->DvdRead(diskIDRaw);
+		diskID[0] = (char)diskIDRaw[0];
+		diskID[1] = (char)diskIDRaw[1];
+		diskID[2] = (char)diskIDRaw[2];
+		diskID[3] = (char)diskIDRaw[3];
+
+		// Set GameID
+
+		char game_id[0x10] = { 0 };
+		sprintf(game_id, "%.4s", diskID);
+		item->id = Util::StringToWstring(std::string(game_id));
+
+		// Restore previous mount state
+
+		if (mounted)
+		{
+			if (mountedAsIso)
+			{
+				UI::Jdi->DvdMount(path);
+			}
+			else
+			{
+				UI::Jdi->DvdMountSDK(path);
+			}
+		}
+		else
+		{
+			UI::Jdi->DvdUnmount();
+		}
+
+		/* Use banner info and remove line-feeds. */
+
+		DVDBanner2* bnr = (DVDBanner2*)banner.data();
+		item->title = CopyAnsiStringAsWcharString(bnr->comments[0].longTitle, sizeof(bnr->comments[0].longTitle));
+		item->comment = CopyAnsiStringAsWcharString(bnr->comments[0].comment, sizeof(bnr->comments[0].comment));
+
+		// Japanese banners keep the text in SJIS
+
+		if (UI::Jdi->DvdRegionById(diskID) == "JPN")
+		{
+			item->title = SjisToWstring(item->title);
+			item->comment = SjisToWstring(item->comment);
+		}
+
+		fix_string(item->title);
+		fix_string(item->comment);
+
+		item->banner = make_banner_texture(bnr->image);
+	}
+	else if (type == SELECTOR_FILE::Executable)
+	{
+		item->id = L"-";
+		item->title = std::filesystem::path(file).stem().wstring();
+	}
+	else
+	{
+		assert(0);
+	}
+
+	/* Extend filelist. */
+	usel.files.push_back(std::move(item));
+}
+
+/* Set selected file, by item index */
+static void selector_set_selected(int item, bool scroll)
+{
+	if (item < 0 || item >= (int)usel.files.size())
+	{
+		return;
+	}
+
+	usel.selected = item;
+	usel.scrollToSelected = scroll;
+
+	if (!emu_running)
+	{
+		SetStatusText(STATUS_ENUM::Progress, usel.files[item]->name);
+	}
+}
+
+// if file not present, keep selection unchanged
+static void selector_select_by_name(const std::wstring& filename)
+{
+	if (filename.empty())
+	{
+		return;
+	}
+
+	auto name = canonical_path(filename);
+
+	for (size_t i = 0; i < usel.files.size(); i++)
+	{
+		if (canonical_path(usel.files[i]->name) == name)
+		{
+			selector_set_selected((int)i, true);
+			break;
+		}
+	}
+}
+
+// Set selected item, by first letter key pressed
+static void selector_type_ahead(wchar_t letter)
+{
+	// Case folding is limited to the ASCII range on purpose: the locale dependent
+	// tolower() is undefined for characters outside of that range.
+	if (letter >= L'A' && letter <= L'Z') letter = (wchar_t)(letter - L'A' + L'a');
+
+	for (size_t i = 0; i < usel.files.size(); i++)
+	{
+		wchar_t first = usel.files[i]->title.empty() ? 0 : usel.files[i]->title[0];
+		if (first >= L'A' && first <= L'Z') first = (wchar_t)(first - L'A' + L'a');
+
+		if (first == letter)
+		{
+			selector_set_selected((int)i, true);
+			break;
+		}
+	}
+}
+
+/* Sort the filelist (the sort rule is stored in the SORTVIEW user variable) */
+static void sort_selector(SELECTOR_SORT sortBy)
+{
+	auto by_title = [](const std::unique_ptr<SelectorFile>& f1, const std::unique_ptr<SelectorFile>& f2)
+	{
+		return _wcsicmp(f1->title.c_str(), f2->title.c_str()) < 0;
+	};
+
+	// the selection is kept by file name, because sorting changes the indexes
+	std::wstring selectedName;
+
+	if (usel.selected >= 0 && usel.selected < (int)usel.files.size())
+	{
+		selectedName = usel.files[usel.selected]->name;
+	}
+
+	switch (sortBy)
+	{
+		case SELECTOR_SORT::Default:        // first by icon, then by title
+			std::stable_sort(usel.files.begin(), usel.files.end(), [&](const auto& f1, const auto& f2)
+				{
+					if (f1->type != f2->type) return f1->type > f2->type;
+					return by_title(f1, f2);
+				});
+			break;
+		case SELECTOR_SORT::Filename:
+			std::stable_sort(usel.files.begin(), usel.files.end(),
+				[](const auto& f1, const auto& f2) { return _wcsicmp(f1->name.c_str(), f2->name.c_str()) < 0; });
+			break;
+		case SELECTOR_SORT::Title:
+			std::stable_sort(usel.files.begin(), usel.files.end(), by_title);
+			break;
+		case SELECTOR_SORT::Size:
+			std::stable_sort(usel.files.begin(), usel.files.end(),
+				[](const auto& f1, const auto& f2) { return f1->size < f2->size; });
+			break;
+		case SELECTOR_SORT::ID:
+			std::stable_sort(usel.files.begin(), usel.files.end(),
+				[](const auto& f1, const auto& f2) { return f1->id < f2->id; });
+			break;
+		case SELECTOR_SORT::Comment:
+			std::stable_sort(usel.files.begin(), usel.files.end(),
+				[](const auto& f1, const auto& f2) { return _wcsicmp(f1->comment.c_str(), f2->comment.c_str()) < 0; });
+			break;
+		default:                            // Unsorted: keep the order in which the files were found
+			break;
+	}
+
+	usel.sortBy = sortBy;
+	UI::Jdi->SetConfigInt(USER_SORTVIEW, (int)usel.sortBy, USER_UI);
+
+	selector_select_by_name(selectedName);
+}
+
+/* Rescan the configured paths (reload and redraw) */
+static void update_selector()
+{
+	if (!usel.active)
+	{
+		return;
+	}
+
+	// Reading the disk banners mounts the disks, which must not disturb the running game
+	if (emu_running)
+	{
+		return;
+	}
+
+	usel.clear();
+	usel.needUpdate = false;
+
+	load_path();
+
+	// The same directory may be specified in different ways, so first drop the duplicates,
+	// otherwise the files of this directory will be listed twice.
+	std::vector<std::wstring> dirs;
+
+	for (auto& path : usel.paths)
+	{
+		auto dir = canonical_path(path);
+
+		if (std::find(dirs.begin(), dirs.end(), dir) == dirs.end())
+		{
+			dirs.push_back(dir);
+		}
+	}
+
+	usel.paths = dirs;
+
+	// file filter: every 8 bits masking an extension (see EditFileFilter in ui.cpp)
+	uint32_t filter = (uint32_t)UI::Jdi->GetConfigInt(USER_FILTER, USER_UI);
+
+	static const struct
+	{
+		const wchar_t* ext;
+		SELECTOR_FILE  type;
+		uint32_t       mask;
+	} file_ext[] =
+	{
+		{ L".dol", SELECTOR_FILE::Executable, 0xff000000 },
+		{ L".elf", SELECTOR_FILE::Executable, 0x00ff0000 },
+		{ L".gcm", SELECTOR_FILE::Dvd,        0x0000ff00 },
+		{ L".iso", SELECTOR_FILE::Dvd,        0x000000ff },
+	};
+
+	for (auto& dir : usel.paths)
+	{
+		std::error_code ec;
+		std::filesystem::directory_iterator entry(std::filesystem::path(dir), ec);
+		if (ec)
+		{
+			continue;       // no such directory
+		}
+
+		for (auto& file : entry)
+		{
+			if (!file.is_regular_file(ec))
+			{
+				continue;
+			}
+
+			auto ext = file.path().extension().wstring();
+			for (auto& c : ext)
+			{
+				if (c >= L'A' && c <= L'Z') c = (wchar_t)(c - L'A' + L'a');
+			}
+
+			for (auto& mask : file_ext)
+			{
+				if ((filter & mask.mask) && ext == mask.ext)
+				{
+					add_file(file.path().wstring(), (size_t)file.file_size(ec), mask.type);
+				}
+			}
+		}
+	}
+
+	sort_selector(usel.sortBy);
+
+	// scroll to last loaded file
+	selector_select_by_name(Util::StringToWstring(UI::Jdi->GetConfigString(USER_LASTFILE, USER_UI)));
+}
+
+/* Options -> Selector */
+static void ui_selector_menu()
+{
+	if (!ImGui::BeginMenu("Selector"))
+	{
+		return;
+	}
+
+	if (ImGui::MenuItem("Enable Selector", NULL, usel.active))
+	{
+		usel.active = !usel.active;
+		UI::Jdi->SetConfigBool(USER_SELECTOR, usel.active, USER_UI);
+		usel.needUpdate = true;
+	}
+
+	if (ImGui::MenuItem("Refresh", NULL, false, usel.active))
+	{
+		usel.needUpdate = true;
+	}
+
+	ImGui::Separator();
+
+	if (ImGui::MenuItem("Small Icons", NULL, usel.smallIcons, usel.active))
+	{
+		usel.smallIcons = !usel.smallIcons;
+		UI::Jdi->SetConfigBool(USER_SMALLICONS, usel.smallIcons, USER_UI);
+	}
+
+	if (ImGui::BeginMenu("Sort by", usel.active))
+	{
+		if (ImGui::MenuItem("Default", NULL, usel.sortBy == SELECTOR_SORT::Default)) sort_selector(SELECTOR_SORT::Default);
+		if (ImGui::MenuItem("Filename", NULL, usel.sortBy == SELECTOR_SORT::Filename)) sort_selector(SELECTOR_SORT::Filename);
+		if (ImGui::MenuItem("Title", NULL, usel.sortBy == SELECTOR_SORT::Title)) sort_selector(SELECTOR_SORT::Title);
+		if (ImGui::MenuItem("Size", NULL, usel.sortBy == SELECTOR_SORT::Size)) sort_selector(SELECTOR_SORT::Size);
+		if (ImGui::MenuItem("Game ID", NULL, usel.sortBy == SELECTOR_SORT::ID)) sort_selector(SELECTOR_SORT::ID);
+		if (ImGui::MenuItem("Comment", NULL, usel.sortBy == SELECTOR_SORT::Comment)) sort_selector(SELECTOR_SORT::Comment);
+		ImGui::Separator();
+		if (ImGui::MenuItem("Unsorted", NULL, usel.sortBy == SELECTOR_SORT::Unsorted)) sort_selector(SELECTOR_SORT::Unsorted);
+		ImGui::EndMenu();
+	}
+
+	if (ImGui::BeginMenu("File Filter", usel.active))
+	{
+		uint32_t filter = (uint32_t)UI::Jdi->GetConfigInt(USER_FILTER, USER_UI);
+
+#define SELECTOR_FILTER_ITEM(label, mask)                                                       \
+		if (ImGui::MenuItem(label, NULL, (filter & mask) != 0))                                 \
+		{                                                                                       \
+			filter ^= mask;                                                                     \
+			UI::Jdi->SetConfigInt(USER_FILTER, (int)filter, USER_UI);                           \
+			usel.needUpdate = true;                                                             \
+		}
+
+		SELECTOR_FILTER_ITEM("*.dol", 0xff000000);
+		SELECTOR_FILTER_ITEM("*.elf", 0x00ff0000);
+		SELECTOR_FILTER_ITEM("*.gcm", 0x0000ff00);
+		SELECTOR_FILTER_ITEM("*.iso", 0x000000ff);
+
+#undef SELECTOR_FILTER_ITEM
+
+		ImGui::EndMenu();
+	}
+
+	ImGui::Separator();
+
+	if (ImGui::MenuItem("Add Directory...", NULL, false, usel.active))
+	{
+		file_reaction = FileReaction::ChooseDirectory_SelectorPath;
+		chooseDirectoryDialog.Open();
+	}
+
+	ImGui::EndMenu();
+}
+
+
+
+
+/*
+
 # Performance Counters
 
 Interesting to track :
@@ -435,6 +1134,15 @@ void OnMainWindowOpened(const wchar_t* currentFileName)
 
 	// set new title for main window
 
+	if (!bootrom)
+	{
+		// remember the directory of the loaded file in the selector search paths
+		AddSelectorPath(ParentPath(currentFileName));
+		UI::Jdi->SetConfigString(USER_LASTFILE, Util::WstringToString(currentFileName), USER_UI);
+	}
+
+	emu_running = true;
+
 	if (dvd)
 	{
 		UI::Jdi->DvdMount(Util::WstringToString(currentFileName));
@@ -516,6 +1224,10 @@ void OnMainWindowClosed()
 		UI::g_perfMetrics = nullptr;
 	}
 
+	// make the selector visible again
+	emu_running = false;
+	usel.needUpdate = true;
+
 	// set to Idle
 	auto win_name = std::wstring(APPNAME) + L" - " + std::wstring(APPDESC) + L" (" + Util::StringToWstring(UI::Jdi->GetVersion()) + L")";
 	std::wstring_convert<std::codecvt_utf8<wchar_t>> utf8_conv;
@@ -579,8 +1291,8 @@ static void ui_main_menu()
 				ImGui::EndMenu();
 			}
 			ImGui::Separator();
-			if (ImGui::MenuItem("Refresh View", NULL)) {
-				UI::Jdi->ExecuteCommand("UIReport \"Not implemented\"");
+			if (ImGui::MenuItem("Refresh View", NULL, false, usel.active)) {
+				usel.needUpdate = true;
 			}
 			ImGui::Separator();
 			if (ImGui::MenuItem("Exit", NULL)) {
@@ -616,6 +1328,7 @@ static void ui_main_menu()
 		{
 			ImGui::MenuItem("Settings...", NULL);
 			ImGui::MenuItem("View", NULL);
+			ui_selector_menu();
 			ImGui::Separator();
 			if (ImGui::BeginMenu("Controllers"))
 			{
@@ -646,12 +1359,147 @@ static void ui_main_menu()
 	}
 }
 
+/* Load and run the file (from the selector or from the Open dialog) */
+static void load_file(const std::wstring& filename)
+{
+	if (filename.empty())
+	{
+		return;
+	}
+
+	CreateRenderTarget();
+	UI::Jdi->LoadFile(Util::WstringToString(filename));
+	if (Debug::debugger)
+	{
+		Debug::debugger->InvalidateAll();
+	}
+	OnMainWindowOpened(filename.c_str());
+	UI::Jdi->Run();
+}
+
+/* Load and run the selected file (Enter or double click on the list item) */
+static void run_selected_file()
+{
+	if (usel.selected < 0 || usel.selected >= (int)usel.files.size())
+	{
+		return;
+	}
+
+	load_file(usel.files[usel.selected]->name);
+}
+
 static void ui_selector()
 {
+	if (!usel.active)
+	{
+		return;
+	}
+
+	if (usel.needUpdate)
+	{
+		update_selector();
+	}
+
 	const float footer_height_to_reserve = ImGui::GetStyle().ItemSpacing.y + ImGui::GetFrameHeightWithSpacing();
 	if (ImGui::BeginChild("selector", ImVec2(0, -footer_height_to_reserve), false, ImGuiWindowFlags_HorizontalScrollbar))
 	{
+		const float iconWidth = (float)(usel.smallIcons ? (DVD_BANNER_WIDTH >> 1) : DVD_BANNER_WIDTH);
+		const float iconHeight = (float)(usel.smallIcons ? (DVD_BANNER_HEIGHT >> 1) : DVD_BANNER_HEIGHT);
+		const float rowHeight = iconHeight + ImGui::GetStyle().CellPadding.y * 2;
 
+		if (ImGui::BeginTable("selector_grid", 5,
+			ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersInnerV | ImGuiTableFlags_BordersOuter |
+			ImGuiTableFlags_ScrollY | ImGuiTableFlags_Resizable,
+			ImVec2(0, ImGui::GetContentRegionAvail().y)))
+		{
+			ImGui::TableSetupScrollFreeze(0, 1);
+
+			ImGui::TableSetupColumn(Util::WstringToString(SELECTOR_COLUMN_BANNER).c_str(), ImGuiTableColumnFlags_WidthFixed, iconWidth + 8);
+			ImGui::TableSetupColumn(Util::WstringToString(SELECTOR_COLUMN_TITLE).c_str(), ImGuiTableColumnFlags_WidthFixed, 200);
+			ImGui::TableSetupColumn(Util::WstringToString(SELECTOR_COLUMN_SIZE).c_str(), ImGuiTableColumnFlags_WidthFixed, 70);
+			ImGui::TableSetupColumn(Util::WstringToString(SELECTOR_COLUMN_GAMEID).c_str(), ImGuiTableColumnFlags_WidthFixed, 70);
+			ImGui::TableSetupColumn(Util::WstringToString(SELECTOR_COLUMN_COMMENT).c_str(), ImGuiTableColumnFlags_WidthStretch);
+
+			ImGui::TableHeadersRow();
+
+			for (int i = 0; i < (int)usel.files.size(); i++)
+			{
+				SelectorFile* file = usel.files[i].get();
+
+				ImGui::TableNextRow(ImGuiTableRowFlags_None, rowHeight);
+				ImGui::TableSetColumnIndex(0);
+
+				ImVec2 iconPos = ImGui::GetCursorScreenPos();
+
+				ImGui::PushID(i);
+				if (ImGui::Selectable("##item", i == usel.selected,
+					ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_AllowDoubleClick, ImVec2(0, rowHeight)))
+				{
+					selector_set_selected(i, false);
+
+					if (ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left))
+					{
+						run_selected_file();
+					}
+				}
+				ImGui::PopID();
+
+				// The banner is drawn over the selected item, because the item itself is a Selectable
+				if (file->banner)
+				{
+					ImGui::GetWindowDrawList()->AddImage((ImTextureID)(intptr_t)file->banner,
+						ImVec2(iconPos.x + 2, iconPos.y),
+						ImVec2(iconPos.x + 2 + iconWidth, iconPos.y + iconHeight));
+				}
+
+				ImGui::TableSetColumnIndex(1);
+				ImGui::TextUnformatted(ToUtf8(file->title).c_str());
+
+				ImGui::TableSetColumnIndex(2);
+				ImGui::TextUnformatted(SmartSize(file->size).c_str());
+
+				ImGui::TableSetColumnIndex(3);
+				ImGui::TextUnformatted(Util::WstringToString(file->id).c_str());
+
+				ImGui::TableSetColumnIndex(4);
+				ImGui::TextUnformatted(ToUtf8(file->comment).c_str());
+
+				if (usel.scrollToSelected && i == usel.selected)
+				{
+					ImGui::SetScrollHereY(0.5f);
+					usel.scrollToSelected = false;
+				}
+			}
+
+			ImGui::EndTable();
+		}
+
+		// The table does not handle the keyboard, so the cursor is moved by the same
+		// keys as in the Win32 selector (see ScrollSelector in ui.cpp).
+		if (ImGui::IsWindowFocused(ImGuiFocusedFlags_ChildWindows | ImGuiFocusedFlags_RootWindow))
+		{
+			if (ImGui::IsKeyPressed(ImGuiKey_UpArrow))
+			{
+				selector_set_selected(usel.selected - 1, true);
+			}
+			if (ImGui::IsKeyPressed(ImGuiKey_DownArrow))
+			{
+				selector_set_selected(usel.selected + 1, true);
+			}
+			if (ImGui::IsKeyPressed(ImGuiKey_Enter) || ImGui::IsKeyPressed(ImGuiKey_KeypadEnter))
+			{
+				run_selected_file();
+			}
+
+			ImGuiIO& io = ImGui::GetIO();
+			for (int i = 0; i < io.InputQueueCharacters.Size; i++)
+			{
+				if (io.InputQueueCharacters[i] >= L' ')
+				{
+					selector_type_ahead((wchar_t)io.InputQueueCharacters[i]);
+				}
+			}
+		}
 	}
 	ImGui::EndChild();
 	ImGui::Separator();
@@ -712,6 +1560,11 @@ static int ui_main()
 
 	chooseDirectoryDialog.SetTitle("Choose Directory");
 
+	// Selector state (see the "Game selector" section)
+	usel.active = UI::Jdi->GetConfigBool(USER_SELECTOR, USER_UI);
+	usel.smallIcons = UI::Jdi->GetConfigBool(USER_SMALLICONS, USER_UI);
+	usel.sortBy = (SELECTOR_SORT)UI::Jdi->GetConfigInt(USER_SORTVIEW, USER_UI);
+
 	CreateStatusBar();
 
 	// From 2.0.18: Enable native IME.
@@ -749,6 +1602,12 @@ static int ui_main()
 
 	ui_active = true;
 
+	// The emulator has more than one SDL window: the video output is a separate window, which can
+	// cover the main window with the selector. Only the events of the main window are passed to
+	// ImGui, otherwise the movements and clicks over the video output window are interpreted as
+	// movements and clicks over the selector (the ImGui backend does not filter events by window).
+	const Uint32 mainWindowID = SDL_GetWindowID(window);
+
 	// Main loop
 
 	while (ui_active) {
@@ -756,16 +1615,63 @@ static int ui_main()
 		SDL_Event event;
 		while (SDL_PollEvent(&event)) {
 
-			ImGui_ImplSDL2_ProcessEvent(&event);
+			bool forMainWindow = true;
+
+			switch (event.type)
+			{
+				case SDL_WINDOWEVENT:     forMainWindow = (event.window.windowID == mainWindowID); break;
+				case SDL_KEYDOWN:
+				case SDL_KEYUP:           forMainWindow = (event.key.windowID == mainWindowID); break;
+				case SDL_MOUSEMOTION:     forMainWindow = (event.motion.windowID == mainWindowID); break;
+				case SDL_MOUSEBUTTONDOWN: forMainWindow = (event.button.windowID == mainWindowID); break;
+				// SDL_MOUSEBUTTONUP is always passed to ImGui: the backend keeps its own state of the
+				// pressed buttons and captures the mouse with SDL_CaptureMouse() while any button is
+				// down. If the release event (which may be delivered to another window) is skipped, the
+				// mouse stays captured by the main window and the other windows stop responding to it.
+				case SDL_MOUSEWHEEL:      forMainWindow = (event.wheel.windowID == mainWindowID); break;
+				default: break;
+			}
+
+			if (forMainWindow)
+			{
+				ImGui_ImplSDL2_ProcessEvent(&event);
+			}
+
 			if (event.type == SDL_QUIT)
 				ui_active = false;
-			if (event.type == SDL_WINDOWEVENT && event.window.event == SDL_WINDOWEVENT_CLOSE && event.window.windowID == SDL_GetWindowID(window))
+			if (event.type == SDL_WINDOWEVENT && event.window.event == SDL_WINDOWEVENT_CLOSE && event.window.windowID == mainWindowID)
 				ui_active = false;
+		}
+
+		// The release of a pressed button can be delivered to another window or to another
+		// application, so do not leave the mouse captured by the main window when it is not active.
+		if ((SDL_GetWindowFlags(window) & SDL_WINDOW_INPUT_FOCUS) == 0)
+		{
+			for (Uint8 button = SDL_BUTTON_LEFT; button <= SDL_BUTTON_X2; button++)
+			{
+				SDL_Event up = { 0 };
+				up.type = SDL_MOUSEBUTTONUP;
+				up.button.type = SDL_MOUSEBUTTONUP;
+				up.button.windowID = mainWindowID;
+				up.button.button = button;
+				up.button.state = SDL_RELEASED;
+				ImGui_ImplSDL2_ProcessEvent(&up);
+			}
 		}
 
 		// Start the Dear ImGui frame
 		ImGui_ImplSDLRenderer2_NewFrame();
 		ImGui_ImplSDL2_NewFrame();
+
+		// While the application is focused, the ImGui SDL2 backend restores the mouse position from
+		// the global mouse state, even if the pointer is over another window (for example, over the
+		// video output window). Tell ImGui that there is no mouse, so that the covered selector is
+		// not highlighted under the pointer.
+		if ((SDL_GetWindowFlags(window) & SDL_WINDOW_MOUSE_FOCUS) == 0)
+		{
+			ImGui::GetIO().AddMousePosEvent(-FLT_MAX, -FLT_MAX);
+		}
+
 		ImGui::NewFrame();
 
 		// 1. Show the big demo window (Most of the sample code is in ImGui::ShowDemoWindow()! You can browse its code to learn more about Dear ImGui!).
@@ -790,14 +1696,7 @@ static int ui_main()
 				case FileReaction::OpenFile_LoadFile:
 					if (!name.empty())
 					{
-						CreateRenderTarget();
-						UI::Jdi->LoadFile(name);
-						if (Debug::debugger)
-						{
-							Debug::debugger->InvalidateAll();
-						}
-						OnMainWindowOpened(Util::StringToWstring(name).c_str());
-						UI::Jdi->Run();
+						load_file(Util::StringToWstring(name));
 					}
 					break;
 
@@ -826,7 +1725,15 @@ static int ui_main()
 		chooseDirectoryDialog.Display();
 		if (chooseDirectoryDialog.HasSelected())
 		{
+			auto name = chooseDirectoryDialog.GetSelected().string();
 			chooseDirectoryDialog.ClearSelected();
+
+			if (file_reaction == FileReaction::ChooseDirectory_SelectorPath && !name.empty())
+			{
+				AddSelectorPath(Util::StringToWstring(name));
+			}
+
+			file_reaction = FileReaction::None;
 		}
 
 		if (draw_message_box) {
@@ -856,6 +1763,8 @@ static int ui_main()
 	// Main window closed
 
 	// Cleanup
+	usel.clear();       // the banner textures must be destroyed before the renderer
+
 	ImGui_ImplSDLRenderer2_Shutdown();
 	ImGui_ImplSDL2_Shutdown();
 	ImGui::DestroyContext();


### PR DESCRIPTION
The SDL UI had only a stub where the selector should be. The port follows the Win32 selector (ui.cpp) and gives the SDL build a similar experience:

- executable files (DOL/ELF) and disk images (GCM/ISO) are collected from the paths of the PATH user variable, and the FILTER user variable keeps the same 8-bit masks per extension;
- for disk images the banner (opening.bnr) is converted from the 4x4 tiled RGB5A3 format into an SDL texture (the alpha channel is kept, so ImGui blends the banner with the row background), the GameID is read from the DiskID with the previous mount state restored, and the Japanese banners are converted from SJIS to Unicode;
- the table has the Icon/Title/Size/Game ID/Comment columns and the sort rules of the Win32 selector: Default (disks first, then by title), Filename, Title, Size, Game ID, Comment and Unsorted;
- the cursor is moved with a click, with the Up/Down keys or by the first letter of the title, and the selected file is started with Enter or with a double click;
- a new Options -> Selector menu holds Enable Selector, Refresh, Small Icons, Sort by, File Filter and Add Directory, and the File -> Refresh View item is implemented at last;
- the directory of every loaded file is appended to PATH and the file itself is remembered in LASTFILE, so the cursor is restored on the next run;
- the rescan is skipped while a game is running, because reading the banners mounts the disks, and is performed as soon as the emulation stops.

The video output is a separate SDL window and it can cover the main window with the selector. The ImGui backend does not filter the SDL events by window, so only the events of the main window are passed to it and the mouse position is invalidated while the pointer is over another window, otherwise the covered selector reacts to the movements and clicks over the video output window (a double click there could even start another game). Mouse button releases are never filtered: the backend captures the mouse with SDL_CaptureMouse() while a button is down, so a skipped release would leave the mouse captured by the main window forever and the other windows would stop responding to the mouse.

Verified with the SDL build on Windows: the disks from the configured paths are listed with their banners, titles, sizes, GameIDs and comments, the cursor jumps by letter, the sort rules, the small icons, the file filter and the Add Directory dialog work, and pong starts from the selector both with Enter and with a double click.

Builds clean (MSVC v145, Release SDL x64) and also compiles clean under g++ -std=gnu++17 -Wall (the Linux build uses the same sources).