### PR TITLE
Fix #349: Metroid Prime — black screen instead of the FMV (THP)

### DIFF
--- a/src/dsparam.cpp
+++ b/src/dsparam.cpp
@@ -307,20 +307,28 @@ namespace DSP
 		}
 	}
 
-	static void ARAMDmaThread(void* Parameter)
+	// Perform the whole ARAM transfer. The hardware streams the block through the ARAM controller
+	// and raises CDCR_ARINT when the last byte has been written; the emulator performs it in one go,
+	// like the other transfer engines (SI, EXI, DVD).
+	//
+	// The transfer used to be sliced into 32-byte steps driven by a worker thread. That conflicts
+	// with the CPU, which is the only other initiator of an ARAM DMA: a driver that starts the next
+	// block before the worker had finished the previous one hit the thread guard (Halt) and had its
+	// request dropped, so it waited for a completion interrupt that never came. Metroid Prime hung
+	// that way right after its intro movie, while the audio kept streaming.
+	static void ARAMDmaRun()
 	{
-		if (Core->GetTicks() < aram.gekkoTicks)
-			return;
-		aram.gekkoTicks = Core->GetTicks() + aram.gekkoTicksPerSlice;
+		int type = aram.cnt >> 31;
+		uint32_t cnt = aram.cnt & 0x03FF'FFE0;
 
-		// The DSP can mask ARAM-DMA requests, dedicating ARAM to the accelerator
+		// The DSP can mask ARAM-DMA requests, dedicating ARAM to the accelerator. The request is
+		// only held back if the DMA has not been started at all (a masked request while a transfer
+		// runs would deadlock the driver); the emulator completes the block at once, so the mask
+		// can only be seen before the first slice.
 		if (aram.masked)
 			return;
 
-		int type = aram.cnt >> 31;
-		uint32_t cnt = aram.cnt & 0x3FF'FFE0;
-
-		// blast data
+		// Main memory can be seen only through the DSP window.
 		uint8_t* ptr = (uint8_t*)Flipper::HW->mem->MIGetMemoryPointerForDSP(aram.mmaddr);
 		bool beyondAram = aram.araddr >= ARAMSIZE;
 
@@ -328,41 +336,28 @@ namespace DSP
 		{
 			// No expansion module is installed: a read returns zeros, a write is discarded
 			if (type == ARAM_TO_RAM && ptr != nullptr)
-				memset(ptr, 0, 32);
+				memset(ptr, 0, cnt);
 		}
-		else if (type == RAM_TO_ARAM)
+		else if (ptr != nullptr)
 		{
-			memcpy(&ARAM[aram.araddr], ptr, 32);
-		}
-		else
-		{
-			memcpy(ptr, &ARAM[aram.araddr], 32);
+			if (type == RAM_TO_ARAM)
+				memcpy(&ARAM[aram.araddr], ptr, cnt);
+			else
+				memcpy(ptr, &ARAM[aram.araddr], cnt);
 		}
 
-		aram.araddr += 32;
-		aram.mmaddr += 32;
-		cnt -= 32;
-		aram.cnt = cnt | (type << 31);
+		aram.araddr += cnt;
+		aram.mmaddr += cnt;
+		aram.cnt = 0;
 
-		if ((aram.cnt & ~0x8000'0000) == 0)
-		{
-			CDCR &= ~CDCR_ARDMA;
-			ARINT();                    // invoke aram TC interrupt
-			//if (aram.dspRunningBeforeAramDma)
-			//{
-			//    Flipper::HW->DSP->Run();
-			//}
-			if (aram.log) {
-				Report(Channel::AR, "Suspending ARAM DMA Thread\n");
-			}
-			aram.dmaThread->Suspend();
-		}
+		CDCR &= ~CDCR_ARDMA;
+		ARINT();                    // invoke aram DMA completion interrupt
 	}
 
 	static void ARDMA()
 	{
 		int type = aram.cnt >> 31;
-		int cnt = aram.cnt & 0x3FF'FFE0;
+		int cnt = aram.cnt & 0x03FF'FFE0;
 		bool specialAramDspDma = aram.mmaddr == 0x0100'0000 && aram.araddr == 0;
 
 		// inform developer about aram transfers
@@ -400,57 +395,7 @@ namespace DSP
 		// console, so such a transfer reads zeros / discards the written data - but it still has
 		// to run to completion and raise the completion interrupt, otherwise a driver that polls
 		// the busy flag (AMBL counter) or waits for the interrupt would hang.
-		if (aram.araddr >= ARAMSIZE)
-		{
-			uint8_t* ptr = (uint8_t*)Flipper::HW->mem->MIGetMemoryPointerForDSP(aram.mmaddr);
-
-			if (type == ARAM_TO_RAM && ptr != nullptr)
-				memset(ptr, 0, cnt);
-
-			aram.cnt = 0;
-			CDCR &= ~CDCR_ARDMA;
-			ARINT();                    // invoke aram DMA completion interrupt
-			return;
-		}
-
-		// For fast transactions, complete the DMA immediately because interthreading takes longer than the DMA readiness check in ar.a::__ARCheckSize..
-
-		if (cnt <= 32) {
-
-			uint8_t* ptr = (uint8_t*)Flipper::HW->mem->MIGetMemoryPointerForDSP(aram.mmaddr);
-			if (type == RAM_TO_ARAM) {
-				memcpy(&ARAM[aram.araddr], ptr, 32);
-			}
-			else {
-				memcpy(ptr, &ARAM[aram.araddr], 32);
-			}
-
-			aram.araddr += 32;
-			aram.mmaddr += 32;
-			aram.cnt = 0;
-
-			CDCR &= ~CDCR_ARDMA;
-			ARINT();	// invoke aram TC interrupt
-			return;
-		}
-
-		// For other cases - delegate job to thread
-
-		if (aram.dmaThread->IsRunning()) {
-			Halt("There is some nonsense going on: the ARAM DMA Thread needs to be started while it is still running.\n");
-		}
-
-		CDCR |= CDCR_ARDMA;
-		aram.gekkoTicks = Core->GetTicks() + aram.gekkoTicksPerSlice;
-		aram.dspRunningBeforeAramDma = Flipper::DSP->IsRunning();
-		//if (aram.dspRunningBeforeAramDma)
-		//{
-		//    Flipper::HW->DSP->Suspend();
-		//}
-		if (aram.log) {
-			Report(Channel::AR, "Resuming ARAM DMA Thread\n");
-		}
-		aram.dmaThread->Resume();
+		ARAMDmaRun();
 	}
 
 	// ---------------------------------------------------------------------------
@@ -541,29 +486,28 @@ namespace DSP
 		aram.mmaddr = aram.araddr = aram.cnt = 0;
 		aram.amcr = 0x43;			// 16 MB internal ARAM, no expansion
 		aram.masked = false;
-		aram.gekkoTicksPerSlice = 4;
 		aram.log = true;
 
 		// set traps to aram registers
-		flipper->pi->PISetTrap(PI_REGSPACE_DSP | AMMAH, am_read_mmah, am_write_mmah);
-		flipper->pi->PISetTrap(PI_REGSPACE_DSP | AMMAL, am_read_mmal, am_write_mmal);
-		flipper->pi->PISetTrap(PI_REGSPACE_DSP | AMAAH, am_read_amaah, am_write_amaah);
-		flipper->pi->PISetTrap(PI_REGSPACE_DSP | AMAAL, am_read_amaal, am_write_amaal);
-		flipper->pi->PISetTrap(PI_REGSPACE_DSP | AMBLH, am_read_amblh, am_write_amblh);
-		flipper->pi->PISetTrap(PI_REGSPACE_DSP | AMBLL, am_read_ambll, am_write_ambll);
+		// (the unit tests initialise the controller without a Flipper instance)
+		if (flipper != nullptr)
+		{
+			flipper->pi->PISetTrap(PI_REGSPACE_DSP | AMMAH, am_read_mmah, am_write_mmah);
+			flipper->pi->PISetTrap(PI_REGSPACE_DSP | AMMAL, am_read_mmal, am_write_mmal);
+			flipper->pi->PISetTrap(PI_REGSPACE_DSP | AMAAH, am_read_amaah, am_write_amaah);
+			flipper->pi->PISetTrap(PI_REGSPACE_DSP | AMAAL, am_read_amaal, am_write_amaal);
+			flipper->pi->PISetTrap(PI_REGSPACE_DSP | AMBLH, am_read_amblh, am_write_amblh);
+			flipper->pi->PISetTrap(PI_REGSPACE_DSP | AMBLL, am_read_ambll, am_write_ambll);
 
-		// controller configuration registers
-		flipper->pi->PISetTrap(PI_REGSPACE_DSP | AMCR, am_read_amcr, am_write_amcr);
-		flipper->pi->PISetTrap(PI_REGSPACE_DSP | AMNF, am_read_amnf, no_write);
-		flipper->pi->PISetTrap(PI_REGSPACE_DSP | AMCT, no_read, no_write);
-
-		aram.dmaThread = EMUCreateThread(ARAMDmaThread, true, nullptr, "ARAMDmaThread");
+			// controller configuration registers
+			flipper->pi->PISetTrap(PI_REGSPACE_DSP | AMCR, am_read_amcr, am_write_amcr);
+			flipper->pi->PISetTrap(PI_REGSPACE_DSP | AMNF, am_read_amnf, no_write);
+			flipper->pi->PISetTrap(PI_REGSPACE_DSP | AMCT, no_read, no_write);
+		}
 	}
 
 	void ARClose()
 	{
-		EMUJoinThread(aram.dmaThread);
-		aram.dmaThread = nullptr;
 
 		// destroy ARAM
 		if (ARAM)

--- a/src/dsparam.h
+++ b/src/dsparam.h
@@ -60,10 +60,6 @@ namespace DSP
 		volatile uint32_t    cnt;                // AMBLH/L - block length (bit 31 = direction)
 		volatile bool        masked;             // AMDM - ARAM-DMA requests masked by the DSP (ARAM dedicated to the accelerator)
 		uint16_t    amcr;               // AMCR (0x12) - the AR driver stores the ARAM size code here
-		Thread* dmaThread;
-		int64_t gekkoTicks;
-		size_t gekkoTicksPerSlice;
-		bool dspRunningBeforeAramDma;
 		bool log;
 	};
 

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -1120,6 +1120,8 @@ namespace GFX
 			msloc[i].bits = 0;
 		}
 
+		frame_dirty = false;
+
 		xf->Reset();
 		su->Reset();
 		ras->Reset();
@@ -1361,7 +1363,35 @@ namespace GFX
 	// rendering complete, swap buffers, sync to vretrace
 	void GFXCore::GPFrameDone()
 	{
-		GL_EndFrame();
+		// PE_FINISH / PE_TOKEN (GXDrawDone and friends) are the frame boundary most titles use: the
+		// picture is complete by then. A frame that a full-frame display copy has already presented
+		// (the movie players) holds nothing new, so it is not swapped a second time.
+		if (frame_dirty)
+		{
+			GL_EndFrame();
+			frame_dirty = false;
+		}
+
+		frame_done = true;
+	}
+
+	// A full-frame display copy (PE_COPY_CMD.opcode = display) makes the finished EFB the XFB that
+	// the video interface scans out (gfx-pe.md 5.6), so it is the moment the frame becomes visible:
+	// the copy engine hands the picture over to the display. The backend displays the EFB itself
+	// instead of a real XFB, which is why the swap happens here.
+	//
+	// This is what drives the titles whose movie player draws a frame, copies it to the XFB and
+	// waits for the retrace without ever calling GXDrawDone: without the swap their frames would
+	// stay on an unpresented back buffer, which is what kept the Metroid Prime FMV black (#349).
+	// See the PE copy command for why only the full-frame copies present.
+	void GFXCore::GPDisplayCopy()
+	{
+		if (frame_dirty)
+		{
+			GL_EndFrame();
+			frame_dirty = false;
+		}
+
 		frame_done = true;
 	}
 

--- a/src/gfx.cpp
+++ b/src/gfx.cpp
@@ -1246,11 +1246,13 @@ namespace GFX
 
 		glDrawBuffer(GL_BACK);
 
-		if (pe->TakePendingCopyClear())
+		PixelEngine::CopyClearState clear{};
+
+		if (pe->TakePendingCopyClear(&clear))
 		{
 			// A copy command of the previous frame asked for the EFB to be cleared. It is the copy
-			// engine's clear, so it honours the PE_COPY_CMD bounds and restores the PE state itself.
-			pe->ApplyCopyClear();
+			// engine's clear, so it restores the PE state itself.
+			pe->ApplyCopyClear(clear);
 		}
 		else
 		{

--- a/src/gfx.h
+++ b/src/gfx.h
@@ -94,6 +94,13 @@ namespace GFX
 
 		bool frame_done = true;
 		bool frameReady = false;
+
+		// The frame holds content that has not been handed to the display yet. A display copy only
+		// presents such a frame: the copy engine may be asked to write the XFB several times per
+		// frame (init sequences, two XFB buffers), and swapping for every copy would show the
+		// cleared EFB of the next frame in between (a flicker).
+		bool frame_dirty = false;
+
 		bool backend_started = false;
 
 #if GFX_USE_SDL_WINDOW
@@ -129,6 +136,12 @@ namespace GFX
 		void GL_EndFrame();
 		void GPFrameBegin();
 		void GPFrameDone();
+
+		//! A full-frame display copy handed the finished EFB over to the display (PE_COPY_CMD.opcode).
+		void GPDisplayCopy();
+
+		//! A primitive was rasterized: the frame now holds content the display has not seen yet.
+		void GPFrameDrawn() { frame_dirty = true; }
 
 		void ResizeRenderTarget(size_t width, size_t height);
 

--- a/src/pe.cpp
+++ b/src/pe.cpp
@@ -244,6 +244,8 @@ namespace GFX
 			// draw done
 			case PE_FINISH_ID:
 			{
+				// GXDrawDone marks the end of the frame and is how most titles present: the copied
+				// picture is complete by now.
 				gfx->GPFrameDone();
 
 				pe_done_num++;
@@ -314,20 +316,38 @@ namespace GFX
 				break;
 
 			// The copy command is the trigger of the whole copy engine. Of its operations only the
-			// clear is something the OpenGL backend can honour: the copy to main memory (display copy
-			// and texture copy) needs the EFB to be readable as a texture, which the emulator does not
-			// emulate (it renders to the back buffer, see gfx.cpp).
+			// clear and the hand-over to the display are something the OpenGL backend can honour:
+			// the copy to main memory (display copy and texture copy) needs the EFB to be readable
+			// as a texture, which the emulator does not emulate.
 			//
-			// The clear is only *recorded* here, it is performed by the frame begin. The copy command
-			// is issued at the end of a frame (to hand the finished EFB over to the display and to
-			// prepare it for the next one), while the presented frame is swapped on PE_FINISH, which
-			// comes later. Clearing right away would therefore erase the frame that is still to be
-			// displayed.
+			// The clear is only *recorded* here, it is performed by the frame begin: it belongs to
+			// the end of the frame (the finished EFB is handed over and prepared for the next one),
+			// so clearing right away would erase the frame that is still to be displayed. The swap
+			// itself happens right here, on the display copy - that is where the XFB the video
+			// interface shows is written (see GFXCore::GPDisplayCopy).
 			case PE_COPY_CMD_ID:
 				pe.copy_cmd.bits = value;
 				if (pe.copy_cmd.clear)
 				{
 					copy_clear_pending = true;
+				}
+
+				// A display copy hands the finished EFB over to the video interface as the XFB
+				// (gfx-pe.md 5.6), so the full-frame ones are a frame boundary of their own. The
+				// backend displays the EFB instead of the XFB, so the picture has to be swapped
+				// here for the titles whose movie player presents through the copy engine and waits
+				// for the retrace without ever calling GXDrawDone (the SDK THP player does that; its
+				// frames stayed on an unpresented back buffer, issue #349).
+				//
+				// A partial display copy is not a frame boundary: the bootrom and the 2D front ends
+				// write the picture in several passes (one copy per display-list buffer) and call
+				// PE_FINISH when the frame is complete. Presenting those would flicker the picture.
+				//
+				// A texture copy is an intermediate render target and never presents.
+				if (pe.copy_cmd.opcode == PE_COPY_CMD_DISPLAY &&
+					pe.copy_src_addr.x == 0 && pe.copy_src_size.x + 1 >= gfx->RenderWidth())
+				{
+					gfx->GPDisplayCopy();
 				}
 				break;
 

--- a/src/pe.cpp
+++ b/src/pe.cpp
@@ -329,7 +329,12 @@ namespace GFX
 				pe.copy_cmd.bits = value;
 				if (pe.copy_cmd.clear)
 				{
-					copy_clear_pending = true;
+					// Capture the clear values now: the clear runs at the next frame begin, and the
+					// game may have programmed the registers for its next copy by then.
+					copy_clear.ar = pe.copy_clear_ar;
+					copy_clear.gb = pe.copy_clear_gb;
+					copy_clear.z = pe.copy_clear_z;
+					copy_clear.pending = true;
 				}
 
 				// A display copy hands the finished EFB over to the video interface as the XFB
@@ -492,36 +497,15 @@ namespace GFX
 			glDisable(GL_DITHER);
 	}
 
-	// The copy bounds come from PE_XBOUND / PE_YBOUND (gfx-pe.md 6.17). The clamp bits of
-	// PE_COPY_CMD belong to the vertical filter and not to the bounds, so they are not consulted.
-	void PixelEngine::CopyBounds(int* x, int* y, int* width, int* height)
-	{
-		int left = (int)pe.xbound.left;
-		int right = (int)pe.xbound.right;
-		int top = (int)pe.ybound.top;
-		int bottom = (int)pe.ybound.bottom;
-
-		if (right < left)
-		{
-			int t = left; left = right; right = t;
-		}
-		if (bottom < top)
-		{
-			int t = top; top = bottom; bottom = t;
-		}
-
-		*x = left;
-		*y = top;
-		*width = right - left + 1;
-		*height = bottom - top + 1;
-	}
-
-	// The copy engine's clear fills the (optionally bounded) EFB region with the PE clear colour and
-	// the clear Z, without depth testing or blending.
-	void PixelEngine::ApplyCopyClear()
+	// The copy engine's clear fills the EFB with the PE clear colour and the clear Z, without depth
+	// testing or blending, using the values the copy that asked for it was programmed with (see
+	// CopyClearState). The hardware clears only the rectangle the copy read, but the backend displays
+	// the whole EFB (a real console shows the scaled XFB instead), so the whole render target is
+	// cleared here: leaving the rest of it alone smeared the previous frame into the part of the
+	// picture the copy does not cover.
+	void PixelEngine::ApplyCopyClear(const CopyClearState& clear)
 	{
 		int x = 0, y = 0, w = (int)gfx->scr_w, h = (int)gfx->scr_h;
-		CopyBounds(&x, &y, &w, &h);
 
 		glScissor(x, (int)gfx->scr_h - (y + h), w, h);
 		glDisable(GL_BLEND);
@@ -535,11 +519,11 @@ namespace GFX
 		glDepthMask(GL_TRUE);
 
 		glClearColor(
-			(float)pe.copy_clear_ar.red / 255.0f,
-			(float)pe.copy_clear_gb.green / 255.0f,
-			(float)pe.copy_clear_gb.blue / 255.0f,
-			(float)pe.copy_clear_ar.alpha / 255.0f);
-		glClearDepth((double)(pe.copy_clear_z.value / 16777215.0));
+			(float)clear.ar.red / 255.0f,
+			(float)clear.gb.green / 255.0f,
+			(float)clear.gb.blue / 255.0f,
+			(float)clear.ar.alpha / 255.0f);
+		glClearDepth((double)(clear.z.value / 16777215.0));
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
 		// The clear bypassed the GL state the registers describe, so it is re-applied
@@ -549,18 +533,23 @@ namespace GFX
 		glScissor(0, 0, (GLsizei)gfx->scr_w, (GLsizei)gfx->scr_h);
 	}
 
-	bool PixelEngine::TakePendingCopyClear()
+	bool PixelEngine::TakePendingCopyClear(CopyClearState* state)
 	{
-		bool pending = copy_clear_pending;
-		copy_clear_pending = false;
-		return pending;
+		if (!copy_clear.pending)
+		{
+			return false;
+		}
+
+		*state = copy_clear;
+		copy_clear.pending = false;
+		return true;
 	}
 
 	void PixelEngine::Reset()
 	{
 		pe = PEState{};
 		peregs = PERegs{};
-		copy_clear_pending = false;
+		copy_clear = CopyClearState{};
 
 		// The hardware reset values that the specification states (gfx-pe.md 6.5, 6.8, 6.20)
 		pe.field_mask.bits = 0x3;

--- a/src/pe.h
+++ b/src/pe.h
@@ -295,6 +295,13 @@ namespace GFX
 		uint32_t bits;
 	};
 
+	// PE_COPY_CMD.opcode: where the copy engine writes the EFB rectangle (gfx-pe.md 5.6, 5.7).
+	enum PE_COPY_CMD_KIND
+	{
+		PE_COPY_CMD_TEXTURE = 0,		// the rectangle becomes a texture in main memory
+		PE_COPY_CMD_DISPLAY = 1,		// the rectangle becomes the XFB the video interface shows
+	};
+
 	// 0x52
 	union PE_COPY_CMD
 	{

--- a/src/pe.h
+++ b/src/pe.h
@@ -468,8 +468,20 @@ namespace GFX
 		size_t frames = 0;
 		size_t pe_done_num = 0;   // number of drawdone (PE_FINISH) events
 
-		//! A PE_COPY_CMD with the clear bit set was issued and its clear has not been performed yet.
-		bool copy_clear_pending = false;
+		//! The clear values of the last PE_COPY_CMD that asked for one, captured when the command was
+		//! issued. The clear itself runs at the next frame begin (it prepares the EFB for the frame
+		//! that follows the copy, and doing it on arrival would wipe the frame that is still to be
+		//! displayed), and by then the game may already have programmed the registers for its next
+		//! copy: reading the live registers there used the wrong Z, which left the depth buffer of
+		//! Metroid Prime at Z=0 and made its LEQUAL depth test reject every draw (issue #349).
+		struct CopyClearState
+		{
+			PE_COPY_CLEAR_AR ar{};
+			PE_COPY_CLEAR_GB gb{};
+			PE_COPY_CLEAR_Z z{};
+			bool pending = false;
+		};
+		CopyClearState copy_clear{};
 
 		PERegs peregs{};	// PE PI regs
 
@@ -480,9 +492,6 @@ namespace GFX
 
 		void PE_DONE_INT();
 		void PE_TOKEN_INT();
-
-		//! The bounds of the copy operation, in EFB pixels.
-		void CopyBounds(int* x, int* y, int* width, int* height);
 
 		// Pixel Engine mapped regs
 		static void PERegRead(uint32_t addr, uint32_t* reg, void* context);
@@ -497,13 +506,13 @@ namespace GFX
 		void ApplyColorMode();
 
 		//! The copy engine's clear operation (PE_COPY_CMD with the clear bit set).
-		void ApplyCopyClear();
+		void ApplyCopyClear(const CopyClearState& clear);
 
-		//! Take the pending copy-clear flag (see the PE_COPY_CMD handling). The clear itself is
-		//! performed by the frame begin, because the clear prepares the EFB for the frame that
-		//! follows the copy: doing it the moment the copy command arrives would wipe the frame that
-		//! is about to be displayed (the swap happens on PE_FINISH, after the copy).
-		bool TakePendingCopyClear();
+		//! Take the pending copy clear (see the PE_COPY_CMD handling). It is performed by the frame
+		//! begin, because it prepares the EFB for the frame that follows the copy: doing it the moment
+		//! the copy command arrives would wipe the frame that is about to be displayed (the swap
+		//! happens later, on PE_FINISH or on a full-frame display copy).
+		bool TakePendingCopyClear(CopyClearState* state);
 
 		PixelEngine(Flipper::Flipper* flipper, HWConfig *config, GFXCore *parent_gfx);
 		~PixelEngine();

--- a/src/ras.cpp
+++ b/src/ras.cpp
@@ -178,6 +178,10 @@ namespace GFX
 		if (vertex_count == 0)
 			return;
 
+		// The frame now holds content: the display copy that closes it presents this picture
+		// (see GFXCore::GPDisplayCopy).
+		gfx->GPFrameDrawn();
+
 		SetUpPipeline();
 		DrawPrimitive();
 

--- a/src/xf.cpp
+++ b/src/xf.cpp
@@ -1067,10 +1067,53 @@ void main()
 		xf.projectionParam[0] = 1.0f;
 		xf.projectionParam[2] = 1.0f;
 		xf.projectionParam[4] = 1.0f;
+
+		SetGxInitDefaults();
 	}
 
 	TransformUnit::~TransformUnit()
 	{
+	}
+
+	// The state the GX SDK's GXInit establishes in the XF before a title draws anything. The hardware
+	// reset values are undefined (gfx-xf.md 4.6.7), the SDK's are not, and a title may rely on them:
+	// Metroid Prime and Zelda select the SDK's identity texture matrix by index without ever loading
+	// it, and they leave the material and the channel controls alone. Without the identity matrices
+	// the texture coordinates of every draw collapse to (0, 0) - one texel stretched over the whole
+	// screen - and without the white material the lighting alpha is zero, which the pixel engine's
+	// SRCALPHA / INVSRCALPHA blend then turns into an invisible draw. The values below are the ones
+	// the real IPL's GXInit leaves in the registers (verified by tracing a bootrom run).
+	void TransformUnit::SetGxInitDefaults()
+	{
+		// GX_PNMTX0 - the geometry and normal identity matrices. Rows are four / three words wide.
+		const float mtx3x4[12] = { 1,0,0,0, 0,1,0,0, 0,0,1,0 };
+		const float mtx3x3[9] = { 1,0,0, 0,1,0, 0,0,1 };
+
+		for (int i = 0; i < 12; i++)
+			xf.mvTexMtx[i] = mtx3x4[i];
+		for (int i = 0; i < 9; i++)
+			xf.nrmMtx[i] = mtx3x3[i];
+
+		// GX_IDENTITY (60) and GX_DTTIDENTITY (61): the identity texture and dual-texture matrices.
+		for (int i = 0; i < 12; i++)
+		{
+			xf.mvTexMtx[GX_IDENTITY * 4 + i] = mtx3x4[i];
+			xf.dualTexMtx[GX_DTTIDENTITY * 4 + i] = mtx3x4[i];
+		}
+
+		// GXSetChanAmbColor(BLACK) / GXSetChanMatColor(WHITE) for both channels.
+		xf.ambient[0].RGBA = 0;
+		xf.ambient[1].RGBA = 0;
+		xf.material[0].RGBA = 0xFFFFFFFF;
+		xf.material[1].RGBA = 0xFFFFFFFF;
+
+		// GXSetChanCtrl(..., GX_SRC_REG, GX_SRC_VTX, ...) for the four colour/alpha controls:
+		// the material comes from the vertex colour and the lighting is the constant 1.0.
+		for (int i = 0; i < 2; i++)
+		{
+			xf.colorControl[i].bits = 0x401;
+			xf.alphaControl[i].bits = 0x401;
+		}
 	}
 
 	void TransformUnit::Reset()
@@ -1087,6 +1130,8 @@ void main()
 		xf.projectionParam[0] = 1.0f;
 		xf.projectionParam[2] = 1.0f;
 		xf.projectionParam[4] = 1.0f;
+
+		SetGxInitDefaults();
 
 		// The GL viewport is not refreshed here: the zeroed viewport registers do not describe one.
 		// It is restored by GFXCore::ApplyDefaultGLState().

--- a/src/xf.h
+++ b/src/xf.h
@@ -333,6 +333,11 @@ namespace GFX
 
 #pragma pack(pop)
 
+	// The texture matrix slots the GX SDK reserves for the identity matrices. GXInit loads them
+	// there and a title selects them by index (the GX SDK calls them GX_IDENTITY and GX_DTTIDENTITY).
+	#define GX_IDENTITY     60
+	#define GX_DTTIDENTITY  61
+
 	class TransformUnit
 	{
 		friend GFXCore;
@@ -431,5 +436,9 @@ namespace GFX
 
 		//! Put the XF register state and the CP interface back into the reset state.
 		void Reset();
+
+		//! Put the matrix RAM, the material/ambient colours and the channel controls at the values
+		//! the GX SDK's GXInit programs.
+		void SetGxInitDefaults();
 	};
 }

--- a/testing/dsp_control_test.cpp
+++ b/testing/dsp_control_test.cpp
@@ -583,6 +583,101 @@ namespace DspUnitTest
 			Assert::AreEqual((uint16_t)0x87FF, m.DMem(0xFFD8), L"ACCAH keeps the direction bit and bits 10:0 only");
 		}
 
+		// ---------------------------------------------------------------
+		// ARAM DMA (issue #349 / #111)
+		// ---------------------------------------------------------------
+
+		/// <summary>
+		/// Program a whole ARAM transfer through the AM* registers. The low word of the block
+		/// length starts the transfer, exactly as the AR driver does it: the length field is a
+		/// byte count stored in bits 25:5 (dsp.md section 5.4), so the driver writes the
+		/// 32-byte aligned byte count straight into it.
+		/// </summary>
+		void StartAramCopy(uint32_t mmaddr, uint32_t araddr, uint32_t length, bool aramToRam)
+		{
+			// The ARAM registers live in the Flipper PI DSP register space, not in DSP data
+			// memory: the AR driver reaches them through the PI traps that AROpen installs.
+			PIRegWrite(PI_REGSPACE_DSP | AMMAH, mmaddr >> 16);
+			PIRegWrite(PI_REGSPACE_DSP | AMMAL, mmaddr & 0xFFFF);
+			PIRegWrite(PI_REGSPACE_DSP | AMAAH, araddr >> 16);
+			PIRegWrite(PI_REGSPACE_DSP | AMAAL, araddr & 0xFFFF);
+			// Bit 15 of AMBLH is the direction; the block length is counted in 32-byte units,
+			// so its bit 5 is bit 0 of the low word (dsp.md section 7.2).
+			PIRegWrite(PI_REGSPACE_DSP | AMBLH, (aramToRam ? 0x8000u : 0x0000u) | ((length >> 16) & 0x03FFu));
+			PIRegWrite(PI_REGSPACE_DSP | AMBLL, length & 0xFFFFu);		// starts the transfer
+		}
+
+		TEST_METHOD(AramDma_MovesTheWholeBlockAndRaisesTheCompletionInterrupt)
+		{
+			// The transfer engine streams the whole block through the ARAM controller and raises
+			// ARINT when the last byte has been written (dsp.md section 7, CDCR bit 5).
+			uint8_t* ram = DspTestMainMemoryBase();
+
+			for (uint32_t i = 0; i < 0x60; i++)
+			{
+				ram[0x1000 + i] = (uint8_t)(i + 1);
+			}
+
+			StartAramCopy(0x00001000, 0x00001000, 0x60, false);
+
+
+			for (uint32_t i = 0; i < 0x60; i++)
+			{
+				Assert::AreEqual((uint8_t)(i + 1), DSP::aram.mem[0x1000 + i], L"RAM->ARAM must copy the whole block");
+			}
+
+			Assert::AreEqual(0u, (uint32_t)DSP::aram.cnt, L"the block counter must be drained");
+			Assert::IsTrue((DSP::dsp_ai.cdcr & CDCR_ARINT) != 0, L"the completion interrupt must have been raised");
+			Assert::IsTrue((DSP::dsp_ai.cdcr & CDCR_ARDMA) == 0, L"the DMA-in-progress bit must be clear after the transfer");
+		}
+
+		TEST_METHOD(AramDma_SecondRequestWhileBusyIsNotDropped)
+		{
+			// Issue #349: Metroid Prime issues the next block before the previous transfer engine
+			// has finished. The emulator used to hit its "the thread is still running" guard, drop
+			// the request and then wait forever for a completion interrupt that never came, which
+			// hung the game right after the intro movie. A request must complete, and it must
+			// complete *after* the one it is queued behind, without dropping either block.
+			uint8_t* ram = DspTestMainMemoryBase();
+
+			for (uint32_t i = 0; i < 0x60; i++)
+			{
+				ram[0x2000 + i] = 0x80;
+				ram[0x3000 + i] = 0x40;
+			}
+
+			StartAramCopy(0x00002000, 0x00002000, 0x60, false);
+
+			// The driver already knows the DMA register is free again as soon as it has been read
+			// back as idle, so a second block must go through as well.
+			StartAramCopy(0x00003000, 0x00003000, 0x60, false);
+
+			for (uint32_t i = 0; i < 0x60; i++)
+			{
+				Assert::AreEqual((uint8_t)0x80, DSP::aram.mem[0x2000 + i], L"the first block must survive");
+				Assert::AreEqual((uint8_t)0x40, DSP::aram.mem[0x3000 + i], L"the second block must not be dropped");
+			}
+
+			Assert::AreEqual(0, DspTestHaltCount(), L"a busy transfer engine must never Halt");
+		}
+
+		TEST_METHOD(AramDma_CopiesBackToMainMemory)
+		{
+			uint8_t* ram = DspTestMainMemoryBase();
+
+			for (uint32_t i = 0; i < 0x60; i++)
+			{
+				DSP::aram.mem[0x4000 + i] = (uint8_t)(0xA0 + i);
+			}
+
+			StartAramCopy(0x00004000, 0x00004000, 0x60, true);
+
+			for (uint32_t i = 0; i < 0x60; i++)
+			{
+				Assert::AreEqual((uint8_t)(0xA0 + i), ram[0x4000 + i], L"ARAM->RAM must copy the whole block");
+			}
+		}
+
 		TEST_METHOD(Mvsi_SignExtendsShortImmediate)
 		{
 			m.Run({ Enc::Mvsi(R8A_A0, (int8_t)0x80) }, 1);

--- a/testing/dsp_test_common.h
+++ b/testing/dsp_test_common.h
@@ -31,6 +31,14 @@ std::string DspTestLogText();
 std::string DspTestLastHalt();
 int DspTestHaltCount();
 
+// The CPU-visible Flipper register window (implemented in dsp_test_support.cpp).
+
+/// <summary>Write a 32-bit word into the emulated PI register space (invokes the block traps).</summary>
+bool PIRegWrite(uint32_t addr, uint32_t value);
+
+/// <summary>Read a 32-bit word from the emulated PI register space.</summary>
+bool PIRegRead(uint32_t addr, uint32_t* value);
+
 namespace Flipper
 {
 	extern uint32_t TestPIAssertedInts;

--- a/testing/dsp_test_support.cpp
+++ b/testing/dsp_test_support.cpp
@@ -68,19 +68,16 @@ uint8_t* DspTestMainMemoryBase()
 /// </summary>
 void DspTestInitAram()
 {
-	if (DSP::aram.mem == nullptr)
-	{
-		DSP::aram.mem = new uint8_t[ARAMSIZE];
-		memset(DSP::aram.mem, 0, ARAMSIZE);
-	}
+	// AROpen installs the ARAM register traps on the Flipper PI. The tests never dereference the
+	// Flipper instance (PISetTrap only records the registration in the test double), so a
+	// zero-initialised shell is enough - the same trick the GFX tests use for their Flipper.
+	// ARAM itself is a flat buffer, so a fresh image is just as cheap.
+	static uint8_t flipperShell[sizeof(Flipper::Flipper)] = { 0 };
 
-	// The ARAM driver normally owns this thread; it is not started in unit tests.
-	DSP::aram.dmaThread = nullptr;
-	DSP::aram.mmaddr = 0;
-	DSP::aram.araddr = 0;
-	DSP::aram.cnt = 0;
-	DSP::aram.amcr = 0x43;			// 16 MB internal ARAM, no expansion
-	DSP::aram.masked = false;
+	Flipper::HW = (Flipper::Flipper*)flipperShell;		// the ARAM DMA engine reaches main memory through it
+
+	DSP::ARClose();
+	DSP::AROpen((Flipper::Flipper*)flipperShell);
 }
 
 void DspTestSetGekkoTicks(int64_t ticks)
@@ -366,6 +363,10 @@ namespace GfxUnitTest
 		return DspTestHaltCount();
 	}
 }
+
+// The DSP tests drive the Flipper register window through the same trap map.
+bool PIRegWrite(uint32_t addr, uint32_t value) { return GfxUnitTest::PIRegWrite(addr, value); }
+bool PIRegRead(uint32_t addr, uint32_t* value) { return GfxUnitTest::PIRegRead(addr, value); }
 
 namespace Flipper
 {

--- a/testing/gfx_pe_test.cpp
+++ b/testing/gfx_pe_test.cpp
@@ -483,5 +483,65 @@ namespace pureikyubutest
 			Assert::IsFalse(right[0] == 0xff && right[1] == 0 && right[2] == 0,
 				L"the pixel outside the bounds must not be cleared");
 		}
+
+		// PE_COPY_CMD.opcode decides what the copy engine does with the EFB rectangle (gfx-pe.md 5.6,
+		// 5.7). A full-frame *display* copy writes the XFB that the video interface scans out, so it is
+		// a point at which the frame becomes visible and the emulator has to swap the EFB it displays.
+		// A *texture* copy is an intermediate render target, and a partial display copy is one pass of
+		// a picture the title finishes with PE_FINISH (the bootrom writes the logo that way), so
+		// neither of them presents: swapping there flickered the picture.
+		//
+		// This is the frame boundary the SDK THP movie player relies on: it draws a frame, copies it
+		// to the XFB and waits for the retrace without ever calling GXDrawDone (PE_FINISH). Without
+		// the swap on the full-frame display copy the Metroid Prime FMV stayed black (issue #349).
+		TEST_METHOD(Pe_OnlyAFullFrameDisplayCopyPresentsTheFrame)
+		{
+			RequireGL();
+			GfxTestMachine& m = M();
+			SetupPassThrough(m);
+
+			m.BpLoad(PE_ZMODE_ID, 0);
+			m.BpLoad(PE_CMODE0_ID, 0x18);
+
+			m.BeginFrame();
+			DrawQuad(m, 0xff, 0xff, 0xff);
+
+			uint8_t rgb[3];
+			m.ReadColorPixel(320, 240, rgb);
+			Assert::AreEqual<int>(0xff, rgb[0], L"the quad must be in the EFB before the copy");
+
+			size_t frames = m.gfx->pe->Frames();
+
+			// The copy rectangle covers the whole render target, like the movie players' copy does.
+			m.BpLoad(PE_COPY_SRC_ADDR_ID, 0);
+			m.BpLoad(PE_COPY_SRC_SIZE_ID, (m.gfx->RenderWidth() - 1) | ((m.gfx->RenderHeight() - 1) << 10));
+
+			GFX::PE_COPY_CMD copy{};
+
+			// A texture copy leaves the frame on the EFB: no swap.
+			copy.opcode = GFX::PE_COPY_CMD_TEXTURE;
+			m.BpLoad(PE_COPY_CMD_ID, copy.bits);
+			Assert::AreEqual<size_t>(frames, m.gfx->pe->Frames(), L"a texture copy must not present");
+
+			// A partial display copy is one pass of a frame the title finishes with PE_FINISH.
+			m.BpLoad(PE_COPY_SRC_SIZE_ID, (m.gfx->RenderWidth() / 2 - 1) | ((m.gfx->RenderHeight() / 2 - 1) << 10));
+			copy.opcode = GFX::PE_COPY_CMD_DISPLAY;
+			m.BpLoad(PE_COPY_CMD_ID, copy.bits);
+			Assert::AreEqual<size_t>(frames, m.gfx->pe->Frames(), L"a partial display copy must not present");
+
+			// Drawing into the frame arms the next present again, and the full-frame display copy
+			// presents it: this is how the titles that never call GXDrawDone show their picture.
+			DrawQuad(m, 0x40, 0x40, 0x40);
+			m.BpLoad(PE_COPY_SRC_SIZE_ID, (m.gfx->RenderWidth() - 1) | ((m.gfx->RenderHeight() - 1) << 10));
+			m.BpLoad(PE_COPY_CMD_ID, copy.bits);
+			Assert::AreEqual<size_t>(frames + 1, m.gfx->pe->Frames(), L"a full-frame display copy must present");
+
+			// A second copy of a frame that has not been drawn into again must not present: that is
+			// what wiped the picture between frames before.
+			m.gfx->GPFrameBegin();
+			m.BpLoad(PE_COPY_CMD_ID, copy.bits);
+			Assert::AreEqual<size_t>(frames + 1, m.gfx->pe->Frames(),
+				L"a copy of a frame with no drawing must not present");
+		}
 	};
 }

--- a/testing/gfx_pe_test.cpp
+++ b/testing/gfx_pe_test.cpp
@@ -438,14 +438,16 @@ namespace pureikyubutest
 		// The copy engine
 		// =========================================================================================
 
-		// PE_COPY_CMD with the clear bit set asks the copy engine to clear the EFB region bounded by
-		// PE_XBOUND / PE_YBOUND with the PE clear values (gfx-pe.md 6.15, 6.17).
+		// PE_COPY_CMD with the clear bit set asks the copy engine to clear the EFB with the PE clear
+		// values while it copies the finished frame out (gfx-pe.md 5.6).
 		//
 		// A copy command is issued at the end of a frame: the finished EFB is handed over to the
-		// display and is prepared for the next frame. The displayed frame is swapped on PE_FINISH,
-		// which comes after the copy, so the clear must not run when the command arrives - it would
-		// erase the frame that is still to be shown (that is what turned the bootrom screen black).
-		// The clear is performed by the frame begin, which keeps the bounds.
+		// display and is prepared for the next frame. The clear must not run when the command arrives
+		// - it would erase the frame that is still to be shown (that is what turned the bootrom screen
+		// black) - so the frame begin performs it, with the values this copy was programmed with. The
+		// live registers cannot be used there: by then the game may have programmed them for its next
+		// copy, and Metroid Prime left the clear Z at 0 that way, which made its LEQUAL depth test
+		// reject every draw (issue #349).
 		TEST_METHOD(Pe_CopyClearKeepsTheCopiedFrameAndClearsTheNextOne)
 		{
 			RequireGL();
@@ -458,30 +460,28 @@ namespace pureikyubutest
 			m.BeginFrame();
 			DrawQuad(m, 0x80, 0x80, 0x80);
 
-			// Clear the left half to red
+			// The clear colour of this copy, and the depth it must leave behind.
 			m.BpLoad(PE_COPY_CLEAR_AR_ID, 0xff);			// red = 0xff, alpha = 0
 			m.BpLoad(PE_COPY_CLEAR_GB_ID, 0);				// blue = 0, green = 0
-			m.BpLoad(PE_XBOUND_ID, (0u << 0) | (319u << 10));
-			m.BpLoad(PE_YBOUND_ID, (0u << 0) | (479u << 10));
+			m.BpLoad(PE_COPY_CLEAR_Z_ID, 0x800000);
 			m.BpLoad(PE_COPY_CMD_ID, 1u << 11);				// clear
 
-			uint8_t left[3], right[3];
-			m.ReadColorPixel(100, 240, left);
-			m.ReadColorPixel(500, 240, right);
+			uint8_t rgb[3];
+			m.ReadColorPixel(320, 240, rgb);
+			Assert::AreEqual<int>(0x80, rgb[0], L"the copy clear must not wipe the frame it copies");
 
-			// The frame the copy belongs to is left alone, both inside and outside the clear bounds.
-			Assert::AreEqual<int>(0x80, left[0], L"the copy clear must not wipe the frame it copies");
-			Assert::AreEqual<int>(0x80, right[0], L"...");
+			// Reprogram the clear registers, as a game does for its next copy.
+			m.BpLoad(PE_COPY_CLEAR_AR_ID, 0);
+			m.BpLoad(PE_COPY_CLEAR_GB_ID, 0);
+			m.BpLoad(PE_COPY_CLEAR_Z_ID, 0);
 
-			// The next frame starts with the cleared region.
+			// The next frame starts cleared with the values of the copy that asked for the clear.
 			m.BeginFrame();
-			m.ReadColorPixel(100, 240, left);
-			m.ReadColorPixel(500, 240, right);
-
-			Assert::AreEqual<int>(0xff, left[0], L"the cleared half must be the clear colour");
-			Assert::AreEqual<int>(0, left[1], L"...");
-			Assert::IsFalse(right[0] == 0xff && right[1] == 0 && right[2] == 0,
-				L"the pixel outside the bounds must not be cleared");
+			m.ReadColorPixel(320, 240, rgb);
+			Assert::AreEqual<int>(0xff, rgb[0], L"the clear colour is the colour of that copy");
+			Assert::AreEqual<int>(0, rgb[1], L"...");
+			Assert::AreEqual(0.5f, m.ReadDepthPixel(320, 240), 0.01f,
+				L"the clear Z is the Z of that copy, not the one programmed later");
 		}
 
 		// PE_COPY_CMD.opcode decides what the copy engine does with the EFB rectangle (gfx-pe.md 5.6,

--- a/testing/gfx_test_common.h
+++ b/testing/gfx_test_common.h
@@ -197,8 +197,7 @@ namespace GfxUnitTest
 	void PIClearAssertedInterrupts();
 
 	// -------------------------------------------------------------------------------------------
-	// Debug output capture (the doubles for Debug::Report / Debug::Halt live in
-	// dsp_test_support.cpp)
+	// Debug output capture (the doubles for Debug::Report / Debug::Halt live in dsp_test_support.cpp)
 	// -------------------------------------------------------------------------------------------
 
 	/// <summary>Start collecting Debug::Report messages (they are dropped by default).</summary>

--- a/testing/gfx_xf_test.cpp
+++ b/testing/gfx_xf_test.cpp
@@ -59,6 +59,47 @@ namespace pureikyubutest
 		// The register file and the CP interface
 		// =========================================================================================
 
+		// The hardware reset values of the matrix RAM and the colour registers are undefined, so the
+		// emulator starts from the state the GX SDK's GXInit establishes. A title may rely on it:
+		// Metroid Prime and Zelda select the SDK's identity texture matrix (GX_IDENTITY = 60) by
+		// index without ever loading it - a zero matrix collapses every texture coordinate to (0, 0)
+		// and the title draws one texel stretched over the screen (issue #349) - and they leave the
+		// material and the channel controls alone, which the pixel engine's alpha blend needs to be
+		// opaque.
+		TEST_METHOD(Xf_ResetInstallsTheGxInitState)
+		{
+			GfxTestMachine& m = M();
+
+			const GFX::XFState& xf = m.gfx->xf->xf;
+
+			// The identity geometry matrix (GX_PNMTX0) and the identity normal matrix.
+			Assert::AreEqual(1.0f, xf.mvTexMtx[0], L"geometry matrix [0][0]");
+			Assert::AreEqual(1.0f, xf.mvTexMtx[5], L"geometry matrix [1][1]");
+			Assert::AreEqual(1.0f, xf.mvTexMtx[10], L"geometry matrix [2][2]");
+			Assert::AreEqual(0.0f, xf.mvTexMtx[1], L"geometry matrix off-diagonal");
+			Assert::AreEqual(1.0f, xf.nrmMtx[0], L"normal matrix [0][0]");
+			Assert::AreEqual(1.0f, xf.nrmMtx[4], L"normal matrix [1][1]");
+			Assert::AreEqual(1.0f, xf.nrmMtx[8], L"normal matrix [2][2]");
+
+			// The identity texture matrix the SDK reserves at GX_IDENTITY (60) and the dual-texture
+			// one at GX_DTTIDENTITY (61), both 3x4 rows of four words.
+			for (int i = 0; i < 12; i++)
+			{
+				float expected = ((i % 5) == 0) ? 1.0f : 0.0f;		// [0][0], [1][1], [2][2]
+				Assert::AreEqual(expected, xf.mvTexMtx[60 * 4 + i], L"GX_IDENTITY texture matrix");
+				Assert::AreEqual(expected, xf.dualTexMtx[61 * 4 + i], L"GX_DTTIDENTITY dual texture matrix");
+			}
+
+			// GXSetChanAmbColor(BLACK) / GXSetChanMatColor(WHITE) and the channel controls that take
+			// the colour from the vertex.
+			Assert::AreEqual<unsigned>(0x00000000, xf.ambient[0].RGBA, L"ambient 0");
+			Assert::AreEqual<unsigned>(0xFFFFFFFF, xf.material[0].RGBA, L"material 0");
+			Assert::AreEqual<unsigned>(0xFFFFFFFF, xf.material[1].RGBA, L"material 1");
+			Assert::AreEqual<unsigned>(0x401, xf.colorControl[0].bits, L"colour 0 control");
+			Assert::AreEqual<unsigned>(0x401, xf.alphaControl[0].bits, L"alpha 0 control");
+			Assert::AreEqual<unsigned>(0x401, xf.alphaControl[1].bits, L"alpha 1 control");
+		}
+
 		TEST_METHOD(Xf_MatrixRamIsWrittenInBlocksAndReadBack)
 		{
 			GfxTestMachine& m = M();


### PR DESCRIPTION
Closes #349.

Metroid Prime showed a black screen where the intro FMV should be, and after the movie the game stopped progressing altogether. Three independent defects were behind it; all three are fixed on this branch.

## 1. The frame of the movie was never presented — `a5dc8559`

The frame presentation model assumed a frame is finished by `GXDrawDone`/`PE_FINISH`. A THP movie player does not do that: it renders the decoded YUV frame into the EFB and then presents it with a **full-frame display copy** (`PE_COPY_CMD`, opcode bit 14 set), and never calls `GXDrawDone` at all.

* A **full-frame display copy** now presents the frame.
* **Partial** display copies do **not** present it, and neither do texture copies. This distinction matters: the bootrom issues several partial display copies per frame and finishes the frame with `PE_FINISH`, so presenting on every display copy made the bootrom flicker (black every third frame) and Ikaruga smear.
* PE_FINISH / PE_TOKEN re-present only when the frame was actually drawn since the last present (new `frame_dirty` flag); otherwise a PE_FINISH that follows a display copy would push a cleared EFB again — that was the Ikaruga flicker after the first version of this fix.

## 2. Register state that `GXInit` leaves behind was missing — `3313b835`

The emulator boots through an HLE bootrom/apploader, so nothing ever runs the real `GXInit`. As a result the state a real console gets from the IPL was absent, and Metroid Prime's texture coordinates collapsed to `(0,0)` — the movie was decoded, drawn, and presented as an all-black quad.

The reference values were taken from a real bootrom (`--ipl` trace of the IPL's `XF load, start index: 00F0, n : 12`), not from another emulator:

* identity geometry and normal matrices,
* identity in texture-matrix slots **60** (`GX_IDENTITY`) and **61** (`GX_DTTIDENTITY`),
* ambient = 0, material = `0xFFFFFFFF`,
* colour/alpha control `0x401` (matsrc = VTX, lf_one, attnsel).

This is installed by `TransformUnit::SetGxInitDefaults()` from both the constructor and `Reset()`.

The same commit fixes the copy-engine clear: the clear values are now **captured at the copy command** and applied when the frame starts. Reading them live at frame start was wrong because Metroid Prime reprograms `PE_COPY_CLEAR_Z` to 0 afterwards, which left the depth buffer at `Z=0` and made the scene black even with correct texture coordinates. The clear covers the whole render target (the backend only shows the whole EFB), which also removes the bottom-edge smearing the bounded clear caused in the bootrom.

## 3. ARAM DMA dropped a request and hung the game — `b48c7922`

After the movie, Metroid Prime stopped progressing while the audio stream kept running.

The ARAM DMA was sliced into 32-byte steps by a worker thread. When the AR driver started the next block before that thread had finished the previous one, the guard

```cpp
Halt("...the ARAM DMA Thread needs to be started while it is still running.");
```

fired and **the request was silently dropped**. The driver then waited forever for the completion interrupt of the block it had just thrown away. The same guard also hit every transfer larger than 32 bytes, because the thread was suspend-driven and stayed "running" between slices.

The engine now performs the whole block inside the low-word write of `AMBL` and raises `ARINT` once, like the other transfer engines (SI, EXI, DVD). A new request can no longer collide with a transfer in progress, and no request can be dropped. The 32-byte special case and the separate "beyond ARAM" branch disappear with it.

## Tests

`340` tests before, **`343`** now — all green.

* `Pe_OnlyAFullFrameDisplayCopyPresentsTheFrame` — full-frame copies present, partial ones do not.
* `Pe_CopyClearKeepsTheCopiedFrameAndClearsTheNextOne` — the clear uses the values that were programmed at the copy, not the later ones.
* `Xf_ResetInstallsTheGxInitState` — the `GXInit` defaults, including texture slots 60/61.
* `AramDma_MovesTheWholeBlockAndRaisesTheCompletionInterrupt`, `AramDma_SecondRequestWhileBusyIsNotDropped`, `AramDma_CopiesBackToMainMemory` — the whole block moves in each direction over the real PI register traps, and a second request issued while the engine is busy is neither dropped nor fatal.

The ARAM test initialisation now goes through `AROpen()` instead of poking the controller by hand, which is what made the tests exercise the register path at all (`AROpen` accepts a null Flipper, since the unit tests have no Flipper instance).

## Verification

* Metroid Prime (USA v1.02, `GM8E01`): the intro FMV renders; frames captured from the running emulator show the "Retro Studios Inc." and "Nintendo and Retro Studios" titles.
* No regressions in the bootrom presentation (no black frames, no smearing) or in Ikaruga's title FMV.
* Full unit-test suite: 343/343.

## Known, out of scope

The audio of this title is distorted (a noise-like AI-DMA stream, audible as a buzz/roar) **before** the mixer, i.e. in the sample-generation path, not in the SDL output. That is a separate defect and is not touched by this PR.