### PR TITLE
GC-Linux now boots to the console: Gekko/SI fixes found while testing issue #58

### DIFF
--- a/src/gekko.cpp
+++ b/src/gekko.cpp
@@ -111,16 +111,13 @@ namespace Gekko
 	{
 		regs.tb.uval += CounterStep;         // timer
 
-		uint32_t old = regs.spr[SPR::DEC];
 		regs.spr[SPR::DEC] -= DecrementerStep;          // decrementer
-		if ((old ^ regs.spr[SPR::DEC]) & 0x80000000)
-		{
-			if (regs.msr & MSR_EE)
-			{
-				decreq = 1;
-				Report(Channel::CPU, "decrementer exception (OS alarm), pc:%08X\n", regs.pc);
-			}
-		}
+
+		// The decrementer exception request is level-sensitive: it stays pending until the
+		// decrementer is reloaded with a positive value, so it must not be lost (as it would
+		// be with an edge-triggered request) while MSR[EE] is cleared.
+
+		decreq = (regs.spr[SPR::DEC] & 0x8000'0000) != 0;
 	}
 
 	int64_t GekkoCore::GetTicks()
@@ -1748,6 +1745,32 @@ namespace Gekko
 		return false;
 	}
 
+	// The hash table walk (unlike DMA traffic) is coherent with the data cache.
+
+	void GekkoCore::ReadHashPte(uint32_t pa, uint32_t* reg)
+	{
+		if (cache->IsEnabled())
+		{
+			cache->ReadWord(pa, reg);
+		}
+		else
+		{
+			Flipper::HW->pi->PIReadWord(pa, reg);
+		}
+	}
+
+	void GekkoCore::WriteHashPte(uint32_t pa, uint32_t data)
+	{
+		if (cache->IsEnabled())
+		{
+			cache->WriteWord(pa, data);
+		}
+		else
+		{
+			Flipper::HW->pi->PIWriteWord(pa, data);
+		}
+	}
+
 	uint32_t GekkoCore::SegmentTranslation(uint32_t ea, MmuAccess type, int& WIMG)
 	{
 		int ptegUpper;
@@ -1810,8 +1833,8 @@ namespace Gekko
 
 			uint32_t pte[2];
 
-			Flipper::HW->pi->PIReadWord(primaryPteAddr, &pte[0]);
-			Flipper::HW->pi->PIReadWord(primaryPteAddr + 4, &pte[1]);
+			ReadHashPte(primaryPteAddr, &pte[0]);
+			ReadHashPte(primaryPteAddr + 4, &pte[1]);
 
 			// Check Hash Bit
 
@@ -1852,7 +1875,7 @@ namespace Gekko
 				{
 					pte[1] |= 0x80;     // Changed
 				}
-				Flipper::HW->pi->PIWriteWord(primaryPteAddr + 4, pte[1]);
+				WriteHashPte(primaryPteAddr + 4, pte[1]);
 
 				if (protectViolation)
 				{
@@ -1893,7 +1916,7 @@ namespace Gekko
 			{
 				// Referenced
 				pte[1] |= 0x100;
-				Flipper::HW->pi->PIWriteWord(primaryPteAddr + 4, pte[1]);
+				WriteHashPte(primaryPteAddr + 4, pte[1]);
 			}
 
 			primaryPteAddr += 8;
@@ -1907,8 +1930,8 @@ namespace Gekko
 
 			uint32_t pte[2];
 
-			Flipper::HW->pi->PIReadWord(secondaryPteAddr, &pte[0]);
-			Flipper::HW->pi->PIReadWord(secondaryPteAddr + 4, &pte[1]);
+			ReadHashPte(secondaryPteAddr, &pte[0]);
+			ReadHashPte(secondaryPteAddr + 4, &pte[1]);
 
 			// Check Hash Bit
 
@@ -1950,7 +1973,7 @@ namespace Gekko
 				{
 					pte[1] |= 0x80;
 				}
-				Flipper::HW->pi->PIWriteWord(secondaryPteAddr + 4, pte[1]);
+				WriteHashPte(secondaryPteAddr + 4, pte[1]);
 
 				if (protectViolation)
 				{
@@ -1991,7 +2014,7 @@ namespace Gekko
 			{
 				// Referenced
 				pte[1] |= 0x100;
-				Flipper::HW->pi->PIWriteWord(secondaryPteAddr + 4, pte[1]);
+				WriteHashPte(secondaryPteAddr + 4, pte[1]);
 			}
 
 			secondaryPteAddr += 8;

--- a/src/gekko.cpp
+++ b/src/gekko.cpp
@@ -93,7 +93,9 @@ namespace Gekko
 
 		regs.tb.uval = 0;
 		regs.spr[SPR::HID1] = 0x8000'0000;
-		regs.spr[SPR::DEC] = 0;
+		// The decrementer produces an exception on underflow, so it starts out negative:
+		// the program has to reload it with a positive value to arm the first exception.
+		regs.spr[SPR::DEC] = 0xffff'ffff;
 		regs.spr[SPR::CTR] = 0;
 
 		gatherBuffer->Reset();
@@ -111,13 +113,26 @@ namespace Gekko
 	{
 		regs.tb.uval += CounterStep;         // timer
 
+		uint32_t old = regs.spr[SPR::DEC];
 		regs.spr[SPR::DEC] -= DecrementerStep;          // decrementer
 
-		// The decrementer exception request is level-sensitive: it stays pending until the
-		// decrementer is reloaded with a positive value, so it must not be lost (as it would
-		// be with an edge-triggered request) while MSR[EE] is cleared.
+		if (regs.spr[SPR::DEC] & 0x8000'0000)
+		{
+			// Underflow. The request is latched, so that it is not lost while MSR[EE] is cleared,
+			// but it is generated only once per underflow: the decrementer has to be reloaded with
+			// a positive value before the next exception can be requested.
 
-		decreq = (regs.spr[SPR::DEC] & 0x8000'0000) != 0;
+			if (!(old & 0x8000'0000))
+			{
+				decreq = 1;
+			}
+		}
+		else
+		{
+			// A positive decrementer clears a pending underflow request.
+
+			decreq = 0;
+		}
 	}
 
 	int64_t GekkoCore::GetTicks()

--- a/src/gekko.h
+++ b/src/gekko.h
@@ -618,6 +618,12 @@ namespace Gekko
 
 		uint32_t EffectiveToPhysicalMmu(uint32_t ea, MmuAccess type, int& WIMG);
 
+		// The hardware hash table walk is coherent with the data cache, so the page table entries
+		// must be accessed through it. A plain bus access would not see the PTEs written by the CPU.
+
+		void ReadHashPte(uint32_t pa, uint32_t* reg);
+		void WriteHashPte(uint32_t pa, uint32_t data);
+
 		volatile bool decreq = false;       // decrementer exception request
 		volatile bool intFlag = false;      // INT signal
 		volatile bool exception = false;    // exception pending

--- a/src/gekkoc.cpp
+++ b/src/gekkoc.cpp
@@ -2318,15 +2318,14 @@ namespace Gekko
 			n--;
 		}
 
-		if (i != 0)
+		// The last word (possibly incomplete) is still accumulated in r.
+
+		while (i)
 		{
-			while (i)
-			{
-				r <<= 8;
-				i--;
-			}
-			core->regs.gpr[rd] = r;
+			r <<= 8;
+			i--;
 		}
+		core->regs.gpr[rd] = r;
 
 		core->regs.pc += 4;
 	}
@@ -2369,15 +2368,14 @@ namespace Gekko
 			n--;
 		}
 
-		if (i != 0)
+		// The last word (possibly incomplete) is still accumulated in r.
+
+		while (i)
 		{
-			while (i)
-			{
-				r <<= 8;
-				i--;
-			}
-			core->regs.gpr[rd] = r;
+			r <<= 8;
+			i--;
 		}
+		core->regs.gpr[rd] = r;
 
 		core->regs.pc += 4;
 	}

--- a/src/gekkodec.cpp
+++ b/src/gekkodec.cpp
@@ -1595,8 +1595,8 @@ namespace Gekko
 
 	void Decoder::CrmsFast(uint32_t instr, DecoderInfo* info)
 	{
-		info->paramBits[0] = DIS_RD;
-		info->paramBits[1] = DIS_CRM;
+		info->paramBits[0] = DIS_CRM;
+		info->paramBits[1] = DIS_RD;
 	}
 
 	void Decoder::Crbd(uint32_t instr, DecoderInfo* info)

--- a/src/si.cpp
+++ b/src/si.cpp
@@ -482,6 +482,13 @@ namespace Flipper
 	// ---------------------------------------------------------------------------
 	// init
 
+	// The SI input buffer registers are writable, but the emulated SI gets their contents from
+	// the transfer engine, so a value written by the CPU is simply not retained.
+
+	static void si_wr_input_buffer(uint32_t addr, uint32_t data, void* context)
+	{
+	}
+
 	SerialInterface::SerialInterface(Flipper* flipper, HWConfig* config)
 	{
 		Debug::Report(Debug::Channel::SI, "Serial interface driver\n");
@@ -514,28 +521,28 @@ namespace Flipper
 		// joypads in/out command buffer
 		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN0_OUTBUF, si_rd_out0_hi, si_wr_out0_hi, this);
 		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN0_OUTBUF + 2, si_rd_out0_lo, si_wr_out0_lo, this);
-		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN0_INBUFH, si_inh0_hi, nullptr, this);
-		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN0_INBUFH + 2, si_inh0_lo, nullptr, this);
-		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN0_INBUFL, si_inl0_hi, nullptr, this);
-		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN0_INBUFL + 2, si_inl0_lo, nullptr, this);
+		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN0_INBUFH, si_inh0_hi, si_wr_input_buffer, this);
+		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN0_INBUFH + 2, si_inh0_lo, si_wr_input_buffer, this);
+		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN0_INBUFL, si_inl0_hi, si_wr_input_buffer, this);
+		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN0_INBUFL + 2, si_inl0_lo, si_wr_input_buffer, this);
 		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN1_OUTBUF, si_rd_out1_hi, si_wr_out1_hi, this);
 		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN1_OUTBUF + 2, si_rd_out1_lo, si_wr_out1_lo, this);
-		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN1_INBUFH, si_inh1_hi, nullptr, this);
-		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN1_INBUFH + 2, si_inh1_lo, nullptr, this);
-		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN1_INBUFL, si_inl1_hi, nullptr, this);
-		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN1_INBUFL + 2, si_inl1_lo, nullptr, this);
+		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN1_INBUFH, si_inh1_hi, si_wr_input_buffer, this);
+		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN1_INBUFH + 2, si_inh1_lo, si_wr_input_buffer, this);
+		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN1_INBUFL, si_inl1_hi, si_wr_input_buffer, this);
+		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN1_INBUFL + 2, si_inl1_lo, si_wr_input_buffer, this);
 		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN2_OUTBUF, si_rd_out2_hi, si_wr_out2_hi, this);
 		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN2_OUTBUF + 2, si_rd_out2_lo, si_wr_out2_lo, this);
-		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN2_INBUFH, si_inh2_hi, nullptr, this);
-		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN2_INBUFH + 2, si_inh2_lo, nullptr, this);
-		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN2_INBUFL, si_inl2_hi, nullptr, this);
-		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN2_INBUFL + 2, si_inl2_lo, nullptr, this);
+		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN2_INBUFH, si_inh2_hi, si_wr_input_buffer, this);
+		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN2_INBUFH + 2, si_inh2_lo, si_wr_input_buffer, this);
+		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN2_INBUFL, si_inl2_hi, si_wr_input_buffer, this);
+		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN2_INBUFL + 2, si_inl2_lo, si_wr_input_buffer, this);
 		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN3_OUTBUF, si_rd_out3_hi, si_wr_out3_hi, this);
 		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN3_OUTBUF + 2, si_rd_out3_lo, si_wr_out3_lo, this);
-		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN3_INBUFH, si_inh3_hi, nullptr, this);
-		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN3_INBUFH + 2, si_inh3_lo, nullptr, this);
-		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN3_INBUFL, si_inl3_hi, nullptr, this);
-		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN3_INBUFL + 2, si_inl3_lo, nullptr, this);
+		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN3_INBUFH, si_inh3_hi, si_wr_input_buffer, this);
+		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN3_INBUFH + 2, si_inh3_lo, si_wr_input_buffer, this);
+		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN3_INBUFL, si_inl3_hi, si_wr_input_buffer, this);
+		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_CHAN3_INBUFL + 2, si_inl3_lo, si_wr_input_buffer, this);
 
 		// si control registers
 		flipper->pi->PISetTrap(PI_REGSPACE_SI | SI_POLL, read_poll_hi, write_poll_hi, this);


### PR DESCRIPTION
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/41f3645e-3d72-4b81-b352-1e74e1bfdd80" />

Refs #58.

The 2004 GC-Linux build from the issue (`zImage-2.6.10-rc2-mm4-isobel-20041130_2142.nbdc7.dol`) now boots on
pureikyubu and brings up its `gcnfb` console (with the Tux logo) on the VI framebuffer. Getting there required
five fixes in the Gekko core and the SI, listed below with the symptom each one produced.

## How it was tested

* The DOL from the issue is loaded as a regular DOL; the kernel map file is picked up automatically
  (`AutoloadMap` finds `<name>.map` next to the DOL), which is what makes the debugging possible.
* Testing was done with a windowless build of the emulator (no UI), driven by a script:
  `load <dol>` → `run` → `sleep 40s` → `stop` → dump memory/state.
* The kernel log is read from the printk ring buffer: `__log_buf` = `0xC02280C4` (physical `0x2280C4`, 16 KB),
  counters `log_start`/`con_start`/`log_end` = `0xC02241E8` (addresses from the map file). Note that the
  emulator keeps a 24 MB write-back data cache shadow, so a raw memory dump shows a **stale, empty** log buffer;
  memory has to be read the way the CPU sees it (`GetDataCachePointer`/`ReadWord`), or the illusion appears that
  `printk` was never called.
* The console text is also visible in the XFB at physical `0x1698000` (640x480x16, RGB565, linelength 1280).

## Fixes

### 1. `mtcrf` decoded its operands in the wrong order — `src/gekkodec.cpp`

`Decoder::CrmsFast` assigned `paramBits[0] = DIS_RD` and `paramBits[1] = DIS_CRM`, while the interpreter
expects the condition register mask in `paramBits[0]` and the source register in `paramBits[1]`. As a result
the RS field was used as the CR mask and the CRM field as the register number (reading `gpr[128]`, out of
bounds), and CR0 was never restored after a call.

Symptom: the kernel oopsed in `ip_auto_config_setup` (`DAR: 00000000`, page fault), which called `do_exit()` on
the idle task and panicked with `Attempted to kill the idle task!`.

### 2. The MMU hash table walk bypassed the data cache — `src/gekko.cpp`, `src/gekko.h`

`SegmentTranslation()` read the page table entries straight from memory (`PIReadWord`), but the CPU writes HPTEs
with normal stores that land in the write-back data cache. Newly created PTEs were therefore invisible to the
table walk and the kernel retried the same fault forever (PC looping in `hash_page`/`retry`, the faulting
instruction in `alloc_slabmgmt`).

Fix: the walk now goes through the data cache (`ReadHashPte`/`WriteHashPte`, i.e. `cache->ReadWord/WriteWord`
when the cache is enabled), which is what the hardware does. This is the fix that makes the hashed page table
usable at all, so it is the most important one in this PR.

### 3. The decrementer exception had to be latched — `src/gekko.cpp`

The request was edge-triggered *and* gated by `MSR[EE]`, so it was lost when the decrementer underflowed with
interrupts disabled. The kernel's `jiffies` then never advanced and the boot hung in `calibrate_delay`
(`while (ticks == jiffies);`).

The first attempt (a purely level-sensitive request) was too aggressive and broke the IPL/Bootrom: the
decrementer starts at zero and is already negative after the first tick, so as soon as BS1 enabled `MSR[EE]`
the exception vector at `0x900` was re-entered forever (an instrumented run took 659 771 decrementer exceptions
without executing anything else). The final model follows the hardware (and Dolphin):

* the exception is caused by an **underflow** (the counter becoming negative) and is latched, so that it is not
  lost while `MSR[EE]` is cleared;
* it is generated **once per underflow** — the decrementer must be reloaded with a positive value before the
  next request is armed;
* a positive value clears a pending request;
* at reset the decrementer is negative (`0xFFFFFFFF`), so nothing is pending before the program has programmed
  it for the first time.

### 4. `lswi`/`lswx` dropped the last word — `src/gekkoc.cpp`

The last accumulated word was only stored when the byte count was not a multiple of four. GCC copies small
structures with `lswi`+`stswi` (12 bytes for a `struct qstr`), so the third register was left untouched and
garbage pointers reached `memcpy()` (oops in `memcpy` called from `d_alloc`, `DAR: 00000000`).

### 5. Writes to the SI input buffer registers halted the emulation — `src/si.cpp`

`SIxINBUFH/L` had no write handler, so the PI default handler stopped the emulation with
`Unhandled HW access: W16 0C006404`, although the hardware allows these registers to be written (the kernel's
`gcn-si` driver zeroes them during initialisation). They now have an empty write handler; the emulated SI fills
their contents from the transfer engine anyway.

## Result

`dmesg` read from the kernel log buffer:

```
Total memory = 22MB; using 64kB for hash table (at c0240000)
Linux version 2.6.10-rc2-mm4-isobel-nbdc7 (albert@g.nothing.org) (gcc version 3.3.2) #1 Tue Nov 30 21:56:45 CET 2004
Kernel command line: root=/dev/ram0 video=gcnfb ip=192.168.000.047 init=/linuxrc ...
Calibrating delay loop... 8.19 BogoMIPS (lpj=4096)
Mount-cache hash table entries: 512 (order: 0, 4096 bytes)
checking if image is initramfs...it isn't (no cpio magic); looks like an initrd
Freeing initrd memory: 679k freed
gcn-mi: Nintendo GameCube Memory Interface driver
gcn-mi: protected region #0 from 0x1654000 to 0x1657fff with 0x1
gcnfb: framebuffer at 0x01698000, mapped to 0xd1698000, size 1200k
gcnfb: mode is 640x480x16, linelength=1280, pages=0
Console: switching to colour frame buffer device 80x30
fb0: GameCube frame buffer device
...
gcn-si: Nintendo GameCube Serial Interface driver
gcn-si: Port 0: Standard Pad
gcn-si: Port 1: Standard Pad
gcn-si: Port 2: Standard Pad
gcn-si: Port 3: Standard Pad
```

* No errors in the log (the only oddity is `Warning: real time clock seems stuck!`, which is an RTC emulation
  limitation and is harmless).
* The MMU works: hash table at `0xC0240000`, demand paging, region protection via `gcn-mi`, no MMU failures.
* The Linux console (with Tux) is in the VI framebuffer — see the screenshot in the issue thread.

## Regression checks

* **IPL/Bootrom**: same PC progression as the parent revision (`FFF0048x` → `8136277x` → ...), no decrementer
  storm in the exception vector (this is what fix 3 was corrected for).
* **Homebrew DOL** (`pong.dol`): boots as before, no halts in the log.
* The fixes only change instruction/interrupt semantics that were plainly wrong; nothing else in the tree is
  touched.

## Known limitations left for follow-ups (not fixed here)

These do not prevent the kernel from booting, but they keep the console from being visible in the emulator's own
VI window / from booting further:

1. **VI framebuffer format.** This kernel's `gcnfb` uses a 640x480x16 RGB565 framebuffer at `0x01698000` and
   writes `TFBL = framebuffer >> 5` (`0x0B4C00`). The emulator treats TFBL as a direct address and always
   converts the XFB as YUV422, so the VI window shows noise for GC-Linux. Supporting the address shift and
   RGB565 (format in `VI_PICT_CR = 0x2850` in this mode) would make the Linux console visible in the emulator.
2. **SI legacy transfer path.** The emulator takes the outgoing command byte from the SI communication buffer
   (`0x6480`), while this kernel writes it to `SI0OUTBUF` (`0x6400`). The emulator then reads its own previous
   response (`0x09`) as the next command and halts with `Unknown SI command. chan:0, cmd:09, out:1, in:8`, which
   stops the boot right after the SI ports are probed. Games use the COM buffer path, which is why they are
   unaffected; the per-channel transfer mode (and the `LENGTH`/`CNT` registers) is not modelled yet.
3. The initrd inside the tested DOL is truncated (the second gzip stream is incomplete in the archive), so a
   full userspace boot is not possible with this image anyway.

## Commits

* `ee9ba000` — Gekko/SI: fix GC-Linux boot blockers (mtcrf, MMU hash walk, decrementer, lswi, SI)
* `a6d661f6` — Gekko: generate the decrementer exception on underflow only (fix Bootrom boot)