### PR TITLE
Gekko/GFX: fix the garbled colours of the THP movies (issue #347)

### DIFF
--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -435,6 +435,12 @@ namespace GFX
 					reg->AddUInt32(nullptr, gfx->tev->State().regl[i].bits);
 					reg->AddUInt32(nullptr, gfx->tev->State().regh[i].bits);
 				}
+				Json::Value* konst = tev->AddArray("konstReg");
+				for (int i = 0; i < 4; i++)
+				{
+					konst->AddUInt32(nullptr, gfx->tev->State().kregl[i].bits);
+					konst->AddUInt32(nullptr, gfx->tev->State().kregh[i].bits);
+				}
 				Json::Value* ksel = tev->AddArray("ksel");
 				for (int i = 0; i < 8; i++)
 				{
@@ -1306,6 +1312,12 @@ namespace GFX
 
 		std::vector<uint8_t> pixels((size_t)w * h * 3);
 		glReadPixels(0, 0, w, h, GL_RGB, GL_UNSIGNED_BYTE, pixels.data());
+
+		// glReadPixels returns RGB triplets, while a 24-bit BMP stores them as BGR.
+		for (size_t i = 0; i < (size_t)w * h; i++)
+		{
+			std::swap(pixels[i * 3 + 0], pixels[i * 3 + 2]);
+		}
 
 		// BMP is bottom-up, exactly like the GL framebuffer, so no flip is needed
 		uint8_t hdr[54] = { 0 };

--- a/src/gqr.h
+++ b/src/gqr.h
@@ -29,11 +29,12 @@ namespace Gekko
 		S16 = 7,			// signed 16-bit integer
 	};
 
-	// GQR bit fields (table 2-16). The table numbers bits from the least significant one:
-	// LD_SCALE 2:7, LD_TYPE 13:15, ST_SCALE 18:23, ST_TYPE 29:31. The manual's own worked
-	// example confirms this reading - GQR0 = 0xE000E000 is documented as "s16 loads and
-	// stores, scale 0", which is what this decoding produces (and the mirror-image reading
-	// would call it "float, scale -32").
+	// GQR bit fields (table 2-16). The manual numbers the bits of a register from the
+	// most significant one (bit 0 is the leftmost bit of Figure 2-15), so LD_SCALE in
+	// "bits 2:7" is the field at the top of the word: with the usual LSB numbering the
+	// layout is LD_SCALE 24:29, LD_TYPE 16:18, ST_SCALE 8:13, ST_TYPE 0:2. The SDK's own
+	// GQR values confirm it - the vertex formats pack to 0x00040004 (u8), 0x00050005 (u16),
+	// 0x00060006 (s8) and 0x00070007 (s16), all with scale 0.
 	struct GqrFields
 	{
 		uint8_t ldScale;			// 6-bit two's complement (-32..+31)
@@ -46,10 +47,10 @@ namespace Gekko
 	{
 
 		GqrFields f;
-		f.ldScale = (uint8_t)((gqr >> 2) & 0x3F);
-		f.ldType = (QuantType)((gqr >> 13) & 7);
-		f.stScale = (uint8_t)((gqr >> 18) & 0x3F);
-		f.stType = (QuantType)((gqr >> 29) & 7);
+		f.ldScale = (uint8_t)((gqr >> 24) & 0x3F);
+		f.ldType = (QuantType)((gqr >> 16) & 7);
+		f.stScale = (uint8_t)((gqr >> 8) & 0x3F);
+		f.stType = (QuantType)(gqr & 7);
 		return f;
 	}
 

--- a/src/tev.cpp
+++ b/src/tev.cpp
@@ -208,10 +208,12 @@ float TevSat(float v, bool low)
 // Component of a K constant (gfx-tev.md 3.4). component: 0 = r, 1 = g, 2 = b, 3 = a.
 //
 // The 5-bit selector is decoded as documented: 0..7 are the fixed 1.0..1/8 fractions, 8..11 are
-// black, 12..15 select a whole K register and 16..31 select one *channel* of K0..K3 (the channel is
-// picked by the low two bits of the selector, the register by the next two). Because a single
-// channel is what those selectors name, the value is the same for every `component`: the colour
-// operand replicates it into r, g and b, and the alpha operand uses it as is.
+// black, 12..15 select a whole K register and 16..31 select one *channel* of K0..K3. The four
+// groups of the single-channel range are the channels (16..19 red, 20..23 green, 24..27 blue,
+// 28..31 alpha) and the low two bits of the selector pick the K register, so the channel is the
+// high part of `sel - 16` and the register the low part. Because a single channel is what those
+// selectors name, the value is the same for every `component`: the colour operand replicates it
+// into r, g and b, and the alpha operand uses it as is.
 float KonstComponent(uint sel, int component)
 {
     if (sel < 8u)
@@ -224,8 +226,8 @@ float KonstComponent(uint sel, int component)
     if (sel < 16u)
         return tevKReg[int(sel) - 12][component];
 
-    uint channel = (sel - 16u) & 3u;
-    uint reg = (sel - 16u) >> 2;
+    uint channel = (sel - 16u) >> 2;
+    uint reg = (sel - 16u) & 3u;
     return tevKReg[int(reg)][int(channel)];
 }
 
@@ -850,10 +852,10 @@ void main()
 			reg[i][2] = sign11(tev.regh[i].b);
 			reg[i][3] = sign11(tev.regl[i].a);
 
-			kreg[i][0] = (float)((tev.regl[i].bits & 0x800000) ? (tev.regl[i].bits & 0xFF) : tev.regl[i].r);
-			kreg[i][1] = (float)((tev.regh[i].bits & 0x800000) ? ((tev.regh[i].bits >> 12) & 0xFF) : tev.regh[i].g);
-			kreg[i][2] = (float)((tev.regh[i].bits & 0x800000) ? (tev.regh[i].bits & 0xFF) : tev.regh[i].b);
-			kreg[i][3] = (float)((tev.regl[i].bits & 0x800000) ? ((tev.regl[i].bits >> 12) & 0xFF) : tev.regl[i].a);
+			kreg[i][0] = (float)tev.kregl[i].r;
+			kreg[i][1] = (float)tev.kregh[i].g;
+			kreg[i][2] = (float)tev.kregh[i].b;
+			kreg[i][3] = (float)tev.kregl[i].a;
 		}
 
 		glUniform4fv(p.Uniform("tevReg[0]"), 4, (float*)reg);
@@ -985,6 +987,35 @@ void main()
 		tev.alpha_func.logic = 0;		// and
 	}
 
+	// A write to TEV_REGISTERL/H belongs to the Rev B 8-bit K form when payload bit 23 is set and
+	// bit 11 is clear (gfx-tev.md 4.4); otherwise it is the original 11-bit colour register. The
+	// K form keeps its components in different places than the colour form (r/b in [7:0], a/g in
+	// [19:12]), so each form is unpacked into its own storage.
+	static bool TEVIsKonstForm(uint32_t value)
+	{
+		return ((value & 0x800000) != 0) && ((value & 0x800) == 0);
+	}
+
+	static void TEVLoadRegisterL(TEV_RegisterL* colour, TEV_KonstRegisterL* konst, uint32_t value)
+	{
+		if (TEVIsKonstForm(value))
+		{
+			konst->r = value & 0xFF;
+			konst->a = (value >> 12) & 0xFF;
+		}
+		else colour->bits = value;
+	}
+
+	static void TEVLoadRegisterH(TEV_RegisterH* colour, TEV_KonstRegisterH* konst, uint32_t value)
+	{
+		if (TEVIsKonstForm(value))
+		{
+			konst->b = value & 0xFF;
+			konst->g = (value >> 12) & 0xFF;
+		}
+		else colour->bits = value;
+	}
+
 	void TextureEnvironmentUnit::loadTEVReg(size_t index, uint32_t value)
 	{
 		switch (index)
@@ -1022,14 +1053,18 @@ void main()
 			case TEV_COLOR_ENV_F_ID: tev.color_env[0xf].bits = value; break;
 			case TEV_ALPHA_ENV_F_ID: tev.alpha_env[0xf].bits = value; break;
 
-			case TEV_REGISTERL_0_ID: tev.regl[0].bits = value; break;
-			case TEV_REGISTERH_0_ID: tev.regh[0].bits = value; break;
-			case TEV_REGISTERL_1_ID: tev.regl[1].bits = value; break;
-			case TEV_REGISTERH_1_ID: tev.regh[1].bits = value; break;
-			case TEV_REGISTERL_2_ID: tev.regl[2].bits = value; break;
-			case TEV_REGISTERH_2_ID: tev.regh[2].bits = value; break;
-			case TEV_REGISTERL_3_ID: tev.regl[3].bits = value; break;
-			case TEV_REGISTERH_3_ID: tev.regh[3].bits = value; break;
+			// The colour registers and the Rev B K constants share the register ids; the RTL routes
+			// the write by the tag bit of the payload: bit 23 set with bit 11 clear means the 8-bit
+			// K form, everything else is the original 11-bit colour form (gfx-tev.md 4.4). The two
+			// forms are separate storages, so a K write does not disturb the colour registers.
+			case TEV_REGISTERL_0_ID: TEVLoadRegisterL(&tev.regl[0], &tev.kregl[0], value); break;
+			case TEV_REGISTERH_0_ID: TEVLoadRegisterH(&tev.regh[0], &tev.kregh[0], value); break;
+			case TEV_REGISTERL_1_ID: TEVLoadRegisterL(&tev.regl[1], &tev.kregl[1], value); break;
+			case TEV_REGISTERH_1_ID: TEVLoadRegisterH(&tev.regh[1], &tev.kregh[1], value); break;
+			case TEV_REGISTERL_2_ID: TEVLoadRegisterL(&tev.regl[2], &tev.kregl[2], value); break;
+			case TEV_REGISTERH_2_ID: TEVLoadRegisterH(&tev.regh[2], &tev.kregh[2], value); break;
+			case TEV_REGISTERL_3_ID: TEVLoadRegisterL(&tev.regl[3], &tev.kregl[3], value); break;
+			case TEV_REGISTERH_3_ID: TEVLoadRegisterH(&tev.regh[3], &tev.kregh[3], value); break;
 			case TEV_RANGE_ADJ_C_ID: tev.rangeadj_control.bits = value; break;
 			case TEV_RANGE_ADJ_0_ID: tev.range_adj[0].bits = value; break;
 			case TEV_RANGE_ADJ_1_ID: tev.range_adj[1].bits = value; break;

--- a/src/tev.h
+++ b/src/tev.h
@@ -319,6 +319,8 @@ namespace GFX
 		TEV_AlphaEnv alpha_env[16]{};		// 0xC1..0xDF
 		TEV_RegisterL regl[4]{};		// 0xE0,0xE2,0xE4,0xE6
 		TEV_RegisterH regh[4]{};		// 0xE1,0xE3,0xE5,0xE7
+		TEV_KonstRegisterL kregl[4]{};	// Rev B K constants, same register ids as the colour registers
+		TEV_KonstRegisterH kregh[4]{};
 		TEV_RangeAdj_Contol rangeadj_control{};	// 0xE8
 		TEV_RangeAdj range_adj[5]{};	// 0xE9...0xED
 		TEV_FogParam0 fog_param0{};		// 0xEE

--- a/testing/gfx_tev_test.cpp
+++ b/testing/gfx_tev_test.cpp
@@ -288,6 +288,23 @@ namespace pureikyubutest
 				Assert::AreEqual<unsigned>(0x200 + i, tev.regl[i].a, L"REGISTERL.a");
 				Assert::AreEqual<unsigned>(0x300 + i, tev.regh[i].b, L"REGISTERH.b");
 				Assert::AreEqual<unsigned>(0x400 + i, tev.regh[i].g, L"REGISTERH.g");
+
+				// The Rev B K form of the same ids lands in its own storage
+				uint32_t kl = (0x11 + i) | ((0x22 + i) << 12) | 0x800000;
+				uint32_t kh = (0x33 + i) | ((0x44 + i) << 12) | 0x800000;
+				m.BpLoad(TEV_REGISTERL_0_ID + i * 2, kl);
+				m.BpLoad(TEV_REGISTERH_0_ID + i * 2, kh);
+
+				Assert::AreEqual<unsigned>(0x11 + i, tev.kregl[i].r, L"K REGISTERL.r");
+				Assert::AreEqual<unsigned>(0x22 + i, tev.kregl[i].a, L"K REGISTERL.a");
+				Assert::AreEqual<unsigned>(0x33 + i, tev.kregh[i].b, L"K REGISTERH.b");
+				Assert::AreEqual<unsigned>(0x44 + i, tev.kregh[i].g, L"K REGISTERH.g");
+
+				// ...and leaves the colour registers alone
+				Assert::AreEqual<unsigned>(0x100 + i, tev.regl[i].r, L"REGISTERL.r stays");
+				Assert::AreEqual<unsigned>(0x200 + i, tev.regl[i].a, L"REGISTERL.a stays");
+				Assert::AreEqual<unsigned>(0x300 + i, tev.regh[i].b, L"REGISTERH.b stays");
+				Assert::AreEqual<unsigned>(0x400 + i, tev.regh[i].g, L"REGISTERH.g stays");
 			}
 		}
 
@@ -570,7 +587,8 @@ namespace pureikyubutest
 		}
 
 		// kcsel values 16..31 name a single channel of K0..K3; for a colour operand that channel is
-		// replicated into r, g and b.
+		// replicated into r, g and b. The four groups of that range are the channels - 16..19 red,
+		// 20..23 green, 24..27 blue, 28..31 alpha - and the low two bits pick the K register.
 		TEST_METHOD(Tev_KonstChannelSelectorsReplicateTheChannel)
 		{
 			RequireGL();
@@ -586,8 +604,8 @@ namespace pureikyubutest
 			m.BpLoad(TEV_REGISTERL_1_ID, 0x55 | (0x88u << 12) | 0x800000);
 			m.BpLoad(TEV_REGISTERH_1_ID, 0x77 | (0x66u << 12) | 0x800000);
 
-			// kcsel = 21 -> K1 green (0x66), kasel = 19 -> K1 red (0x55)
-			m.BpLoad(TEV_KSEL_0_ID, PackKsel(21, 19, 0, 0));
+			// kcsel = 21 -> K1 green (0x66), kasel = 28 -> K0 alpha (0x44)
+			m.BpLoad(TEV_KSEL_0_ID, PackKsel(21, 28, 0, 0));
 			m.BpLoad(TEV_COLOR_ENV_0_ID, PackColorEnv(14, 15, 15, 15, 0, 0, 1, 0, 0));
 			m.BpLoad(TEV_ALPHA_ENV_0_ID, PackAlphaEnv(6, 7, 7, 7, 0, 0, 1, 0, 0));
 
@@ -600,6 +618,41 @@ namespace pureikyubutest
 			Assert::AreEqual<int>(0x66, rgb[0], L"the selected K channel is replicated into red");
 			Assert::AreEqual<int>(0x66, rgb[1], L"... green");
 			Assert::AreEqual<int>(0x66, rgb[2], L"... blue");
+		}
+
+		// The Rev B K constants and the 11-bit colour registers share the register ids but not the
+		// storage: the write path routes a write by the payload tag (bit 23 set, bit 11 clear is the
+		// 8-bit K form), so a later K write must not disturb the colour register written before it.
+		TEST_METHOD(Tev_KonstWriteDoesNotOverwriteTheColourRegister)
+		{
+			RequireGL();
+			GfxTestMachine& m = M();
+
+			SetupPassThroughXF(m);
+			SetupRasterColorSource(m);
+			SetupDefaultPixelState(m);
+
+			// Colour form first: c0 = (0x40, 0x00, 0xc0, 0x80)
+			m.BpLoad(TEV_REGISTERL_0_ID, 0x040 | (0x080u << 12));
+			m.BpLoad(TEV_REGISTERH_0_ID, 0x0c0 | (0x000u << 12));
+
+			// ...then the K form of the same ids: K0 = (0x10, 0x40, 0x30, 0x20)
+			m.BpLoad(TEV_REGISTERL_0_ID, 0x10 | (0x20u << 12) | 0x800000);
+			m.BpLoad(TEV_REGISTERH_0_ID, 0x30 | (0x40u << 12) | 0x800000);
+
+			// Stage 0: colour = c0 (seld = 0), the blend inputs are zero, so the register is output
+			m.BpLoad(TEV_COLOR_ENV_0_ID, PackColorEnv(15, 15, 15, 0, 0, 0, 1, 0, 0));
+			m.BpLoad(TEV_ALPHA_ENV_0_ID, PackAlphaEnv(7, 7, 7, 0, 0, 0, 1, 0, 0));
+
+			m.BeginFrame();
+			DrawFullScreenQuad(m, 0, 0, 0, 0xff);
+
+			uint8_t rgb[3];
+			m.ReadColorPixel(320, 240, rgb);
+
+			Assert::AreEqual<int>(0x40, rgb[0], L"the colour register keeps its red");
+			Assert::AreEqual<int>(0x00, rgb[1], L"... green");
+			Assert::AreEqual<int>(0xc0, rgb[2], L"... blue");
 		}
 
 		// =========================================================================================

--- a/testing/gqr_test.cpp
+++ b/testing/gqr_test.cpp
@@ -34,48 +34,64 @@ namespace GekkoUnitTest
 
 		TEST_METHOD(Decode_FieldsSitAtTheDocumentedBitPositions)
 		{
-			// LD_SCALE in bits 2-7 (least significant numbering, as the manual's worked
-			// example 0xE000E000 = "s16 in/out, scale 0" confirms)
+			// The manual numbers the bits of the GQR figure from the most significant end (bit 0
+			// is the leftmost bit), so "LD_SCALE 2:7" is the field at the top of the word. With
+			// the usual least-significant-first numbering the fields are LD_SCALE 24:29,
+			// LD_TYPE 16:18, ST_SCALE 8:13 and ST_TYPE 0:2.
 			for (int s = -32; s <= 31; s++)
 			{
-				uint32_t gqr = ((uint32_t)S(s) << 2);
+				uint32_t gqr = ((uint32_t)S(s) << 24);
 				Assert::AreEqual((int)S(s), (int)Gekko::GqrDecode(gqr).ldScale);
 				Assert::AreEqual((int)QuantType::SingleFloat, (int)Gekko::GqrDecode(gqr).ldType);
 				Assert::AreEqual(0, (int)Gekko::GqrDecode(gqr).stScale);
 				Assert::AreEqual((int)QuantType::SingleFloat, (int)Gekko::GqrDecode(gqr).stType);
 			}
 
-			// LD_TYPE in bits 13-15
+			// LD_TYPE in bits 16-18
 			for (int t = 0; t < 8; t++)
 			{
-				uint32_t gqr = ((uint32_t)t << 13);
+				uint32_t gqr = ((uint32_t)t << 16);
 				Assert::AreEqual(t, (int)Gekko::GqrDecode(gqr).ldType);
 			}
 
-			// ST_SCALE in bits 18-23
+			// ST_SCALE in bits 8-13
 			for (int s = -32; s <= 31; s++)
 			{
-				uint32_t gqr = ((uint32_t)S(s) << 18);
+				uint32_t gqr = ((uint32_t)S(s) << 8);
 				Assert::AreEqual((int)S(s), (int)Gekko::GqrDecode(gqr).stScale);
 			}
 
-			// ST_TYPE in bits 29-31
+			// ST_TYPE in bits 0-2
 			for (int t = 0; t < 8; t++)
 			{
-				uint32_t gqr = ((uint32_t)t << 29);
+				uint32_t gqr = ((uint32_t)t);
 				Assert::AreEqual(t, (int)Gekko::GqrDecode(gqr).stType);
 			}
 		}
 
-		TEST_METHOD(Decode_TypicalS16InS16OutGqr)
+		TEST_METHOD(Decode_TypicalQuantizedVertexFormatGqrs)
 		{
-			// The manual's example configuration "s16 loads & stores, scale 0"
-			uint32_t gqr = 0xE000E000;
+			// The values the SDK packs for the quantized vertex formats (u8, u16, s8, s16, all
+			// with scale 0) - the packer puts the type in the top field of each half.
+			uint32_t gqr = 0x00040004;
 			Gekko::GqrFields f = Gekko::GqrDecode(gqr);
-			Assert::AreEqual((int)QuantType::S16, (int)f.ldType);
-			Assert::AreEqual((int)QuantType::S16, (int)f.stType);
+			Assert::AreEqual((int)QuantType::U8, (int)f.ldType);
+			Assert::AreEqual((int)QuantType::U8, (int)f.stType);
 			Assert::AreEqual(0, (int)f.ldScale);
 			Assert::AreEqual(0, (int)f.stScale);
+
+			gqr = 0x00070007;
+			f = Gekko::GqrDecode(gqr);
+			Assert::AreEqual((int)QuantType::S16, (int)f.ldType);
+			Assert::AreEqual((int)QuantType::S16, (int)f.stType);
+
+			// A nonzero scale on both halves (u8, scale -3)
+			gqr = 0x3D043D04;
+			f = Gekko::GqrDecode(gqr);
+			Assert::AreEqual((int)QuantType::U8, (int)f.ldType);
+			Assert::AreEqual((int)QuantType::U8, (int)f.stType);
+			Assert::AreEqual(-3, Gekko::GqrScaleExponent(f.ldScale));
+			Assert::AreEqual(-3, Gekko::GqrScaleExponent(f.stScale));
 		}
 
 		TEST_METHOD(Decode_ScaleFieldIsSixBitTwosComplement)


### PR DESCRIPTION
The "ATARI" title FMV of Ikaruga decoded into a checkerboard of float fragments and then rendered pink instead of black. Three defects:

- GQR: rebuilding the field decoding in 1bb3d8d2 read table 2-16 with least-significant-bit numbering, but the manual numbers the bits of a register from the most significant one. With the usual numbering the layout is LD_SCALE 24:29, LD_TYPE 16:18, ST_SCALE 8:13 and ST_TYPE 0:2; the SDK's own GQR values (0x00040004 = u8/u8, 0x00050005 = u16/u16, 0x3D043D04 = u8 with scale -3, ...) confirm it. The wrong decode made the THP decoder load and store the frame data with the wrong type.

- TEV: the Rev B K constants share the register ids 0xE0-0xE7 with the 11-bit colour registers, but have their own storage and the write path picks it with the payload tag (bit 23 set, bit 11 clear). The emulator kept one value and derived both views from it, so a K write clobbered the colour register. Ikaruga programs both forms, and the movie conversion lost the offsets that the colour registers carry.

- TEV: the single-channel K selectors 16..31 are grouped by channel (16..19 red, 20..23 green, 24..27 blue, 28..31 alpha) and the low two bits pick the K register; the channel and register fields were swapped, so selector 28 (K0 alpha, the one the movie uses for green) resolved to K3 red, which is zero.

Also swap R and B when writing the GFX_DUMP BMP: glReadPixels returns RGB triplets while a 24-bit BMP stores BGR.

Verified against ffmpeg's decode of _atari.thp: the emulator's Y, U and V planes match the reference (correlation 1.000/0.997/0.997) and the rendered frame is pixel-close to it. The GQR and TEV tests are updated and extended for the corrected layout and the separate K storage; 338/338 pass.