### PR TITLE
Config: separate the Windows and SDL settings (issue #352)

### DIFF
--- a/build/Data/.gitignore
+++ b/build/Data/.gitignore
@@ -3,4 +3,5 @@
 *.cmd
 *.txt
 *.patch
-Settings.json
+SettingsWin.json
+SettingsSdl.json

--- a/build/Data/DefaultSettingsSdl.json
+++ b/build/Data/DefaultSettingsSdl.json
@@ -1,27 +1,15 @@
 {
 	"info":
 	{
-		"description": "Default configuration. Loaded before Settings.json"
+		"description": "Default configuration for the SDL build. Loaded before SettingsSdl.json"
 	},
 
 	"ui":
 	{
 		"DOLDEBUG": false,
 		"FILTER": 4294967295,
-		"LASTDIR_ALL": "./",
-		"LASTDIR_DVD": "./",
-		"LASTDIR_MAP": "./Data",
-		"LASTDIR_PATCH": "./Data",
 		"LASTFILE": "",
-		"ONTOP": false,
 		"PATH": "./",
-		"RECENT0": "",
-		"RECENT1": "",
-		"RECENT2": "",
-		"RECENT3": "",
-		"RECENT4": "",
-		"RECENTNUM": 0,
-		"RUNONCE": true,
 		"SELECTOR": true,
 		"SMALLICONS": true,
 		"SORTVIEW": 1
@@ -49,7 +37,7 @@
 		"CP_LOG": false,
 		"BOOTROM": "Data/gc-ntsc-11.bin",
 		"DSP_DROM": "Data/dsp_drom.bin",
-		"DSP_IROM": "Data/dsp_irom.bin",
+		"DSP_IROM": "Data/dsp_irom.bin"
 	},
 
 	"hle":

--- a/build/Data/DefaultSettingsWin.json
+++ b/build/Data/DefaultSettingsWin.json
@@ -1,0 +1,75 @@
+{
+	"info":
+	{
+		"description": "Default configuration for the Windows build. Loaded before SettingsWin.json"
+	},
+
+	"ui":
+	{
+		"DOLDEBUG": false,
+		"FILTER": 4294967295,
+		"LASTDIR_ALL": "./",
+		"LASTDIR_DVD": "./",
+		"LASTDIR_MAP": "./Data",
+		"LASTDIR_PATCH": "./Data",
+		"LASTFILE": "",
+		"ONTOP": false,
+		"PATH": "./",
+		"RECENT0": "",
+		"RECENT1": "",
+		"RECENT2": "",
+		"RECENT3": "",
+		"RECENT4": "",
+		"RECENTNUM": 0,
+		"RUNONCE": true,
+		"SELECTOR": true,
+		"SMALLICONS": true,
+		"SORTVIEW": 1
+	},
+
+	"loader":
+	{
+		"MAKEMAP": true
+	},
+
+	"hardware":
+	{
+		"ANSI": "Data/AnsiFont.szp",
+		"SJIS": "Data/SjisFont.szp",
+		"CONSOLE": 3,
+		"EXI_LOG": true,
+		"OS_REPORT": true,
+		"VI_LOG": false,
+		"VI_XFB": true,
+		"PI_LOG": false,
+		"DI_LOG": false,
+		"SI_LOG": false,
+		"AI_LOG": false,
+		"MI_LOG": false,
+		"CP_LOG": false,
+		"BOOTROM": "Data/gc-ntsc-11.bin",
+		"DSP_DROM": "Data/dsp_drom.bin",
+		"DSP_IROM": "Data/dsp_irom.bin"
+	},
+
+	"hle":
+	{
+		"HLEMTX": false
+	},
+
+	"controllers":
+	{
+		"PluggedIn_0": false,
+		"PluggedIn_1": false,
+		"PluggedIn_2": false,
+		"PluggedIn_3": false
+	},
+
+	"memcards":
+	{
+		"Memcard_SyncSave": false,
+		"MemcardA_Connected": false,
+		"MemcardB_Connected": false
+	}
+	
+}

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -8,8 +8,9 @@ Previously stored in the registry, in separate keys.
 
 ## As it is now.
 
-Settings are stored in Json. The default settings are stored in DefaultSettings.json and overrided by the current settings from Settings.json.
-New settings are saved only in Settings.json.
+Settings are stored in Json. The default settings are stored in DefaultSettingsWin.json / DefaultSettingsSdl.json
+(depending on the build) and overrided by the current settings from SettingsWin.json / SettingsSdl.json.
+New settings are saved only in the current settings file.
 
 */
 

--- a/src/config.h
+++ b/src/config.h
@@ -2,8 +2,20 @@
 
 #pragma once
 
-constexpr auto EMU_DEFAULT_SETTINGS = L"./Data/DefaultSettings.json";		// Must exist
-constexpr auto EMU_SETTINGS = L"./Data/Settings.json";
+// The Windows and SDL builds keep their settings apart, so that both can be run from the
+// same directory without overwriting each other's configuration.
+
+// The SDL build is the one that renders into an SDL window: either the Linux port (_LINUX,
+// see CMakeLists.txt) or the "SDL" Visual Studio configurations (GFX_USE_SDL_WINDOW, see gfx.h,
+// which is included before this header).
+
+#if defined(_LINUX) || GFX_USE_SDL_WINDOW
+constexpr auto EMU_DEFAULT_SETTINGS = L"./Data/DefaultSettingsSdl.json";	// Must exist
+constexpr auto EMU_SETTINGS = L"./Data/SettingsSdl.json";
+#else
+constexpr auto EMU_DEFAULT_SETTINGS = L"./Data/DefaultSettingsWin.json";	// Must exist
+constexpr auto EMU_SETTINGS = L"./Data/SettingsWin.json";
+#endif
 
 // Sections
 #define USER_UI "ui"

--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -8,7 +8,7 @@ Will be gradually superseded by DirectInput/SDL implementation.
 
 The code relies on polling the state of the keyboard using the Win32 GetAsyncKeyState method.
 
-The binding of VK codes to the buttons of the GameCube controller is in the configuration (Settings.json).
+The binding of VK codes to the buttons of the GameCube controller is in the configuration (SettingsWin.json).
 
 The configuration (dialog box for the user) is handled by the code in the UI.
 

--- a/src/ui.h
+++ b/src/ui.h
@@ -4,7 +4,7 @@
 
 At the heart of the interface is the "Selector" - a custom ListView with a list of executable files (DOL/ELF) and disk images (GCM).
 
-The emulator settings dialog is used only for modifying Settings.json.
+The emulator settings dialog is used only for modifying the settings Json (SettingsWin.json).
 
 ## Controller Settings Dialog (PAD)
 


### PR DESCRIPTION
The Windows and the SDL builds are run from the same directory (build), so they shared DefaultSettings.json / Settings.json and overwrote each other's configuration. Each port now has its own pair, selected at compile time the same way the rest of the code tells the ports apart:

* DefaultSettingsWin.json / SettingsWin.json for the Windows build;
* DefaultSettingsSdl.json / SettingsSdl.json for the SDL build (the Linux CMake port, _LINUX, or the "SDL" Visual Studio configurations, GFX_USE_SDL_WINDOW).

The SDL defaults contain only the settings the SDL port uses (it has no Win32 virtual key bindings and no Win32 file dialogs), and build/Data/.gitignore ignores the two new runtime files.

Verified: "Release|x64" and "Release SDL|x64" both build, and each executable embeds its own settings file names (checked in the linked binaries).