### PR TITLE
Gekko: inline the interpreter hot path and add an x86-64 recompiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ add_executable (pureikyubu
 	src/flipperdebug.cpp
 	src/gekko.cpp
 	src/gekkoc.cpp
+	src/gekkojit.cpp
 	src/gekkodebug.cpp
 	src/gekkodec.cpp
 	src/gekkodisasm.cpp

--- a/scripts/VS2022/pureikyubu.vcxproj
+++ b/scripts/VS2022/pureikyubu.vcxproj
@@ -77,6 +77,7 @@
     <ClInclude Include="..\..\src\flipperdebug.h" />
     <ClInclude Include="..\..\src\gekko.h" />
     <ClInclude Include="..\..\src\gekkoc.h" />
+    <ClInclude Include="..\..\src\gekkojit.h" />
     <ClInclude Include="..\..\src\gekkodebug.h" />
     <ClInclude Include="..\..\src\gekkodec.h" />
     <ClInclude Include="..\..\src\gekkodisasm.h" />
@@ -179,6 +180,7 @@
     <ClCompile Include="..\..\src\flipperdebug.cpp" />
     <ClCompile Include="..\..\src\gekko.cpp" />
     <ClCompile Include="..\..\src\gekkoc.cpp" />
+    <ClCompile Include="..\..\src\gekkojit.cpp" />
     <ClCompile Include="..\..\src\gekkodebug.cpp" />
     <ClCompile Include="..\..\src\gekkodec.cpp" />
     <ClCompile Include="..\..\src\gekkodisasm.cpp" />

--- a/scripts/VS2022/pureikyubu.vcxproj.filters
+++ b/scripts/VS2022/pureikyubu.vcxproj.filters
@@ -118,6 +118,9 @@
     <ClInclude Include="..\..\src\gekkoc.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\gekkojit.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\gekkodebug.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -283,6 +286,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\gekkoc.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\gekkojit.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\gekkodebug.cpp">

--- a/scripts/VS2026/pureikyubu.vcxproj
+++ b/scripts/VS2026/pureikyubu.vcxproj
@@ -78,6 +78,7 @@
     <ClInclude Include="..\..\src\gekko.h" />
     <ClInclude Include="..\..\src\gqr.h" />
     <ClInclude Include="..\..\src\gekkoc.h" />
+    <ClInclude Include="..\..\src\gekkojit.h" />
     <ClInclude Include="..\..\src\gekkodebug.h" />
     <ClInclude Include="..\..\src\gekkodec.h" />
     <ClInclude Include="..\..\src\gekkodisasm.h" />
@@ -180,6 +181,7 @@
     <ClCompile Include="..\..\src\flipperdebug.cpp" />
     <ClCompile Include="..\..\src\gekko.cpp" />
     <ClCompile Include="..\..\src\gekkoc.cpp" />
+    <ClCompile Include="..\..\src\gekkojit.cpp" />
     <ClCompile Include="..\..\src\gekkodebug.cpp" />
     <ClCompile Include="..\..\src\gekkodec.cpp" />
     <ClCompile Include="..\..\src\gekkodisasm.cpp" />

--- a/scripts/VS2026/pureikyubu.vcxproj.filters
+++ b/scripts/VS2026/pureikyubu.vcxproj.filters
@@ -118,6 +118,9 @@
     <ClInclude Include="..\..\src\gekkoc.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\gekkojit.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\src\gekkodebug.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -283,6 +286,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\gekkoc.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\gekkojit.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\gekkodebug.cpp">

--- a/src/gekko.cpp
+++ b/src/gekko.cpp
@@ -23,6 +23,14 @@ namespace Gekko
 			}
 		}
 
+		// Breakpoints and single stepping stay on the interpreter, so that the
+		// debugger sees every instruction.
+		if (core->JitEnabled && core->jit != nullptr && core->jit->IsSupported() && !core->EnableTestBreakpoints)
+		{
+			core->jit->Run();
+			return;
+		}
+
 		core->interp->ExecuteOpcode();
 	}
 
@@ -39,6 +47,8 @@ namespace Gekko
 
 		interp = new Interpreter(this);
 
+		jit = new Jit(this);
+
 		gekkoThread = EMUCreateThread(GekkoThreadProc, false, this, "GekkoCore");
 
 		Reset();
@@ -48,6 +58,7 @@ namespace Gekko
 	{
 		StopOpcodeStatsThread();
 		EMUJoinThread(gekkoThread);
+		delete jit;
 		delete interp;
 		delete gatherBuffer;
 	}
@@ -100,6 +111,11 @@ namespace Gekko
 
 		gatherBuffer->Reset();
 
+		if (jit != nullptr)
+		{
+			jit->InvalidateAll();
+		}
+
 		dtlb.InvalidateAll();
 		itlb.InvalidateAll();
 		cache->Reset();
@@ -109,31 +125,7 @@ namespace Gekko
 	}
 
 	// Modify CPU counters
-	void GekkoCore::Tick()
-	{
-		regs.tb.uval += CounterStep;         // timer
-
-		uint32_t old = regs.spr[SPR::DEC];
-		regs.spr[SPR::DEC] -= DecrementerStep;          // decrementer
-
-		if (regs.spr[SPR::DEC] & 0x8000'0000)
-		{
-			// Underflow. The request is latched, so that it is not lost while MSR[EE] is cleared,
-			// but it is generated only once per underflow: the decrementer has to be reloaded with
-			// a positive value before the next exception can be requested.
-
-			if (!(old & 0x8000'0000))
-			{
-				decreq = 1;
-			}
-		}
-		else
-		{
-			// A positive decrementer clears a pending underflow request.
-
-			decreq = 0;
-		}
-	}
+	// (GekkoCore::Tick is defined inline in gekko.h - it is on the hot path.)
 
 	int64_t GekkoCore::GetTicks()
 	{
@@ -295,6 +287,7 @@ namespace Gekko
 		}
 
 		// disable address translation
+		if (jit != nullptr) jit->InvalidateAll();
 		regs.msr &= ~(MSR_IR | MSR_DR);
 
 		regs.msr &= ~MSR_RI;
@@ -304,11 +297,6 @@ namespace Gekko
 		// change PC and set exception flag
 		regs.pc = (uint32_t)code;
 		exception = true;
-	}
-
-	uint32_t GekkoCore::EffectiveToPhysical(uint32_t ea, MmuAccess type, int& WIMG)
-	{
-		return EffectiveToPhysicalMmu(ea, type, WIMG);
 	}
 }
 
@@ -621,54 +609,19 @@ namespace Gekko
 
 namespace Gekko
 {
-	bool TLB::Exists(uint32_t ea, uint32_t& pa, int& WIMG)
-	{
-		auto it = tlb.find(ea >> 12);
-		if (it != tlb.end())
-		{
-			TLBEntry* entry = it->second;
-			pa = (entry->addressTag << 12) | (ea & 0xfff);
-			WIMG = entry->wimg;
-			return true;
-		}
-		return false;
-	}
-
-	void TLB::Map(uint32_t ea, uint32_t pa, uint32_t pc, int WIMG)
-	{
-		TLBEntry* entry = new TLBEntry;
-		entry->addressTag = pa >> 12;
-		entry->wimg = WIMG;
-		entry->pc = pc;
-		tlb[ea >> 12] = entry;
-	}
-
-	void TLB::Invalidate(uint32_t ea)
-	{
-		auto it = tlb.find(ea >> 12);
-		if (it != tlb.end())
-		{
-			delete it->second;
-			tlb.erase(it);
-		}
-	}
-
-	void TLB::InvalidateAll()
-	{
-		for (auto it = tlb.begin(); it != tlb.end(); ++it)
-		{
-			delete it->second;
-		}
-		tlb.clear();
-	}
-
 	void TLB::Dump()
 	{
-		for (auto it = tlb.begin(); it != tlb.end(); ++it)
+		for (size_t n = 0; n < Size; n++)
 		{
-			uint32_t ea = it->first << 12;
-			TLBEntry* entry = it->second;
-			Report(Channel::CPU, "EA 0x%08X -> PA 0x%08X (wimg: %d, pc: 0x%08X)\n", ea, entry->addressTag << 12, entry->wimg, entry->pc);
+			TLBEntry* entry = &entries[n];
+
+			if (entry->eaTag == EmptyTag)
+			{
+				continue;
+			}
+
+			uint32_t ea = entry->eaTag << 12;
+			Report(Channel::CPU, "EA 0x%08X -> PA 0x%08X (wimg: %d, pc: 0x%08X)\n", ea, entry->addressTag << 12, entry->WIMG, entry->pc);
 		}
 	}
 }
@@ -1009,6 +962,15 @@ namespace Gekko
 
 	void Cache::FlashInvalidate()
 	{
+		// A flash invalidate also drops every compiled block: it is used both for the
+		// data cache (the 0x81300000 hack in ExecuteOpcode, which exists precisely
+		// because IPL2 is DMA'ed into memory behind the CPU's back) and for the
+		// instruction cache (HID0[ICFI]).
+		if (core->jit != nullptr)
+		{
+			core->jit->InvalidateAll();
+		}
+
 		size_t blocks_num = cacheSize >> 5;
 		for (size_t n = 0; n < blocks_num; n++) {
 			modifiedBlocks[n] = false;
@@ -1665,16 +1627,7 @@ namespace Gekko
 
 		WIMG = 0;
 
-		// Try TLB
-
-#if GEKKOCORE_USE_TLB
-		TLB* tlb = (type == MmuAccess::Execute) ? &itlb : &dtlb;
-
-		if (tlb->Exists(ea, pa, WIMG))
-		{
-			return pa;
-		}
-#endif
+		// The translation cache has already been probed by EffectiveToPhysical().
 
 		// First, try the block translation, if it doesn’t work, try the Page Table.
 

--- a/src/gekko.h
+++ b/src/gekko.h
@@ -364,34 +364,104 @@ namespace GekkoCoreUnitTest
 #define __FASTCALL __fastcall
 #endif
 
+// The hot helpers below (address translation, the tick, the compare) are marked with
+// this so that they really end up inside their callers. Plain `inline` is only a hint:
+// both MSVC and GCC keep an out-of-line copy around and then call it, which on this
+// interpreter costs more than the body of the function itself.
+
+#if defined(_MSC_VER)
+#define GEKKO_INLINE __forceinline
+#else
+#define GEKKO_INLINE inline __attribute__((always_inline))
+#endif
+
 
 namespace Gekko
 {
 	class GekkoCore;
+	class Jit;
 }
 
 
 // This module is used to simulate Gekko TLB.
 
+// The translation cache sits on the hot path of every instruction fetch and every
+// memory access, so it is a direct-mapped array of 4 KB page translations rather
+// than a hash map. A miss simply falls through to the BAT/page-table walk, which
+// refills the entry - evicting a conflicting page is never a correctness problem.
+
 namespace Gekko
 {
 	struct TLBEntry
 	{
-		uint32_t addressTag;
-		int8_t wimg;
+		uint32_t eaTag;		// Effective page number (ea >> 12), or the empty marker
+		uint32_t addressTag;	// Physical page number (pa >> 12)
+		int WIMG;
 		uint32_t pc;		// PC value when the record was added to the TLB so that it can be tracked
 	};
 
 	class TLB
 	{
-		std::unordered_map<int, TLBEntry*> tlb;
+	public:
+		// The number of entries is a trade-off between the coverage (an aliasing
+		// translation is only a refill, never a correctness problem) and the size of
+		// the array, which is probed on every fetch and every memory access.
+#ifndef GEKKOCORE_TLB_SIZE
+#define GEKKOCORE_TLB_SIZE 2048
+#endif
+		static constexpr size_t Size = GEKKOCORE_TLB_SIZE;
+		static constexpr size_t IndexMask = Size - 1;
+		static constexpr uint32_t EmptyTag = 0xffff'ffff;
+
+	private:
+		TLBEntry entries[Size];
 
 	public:
-		bool Exists(uint32_t ea, uint32_t& pa, int& WIMG);
-		void Map(uint32_t ea, uint32_t pa, uint32_t pc, int WIMG);
+		TLB() { InvalidateAll(); }
 
-		void Invalidate(uint32_t ea);
-		void InvalidateAll();
+		GEKKO_INLINE bool Exists(uint32_t ea, uint32_t& pa, int& WIMG)
+		{
+			uint32_t page = ea >> 12;
+			const TLBEntry& entry = entries[page & IndexMask];
+
+			if (entry.eaTag != page)
+			{
+				return false;
+			}
+
+			pa = (entry.addressTag << 12) | (ea & 0xfff);
+			WIMG = entry.WIMG;
+			return true;
+		}
+
+		GEKKO_INLINE void Map(uint32_t ea, uint32_t pa, uint32_t pc, int WIMG)
+		{
+			TLBEntry& entry = entries[(ea >> 12) & IndexMask];
+
+			entry.eaTag = ea >> 12;
+			entry.addressTag = pa >> 12;
+			entry.WIMG = WIMG;
+			entry.pc = pc;
+		}
+
+		void Invalidate(uint32_t ea)
+		{
+			uint32_t page = ea >> 12;
+			TLBEntry& entry = entries[page & IndexMask];
+
+			if (entry.eaTag == page)
+			{
+				entry.eaTag = EmptyTag;
+			}
+		}
+
+		void InvalidateAll()
+		{
+			for (size_t n = 0; n < Size; n++)
+			{
+				entries[n].eaTag = EmptyTag;
+			}
+		}
 
 		void Dump();
 	};
@@ -581,6 +651,7 @@ namespace Gekko
 	{
 		friend Interpreter;
 		friend GatherBuffer;
+		friend Jit;
 		friend GekkoCoreUnitTest::GekkoCoreUnitTest;
 
 		// How many ticks Gekko takes to execute one instruction. 
@@ -671,6 +742,12 @@ namespace Gekko
 
 		GekkoRegs regs;
 
+		// Basic block recompiler (see gekkojit.h). It is created by the constructor;
+		// when the host does not support it (or the user switched it off), execution
+		// stays on the interpreter.
+		Jit* jit = nullptr;
+		bool JitEnabled = true;
+
 		GekkoCore();
 		~GekkoCore();
 
@@ -680,7 +757,61 @@ namespace Gekko
 
 		void Reset();
 
-		void Tick();
+		// The tick is advanced at least once per instruction (and a second time by
+		// branches), so it is kept inline - a call here costs more than the work.
+		GEKKO_INLINE void Tick()
+		{
+			regs.tb.uval += CounterStep;         // timer
+
+			uint32_t old = regs.spr[SPR::DEC];
+			regs.spr[SPR::DEC] -= DecrementerStep;          // decrementer
+
+			if (regs.spr[SPR::DEC] & 0x8000'0000)
+			{
+				// Underflow. The request is latched, so that it is not lost while MSR[EE] is cleared,
+				// but it is generated only once per underflow: the decrementer has to be reloaded with
+				// a positive value before the next exception can be requested.
+
+				if (!(old & 0x8000'0000))
+				{
+					decreq = 1;
+				}
+			}
+			else
+			{
+				// A positive decrementer clears a pending underflow request.
+
+				decreq = 0;
+			}
+		}
+
+		// Apply n ticks at once. Identical to n calls of Tick(), which is what the
+		// recompiler uses for a whole basic block.
+		void TickN(uint32_t n)
+		{
+			if (n == 0)
+			{
+				return;
+			}
+
+			regs.tb.uval += (uint64_t)CounterStep * n;
+
+			uint32_t old = regs.spr[SPR::DEC];
+			regs.spr[SPR::DEC] -= DecrementerStep * n;
+
+			if (regs.spr[SPR::DEC] & 0x8000'0000)
+			{
+				if (!(old & 0x8000'0000))
+				{
+					decreq = 1;
+				}
+			}
+			else
+			{
+				decreq = 0;
+			}
+		}
+
 		int64_t GetTicks();
 		int64_t OneSecond();
 
@@ -704,8 +835,21 @@ namespace Gekko
 		void WriteDouble(uint32_t addr, uint64_t* data);
 		void Fetch(uint32_t addr, uint32_t* reg);
 
-		// Translate address by Mmu
-		uint32_t EffectiveToPhysical(uint32_t ea, MmuAccess type, int& WIMG);
+		// Translate address by Mmu.
+		// A translation cache hit is by far the common case, so the probe is inline here;
+		// the BAT / page table walk lives in EffectiveToPhysicalMmu (see gekko.cpp).
+		GEKKO_INLINE uint32_t EffectiveToPhysical(uint32_t ea, MmuAccess type, int& WIMG)
+		{
+			TLB* tlb = (type == MmuAccess::Execute) ? &itlb : &dtlb;
+
+			uint32_t pa;
+			if (tlb->Exists(ea, pa, WIMG))
+			{
+				return pa;
+			}
+
+			return EffectiveToPhysicalMmu(ea, type, WIMG);
+		}
 
 		static void SwapArea(uint32_t* addr, int count);
 		static void SwapAreaHalf(uint16_t* addr, int count);

--- a/src/gekkoc.cpp
+++ b/src/gekkoc.cpp
@@ -62,8 +62,12 @@ namespace Gekko
 	// calculation of conditional branch
 	bool Interpreter::BcTest()
 	{
+		return BcTest((uint32_t)info.paramBits[0], (uint32_t)info.paramBits[1]);
+	}
+
+	bool Interpreter::BcTest(uint32_t bo, uint32_t bi)
+	{
 		bool ctr_ok, cond_ok;
-		size_t bo = info.paramBits[0], bi = info.paramBits[1];
 
 		if (BO(2) == 0)
 		{
@@ -150,8 +154,12 @@ namespace Gekko
 	// calculation of conditional to count register branch
 	bool Interpreter::BctrTest()
 	{
+		return BctrTest((uint32_t)info.paramBits[0], (uint32_t)info.paramBits[1]);
+	}
+
+	bool Interpreter::BctrTest(uint32_t bo, uint32_t bi)
+	{
 		bool cond_ok;
-		size_t bo = info.paramBits[0], bi = info.paramBits[1];
 
 		if (BO(0) == 0)
 		{
@@ -3968,6 +3976,10 @@ namespace Gekko
 	// return from exception
 	void Interpreter::rfi()
 	{
+		// SRR1 can flip MSR[IR]/[DR], which changes what every effective address in
+		// the compiled blocks translates to.
+		if (core->jit != nullptr) core->jit->InvalidateAll();
+
 		core->regs.msr &= ~(0x87C0FF73 | 0x00040000);
 		core->regs.msr |= core->regs.spr[SPR::SRR1] & 0x87C0FF73;
 		core->regs.pc = core->regs.spr[SPR::SRR0] & ~3;
@@ -4133,6 +4145,7 @@ namespace Gekko
 
 		uint32_t oldMsr = core->regs.msr;
 		core->regs.msr = core->regs.gpr[info.paramBits[0]];
+		if (core->jit != nullptr) core->jit->InvalidateAll();
 
 		if ((oldMsr & MSR_IR) != (core->regs.msr & MSR_IR))
 		{
@@ -4151,6 +4164,14 @@ namespace Gekko
 	void Interpreter::mtspr()
 	{
 		size_t spr = info.paramBits[0];
+
+		// Any SPR that changes address translation or the caches invalidates the
+		// compiled blocks.
+		if (spr == SPR::SDR1 || spr == SPR::HID0 || spr == SPR::HID2 ||
+			(spr >= SPR::IBAT0U && spr <= SPR::DBAT3L))
+		{
+			if (core->jit != nullptr) core->jit->InvalidateAll();
+		}
 
 		// Diagnostic output when the BAT registers are changed.
 
@@ -4512,6 +4533,7 @@ namespace Gekko
 		if (pa != Gekko::BadAddress)
 		{
 			core->icache->Invalidate(pa);
+			if (core->jit != nullptr) core->jit->InvalidateAll();
 		}
 		else
 		{
@@ -4581,6 +4603,7 @@ namespace Gekko
 
 	void Interpreter::tlbie()
 	{
+		if (core->jit != nullptr) core->jit->InvalidateAll();
 		core->dtlb.Invalidate(core->regs.gpr[info.paramBits[0]]);
 		core->itlb.Invalidate(core->regs.gpr[info.paramBits[0]]);
 		core->regs.pc += 4;
@@ -4588,6 +4611,7 @@ namespace Gekko
 
 	void Interpreter::tlbsync()
 	{
+		if (core->jit != nullptr) core->jit->InvalidateAll();
 		core->regs.pc += 4;
 	}
 
@@ -4663,9 +4687,46 @@ namespace Gekko
 	}
 
 
+	// Decode one instruction (through the decode cache) and run it. The recompiler
+	// calls this for every instruction it does not translate itself, so those
+	// instructions see exactly the same decoder state as they would in the
+	// interpreter.
+	void Interpreter::ExecuteDecoded(uint32_t pc, uint32_t instr)
+	{
+		DecodeEntry* entry = &decodeCache[(pc >> 2) & DecodeCacheMask];
+
+		if (entry->pc == pc && entry->instrBits == instr)
+		{
+			info.instr = (Instruction)entry->instr;
+			info.Imm.Address = entry->imm;
+			info.paramBits[0] = entry->paramBits[0];
+			info.paramBits[1] = entry->paramBits[1];
+			info.paramBits[2] = entry->paramBits[2];
+			info.paramBits[3] = entry->paramBits[3];
+			info.paramBits[4] = entry->paramBits[4];
+		}
+		else
+		{
+			Decoder::DecodeFast(pc, instr, &info);
+
+			entry->pc = pc;
+			entry->instrBits = instr;
+			entry->instr = (uint32_t)info.instr;
+			entry->imm = info.Imm.Address;
+			entry->paramBits[0] = (uint32_t)info.paramBits[0];
+			entry->paramBits[1] = (uint32_t)info.paramBits[1];
+			entry->paramBits[2] = (uint32_t)info.paramBits[2];
+			entry->paramBits[3] = (uint32_t)info.paramBits[3];
+			entry->paramBits[4] = (uint32_t)info.paramBits[4];
+		}
+
+		Dispatch();
+	}
+
 	// parse and execute single opcode
 	void Interpreter::ExecuteOpcode()
 	{
+		uint32_t pc = core->regs.pc;
 		uint32_t instr = 0;
 
 		// Hack for the first time.
@@ -4673,13 +4734,13 @@ namespace Gekko
 		// So when entering BS2, you just need to invalidate the DCache.
 		// Need to figure out why this is happening / come up with a better place to do it
 
-		if (core->regs.pc == 0x81300000) {
+		if (pc == 0x81300000) {
 			Core->cache->FlashInvalidate();
 		}
 
 		// Fetch instruction
 
-		core->Fetch(core->regs.pc, &instr);
+		core->Fetch(pc, &instr);
 		// ISI
 		if (core->exception)
 		{
@@ -4687,10 +4748,7 @@ namespace Gekko
 			return;
 		}
 
-		// Decode instruction and dispatch
-
-		Decoder::DecodeFast(core->regs.pc, instr, &info);
-		Dispatch();
+		ExecuteDecoded(pc, instr);
 		core->ops++;
 
 		if (core->resetInstructionCounter)

--- a/src/gekkoc.h
+++ b/src/gekkoc.h
@@ -36,9 +36,12 @@
 
 namespace Gekko
 {
+	class Jit;
+
 	class Interpreter
 	{
 		friend GekkoCoreUnitTest::GekkoCoreUnitTest;
+		friend Jit;
 
 		GekkoCore* core = nullptr;
 
@@ -411,15 +414,46 @@ namespace Gekko
 		// The quantized load/store conversion scales are computed on demand by
 		// Gekko::GqrScaleFactor (src/gqr.h), which is covered by testing/gqr_test.cpp.
 
+		// Decoded instruction cache.
+
+		// Decoding is a large part of the interpreter's per-instruction cost and the code
+		// of a game is executed over and over, so the outcome of the decoder is remembered.
+		//
+		// There is deliberately no invalidation hook anywhere: the instruction word is
+		// always re-fetched (through the emulated instruction cache) before the entry is
+		// used, and an entry is accepted only when both the pc and that freshly fetched
+		// word match what was decoded. Any change of the code - by a store, by a DMA or
+		// by the debugger - therefore re-decodes by itself, and a missed invalidation is
+		// not possible. If the instruction cache still holds the old line (which is what
+		// the hardware would execute too), the old decode matches it and is used.
+
+		struct DecodeEntry
+		{
+			uint32_t pc;
+			uint32_t instrBits;
+			uint32_t instr;
+			uint32_t imm;
+			uint32_t paramBits[5];
+		};
+
+		// 8192 entries keep the hot loops of a game resident without aliasing; the entry
+		// is deliberately small so that the table stays cheap to touch.
+		static const size_t DecodeCacheSize = 8192;
+		static const size_t DecodeCacheMask = DecodeCacheSize - 1;
+
+		DecodeEntry decodeCache[DecodeCacheSize];
+
 		float dequantize(uint32_t data, GEKKO_QUANT_TYPE type, uint8_t scale);
 		uint32_t quantize(float data, GEKKO_QUANT_TYPE type, uint8_t scale);
 
 		void BranchCheck();
 		bool BcTest();
+		bool BcTest(uint32_t bo, uint32_t bi);
 		bool BctrTest();
+		bool BctrTest(uint32_t bo, uint32_t bi);
 
 		template <typename T>
-		inline void CmpCommon(size_t crfd, T a, T b);
+		GEKKO_INLINE void CmpCommon(size_t crfd, T a, T b);
 
 		void Dispatch();
 
@@ -447,6 +481,11 @@ namespace Gekko
 		~Interpreter() {}
 
 		void ExecuteOpcode();
+
+		// Decode (from the decode cache) and execute a single instruction. Shared with
+		// the recompiler so that an instruction it does not translate goes through
+		// exactly the same decode/dispatch path as the interpreter.
+		void ExecuteDecoded(uint32_t pc, uint32_t instr);
 
 		uint32_t GetRotMask(int mb, int me);
 	};

--- a/src/gekkodebug.cpp
+++ b/src/gekkodebug.cpp
@@ -233,6 +233,15 @@ namespace Debug
       ]
     },
 
+    "jit": {
+      "help": "Enables or disables the Gekko basic block recompiler (0: interpreter only, 1: recompiler). Reports the current state when called without an argument",
+      "args": 1,
+      "output": "Bool",
+      "usage": [
+        "Syntax: jit <0|1>"
+      ]
+    },
+
     "EnableOpcodeStats": {
       "help": "Enables or disables the maintenance of opcode usage statistics",
       "args": 1,
@@ -1053,6 +1062,26 @@ namespace Debug
 	}
 
 	// Enables or disables the maintenance of opcode usage statistics
+	// Enable or disable the Gekko basic block recompiler. With no argument the current
+	// state is reported; the recompiler is also dropped (all blocks recompiled) when
+	// it is switched back on.
+	static Json::Value* CmdJit(std::vector<std::string>& args)
+	{
+		if (args.size() > 1)
+		{
+			Core->JitEnabled = strtoul(args[1].c_str(), nullptr, 0) != 0;
+			if (Core->JitEnabled && Core->jit != nullptr)
+			{
+				Core->jit->InvalidateAll();
+			}
+		}
+
+		Json::Value* output = new Json::Value();
+		output->type = Json::ValueType::Bool;
+		output->value.AsBool = Core->JitEnabled;
+		return output;
+	}
+
 	static Json::Value* CmdEnableOpcodeStats(std::vector<std::string>& args)
 	{
 		bool enable = strtoul(args[1].c_str(), nullptr, 0) != 0 ? true : false;
@@ -1225,6 +1254,7 @@ namespace Debug
 		JDI::Hub.AddCmd("bw", CmdBreakWrite);
 		JDI::Hub.AddCmd("bc", CmdBreakClearAll);
 		JDI::Hub.AddCmd("CacheLog", CmdCacheLog);
+		JDI::Hub.AddCmd("jit", CmdJit);
 
 		JDI::Hub.AddCmd("IsRunning", CmdIsRunning);
 		JDI::Hub.AddCmd("GekkoRun", CmdGekkoRun);

--- a/src/gekkodec.h
+++ b/src/gekkodec.h
@@ -435,7 +435,10 @@ namespace Gekko
 
 		size_t numParam;
 		Param param[5];
-		size_t paramBits[5];
+		// Every decoded parameter is an instruction field (a register number, a CR field,
+		// an SPR number, ...), so 16 bits is enough and keeps DecoderInfo small - it is
+		// written and read once per emulated instruction.
+		uint16_t paramBits[5];
 
 		// The value for Immediate parameters is stored here instead of paramBits. I don't know why I did this, it would probably be good to store it in paramBits, but I don't want to redo it anymore.
 

--- a/src/gekkojit.cpp
+++ b/src/gekkojit.cpp
@@ -1,0 +1,1725 @@
+/*
+
+Gekko -> x86-64 basic block recompiler. See gekkojit.h for the design notes.
+
+The emitter below only implements the exact operand forms that the translator
+needs, which keeps it small enough to be reviewable.
+
+Division of labour: the generated code translates instructions and keeps the pc
+in a register; everything that has to happen once per block - retiring the
+instruction counter, advancing the time base and the decrementer, the branch
+check - is done in C++ by Jit::Run when the block returns. That keeps the
+generated code (and this file) much smaller and keeps the timing model in one
+readable place.
+
+*/
+
+#include "pch.h"
+#include "gekkojit.h"
+
+#if GEKKO_JIT_SUPPORTED
+
+#if defined(_WINDOWS)
+#include <windows.h>
+#else
+#include <sys/mman.h>
+#endif
+
+namespace Gekko
+{
+
+// ---------------------------------------------------------------------------
+// x86-64 encoder
+
+namespace X64
+{
+	enum Reg : uint8_t
+	{
+		RAX = 0, RCX, RDX, RBX, RSP, RBP, RSI, RDI,
+		R8, R9, R10, R11, R12, R13, R14, R15,
+	};
+
+	enum Cc : uint8_t
+	{
+		CcO = 0, CcNO, CcB, CcAE, CcE, CcNE, CcBE, CcA,
+		CcS, CcNS, CcP, CcNP, CcL, CcGE, CcLE, CcG,
+	};
+
+	// Extension of the 0x81/0x83 group
+	enum Alu : uint8_t
+	{
+		AluAdd = 0, AluOr, AluAdc, AluSbb, AluAnd, AluSub, AluXor, AluCmp,
+	};
+
+	class Emitter
+	{
+	public:
+		uint8_t* buf = nullptr;
+		size_t cap = 0;
+		size_t pos = 0;
+		bool overflow = false;
+
+		Emitter(uint8_t* _buf, size_t _cap) : buf(_buf), cap(_cap) {}
+
+		void u8(uint8_t v)
+		{
+			if (pos < cap) buf[pos] = v; else overflow = true;
+			pos++;
+		}
+
+		void u32(uint32_t v)
+		{
+			u8((uint8_t)v); u8((uint8_t)(v >> 8)); u8((uint8_t)(v >> 16)); u8((uint8_t)(v >> 24));
+		}
+
+		void u64(uint64_t v)
+		{
+			u32((uint32_t)v); u32((uint32_t)(v >> 32));
+		}
+
+		void rex(bool w, uint8_t r, uint8_t x, uint8_t b)
+		{
+			uint8_t v = 0x40
+				| (w ? 0x08 : 0)
+				| (uint8_t)(((r >> 3) & 1) << 2)
+				| (uint8_t)(((x >> 3) & 1) << 1)
+				| (uint8_t)((b >> 3) & 1);
+			if (v != 0x40) u8(v);
+		}
+
+		// Replaces REX.B? No - forces a REX prefix when the 8 bit operand is one
+		// of spl/bpl/sil/dil, whose encoding without REX means ah/ch/dh/bh.
+		void rex8(uint8_t r, uint8_t x, uint8_t b)
+		{
+			uint8_t v = 0x40
+				| (uint8_t)(((r >> 3) & 1) << 2)
+				| (uint8_t)(((x >> 3) & 1) << 1)
+				| (uint8_t)((b >> 3) & 1);
+			u8(v);
+		}
+
+		// ModRM + SIB for [base + index*scale + disp32]. index == RSP means "no index".
+		void mem(uint8_t reg, uint8_t base, uint8_t index, uint8_t scale, int32_t disp)
+		{
+			u8(0x80 | (uint8_t)((reg & 7) << 3) | 4);		// mod=10, rm=100 -> SIB
+			u8((uint8_t)((scale << 6) | ((index & 7) << 3) | (base & 7)));
+			u32((uint32_t)disp);
+		}
+
+		void modrmReg(uint8_t reg, uint8_t rm)
+		{
+			u8(0xC0 | (uint8_t)((reg & 7) << 3) | (rm & 7));
+		}
+
+		// ---- moves ----------------------------------------------------------
+
+		void mov_r32_m(uint8_t dst, uint8_t base, int32_t disp, uint8_t index = RSP, uint8_t scale = 0)
+		{
+			rex(false, dst, index, base);
+			u8(0x8B);
+			mem(dst, base, index, scale, disp);
+		}
+
+		void mov_r64_m(uint8_t dst, uint8_t base, int32_t disp)
+		{
+			rex(true, dst, RSP, base);
+			u8(0x8B);
+			mem(dst, base, RSP, 0, disp);
+		}
+
+		void mov_m32_r(uint8_t base, int32_t disp, uint8_t src)
+		{
+			rex(false, src, RSP, base);
+			u8(0x89);
+			mem(src, base, RSP, 0, disp);
+		}
+
+		void mov_m64_r(uint8_t base, int32_t disp, uint8_t src)
+		{
+			rex(true, src, RSP, base);
+			u8(0x89);
+			mem(src, base, RSP, 0, disp);
+		}
+
+		void mov_r32_r32(uint8_t dst, uint8_t src)
+		{
+			rex(false, src, RSP, dst);
+			u8(0x89);
+			modrmReg(src, dst);
+		}
+
+		void mov_r64_r64(uint8_t dst, uint8_t src)
+		{
+			rex(true, src, RSP, dst);
+			u8(0x89);
+			modrmReg(src, dst);
+		}
+
+		void mov_r32_imm(uint8_t dst, uint32_t imm)
+		{
+			rex(false, 0, RSP, dst);
+			u8((uint8_t)(0xB8 + (dst & 7)));
+			u32(imm);
+		}
+
+		void mov_r64_imm(uint8_t dst, uint64_t imm)
+		{
+			rex(true, 0, RSP, dst);
+			u8((uint8_t)(0xB8 + (dst & 7)));
+			u64(imm);
+		}
+
+		void mov_m32_imm(uint8_t base, int32_t disp, uint32_t imm)
+		{
+			rex(false, 0, RSP, base);
+			u8(0xC7);
+			mem(0, base, RSP, 0, disp);
+			u32(imm);
+		}
+
+		void mov_m8_imm(uint8_t base, int32_t disp, uint8_t imm)
+		{
+			rex(false, 0, RSP, base);
+			u8(0xC6);
+			mem(0, base, RSP, 0, disp);
+			u8(imm);
+		}
+
+		void lea_r64_m(uint8_t dst, uint8_t base, int32_t disp, uint8_t index = RSP, uint8_t scale = 0)
+		{
+			rex(true, dst, index, base);
+			u8(0x8D);
+			mem(dst, base, index, scale, disp);
+		}
+
+		void movsx_r64_r32(uint8_t dst, uint8_t src)
+		{
+			rex(true, dst, RSP, src);
+			u8(0x63);
+			modrmReg(dst, src);
+		}
+
+		// ---- ALU ------------------------------------------------------------
+
+		void alu_r32_r32(uint8_t op, uint8_t dst, uint8_t src)
+		{
+			static const uint8_t opc[8] = { 0x03, 0x0B, 0x13, 0x1B, 0x23, 0x2B, 0x33, 0x3B };
+			rex(false, dst, RSP, src);
+			u8(opc[op]);
+			modrmReg(dst, src);
+		}
+
+		void alu_r32_m(uint8_t op, uint8_t dst, uint8_t base, int32_t disp)		// NOLINT
+		{
+			static const uint8_t opc[8] = { 0x03, 0x0B, 0x13, 0x1B, 0x23, 0x2B, 0x33, 0x3B };
+			rex(false, dst, RSP, base);
+			u8(opc[op]);
+			mem(dst, base, RSP, 0, disp);
+		}
+
+		void alu_r32_imm(uint8_t op, uint8_t dst, uint32_t imm)
+		{
+			rex(false, 0, RSP, dst);
+			u8(0x81);
+			modrmReg(op, dst);
+			u32(imm);
+		}
+
+		void add_r32_imm(uint8_t dst, uint32_t imm) { alu_r32_imm(AluAdd, dst, imm); }
+		void and_r32_imm(uint8_t dst, uint32_t imm) { alu_r32_imm(AluAnd, dst, imm); }
+		void or_r32_r32(uint8_t dst, uint8_t src) { alu_r32_r32(AluOr, dst, src); }
+		void and_r32_r32(uint8_t dst, uint8_t src) { alu_r32_r32(AluAnd, dst, src); }
+		void sub_r32_r32(uint8_t dst, uint8_t src) { alu_r32_r32(AluSub, dst, src); }
+		void xor_r32_r32_same(uint8_t r) { alu_r32_r32(AluXor, r, r); }
+
+		void test_r32_r32(uint8_t a, uint8_t b)
+		{
+			rex(false, b, RSP, a);
+			u8(0x85);
+			modrmReg(b, a);
+		}
+
+		void test_r32_imm(uint8_t r, uint32_t imm)
+		{
+			rex(false, 0, RSP, r);
+			u8(0xF7);
+			modrmReg(0, r);
+			u32(imm);
+		}
+
+		void test_m8_imm(uint8_t base, int32_t disp, uint8_t imm)
+		{
+			rex(false, 0, RSP, base);
+			u8(0xF6);
+			mem(0, base, RSP, 0, disp);
+			u8(imm);
+		}
+
+		void cmp_m8_imm(uint8_t base, int32_t disp, uint8_t imm)
+		{
+			rex(false, 0, RSP, base);
+			u8(0x80);
+			mem(7, base, RSP, 0, disp);
+			u8(imm);
+		}
+
+		void cmp_r32_r32(uint8_t a, uint8_t b) { alu_r32_r32(AluCmp, a, b); }
+
+		void imul_r32_r32(uint8_t dst, uint8_t src)
+		{
+			rex(false, dst, RSP, src);
+			u8(0x0F); u8(0xAF);
+			modrmReg(dst, src);
+		}
+
+		void neg_r32(uint8_t r)
+		{
+			rex(false, 0, RSP, r);
+			u8(0xF7);
+			modrmReg(3, r);
+		}
+
+		void not_r32(uint8_t r)
+		{
+			rex(false, 0, RSP, r);
+			u8(0xF7);
+			modrmReg(2, r);
+		}
+
+		void inc_r64(uint8_t r)
+		{
+			rex(true, 0, RSP, r);
+			u8(0xFF);
+			modrmReg(0, r);
+		}
+
+		void dec_r64(uint8_t r)
+		{
+			rex(true, 0, RSP, r);
+			u8(0xFF);
+			modrmReg(1, r);
+		}
+
+		void shl_r32_imm(uint8_t r, uint8_t n) { rex(false, 0, RSP, r); u8(0xC1); modrmReg(4, r); u8(n); }
+		void shr_r32_imm(uint8_t r, uint8_t n) { rex(false, 0, RSP, r); u8(0xC1); modrmReg(5, r); u8(n); }
+		void sar_r32_imm(uint8_t r, uint8_t n) { rex(false, 0, RSP, r); u8(0xC1); modrmReg(7, r); u8(n); }
+		void rol_r32_imm(uint8_t r, uint8_t n) { rex(false, 0, RSP, r); u8(0xC1); modrmReg(0, r); u8(n); }
+
+		void shl_r32_cl(uint8_t r) { rex(false, 0, RSP, r); u8(0xD3); modrmReg(4, r); }
+		void shr_r32_cl(uint8_t r) { rex(false, 0, RSP, r); u8(0xD3); modrmReg(5, r); }
+		void rol_r32_cl(uint8_t r) { rex(false, 0, RSP, r); u8(0xD3); modrmReg(0, r); }
+
+		// 8 bit destination, so the encoding has to be REX safe.
+		void setcc_r8(uint8_t cc, uint8_t r)
+		{
+			rex8(0, RSP, r);
+			u8(0x0F);
+			u8((uint8_t)(0x90 + cc));
+			modrmReg(0, r);
+		}
+
+		void movzx_r32_r8(uint8_t dst, uint8_t src)
+		{
+			rex8(dst, RSP, src);
+			u8(0x0F); u8(0xB6);
+			modrmReg(dst, src);
+		}
+
+		void movsx_r32_r8(uint8_t dst, uint8_t src)
+		{
+			rex8(dst, RSP, src);
+			u8(0x0F); u8(0xBE);
+			modrmReg(dst, src);
+		}
+
+		void bsr_r32_r32(uint8_t dst, uint8_t src)
+		{
+			rex(false, dst, RSP, src);
+			u8(0x0F); u8(0xBD);
+			modrmReg(dst, src);
+		}
+
+		void bswap_r32(uint8_t r)
+		{
+			rex(false, 0, RSP, r);
+			u8(0x0F);
+			u8((uint8_t)(0xC8 + (r & 7)));
+		}
+
+		// ---- stack / control ------------------------------------------------
+
+		void push_r64(uint8_t r)
+		{
+			if (r >= 8) u8(0x41);
+			u8((uint8_t)(0x50 + (r & 7)));
+		}
+
+		void pop_r64(uint8_t r)
+		{
+			if (r >= 8) u8(0x41);
+			u8((uint8_t)(0x58 + (r & 7)));
+		}
+
+		void sub_rsp_imm8(uint8_t n)
+		{
+			rex(true, 0, RSP, RSP);
+			u8(0x83);
+			modrmReg(5, RSP);
+			u8(n);
+		}
+
+		void add_rsp_imm8(uint8_t n)
+		{
+			rex(true, 0, RSP, RSP);
+			u8(0x83);
+			modrmReg(0, RSP);
+			u8(n);
+		}
+
+		void ret() { u8(0xC3); }
+
+		size_t jmp_rel32()
+		{
+			u8(0xE9);
+			size_t at = pos;
+			u32(0);
+			return at;
+		}
+
+		size_t jcc_rel32(uint8_t cc)
+		{
+			u8(0x0F);
+			u8((uint8_t)(0x80 + cc));
+			size_t at = pos;
+			u32(0);
+			return at;
+		}
+
+		// mov r11, addr ; call r11
+		// A Win64 callee is allowed to spill its four register arguments into the 32
+		// bytes above the return address (the caller's "shadow space"), so a block may
+		// not keep anything live there. SysV hosts have no such area, which makes the
+		// mistake invisible on Linux; in the ABI regression build this poisons exactly
+		// that area before every helper call, so the corruption is reproducible there
+		// too. R11 is free: call_abs loads it with the target right afterwards.
+		void poison_shadow_space()
+		{
+#ifdef GEKKO_JIT_TEST_WIN64_SHADOW
+			mov_r64_imm(R11, 0x1122334455667788ull);
+			mov_m64_r(RSP, 0, R11);
+			mov_m64_r(RSP, 8, R11);
+			mov_m64_r(RSP, 16, R11);
+			mov_m64_r(RSP, 24, R11);
+#endif
+		}
+
+		void call_abs(uint64_t addr)
+		{
+			poison_shadow_space();
+			mov_r64_imm(R11, addr);
+			u8(0x41); u8(0xFF);
+			modrmReg(2, R11);
+		}
+
+		void patch32(size_t at, uint32_t value)
+		{
+			if (at + 4 > cap) { overflow = true; return; }
+			buf[at + 0] = (uint8_t)value;
+			buf[at + 1] = (uint8_t)(value >> 8);
+			buf[at + 2] = (uint8_t)(value >> 16);
+			buf[at + 3] = (uint8_t)(value >> 24);
+		}
+
+		// Offset from the end of a rel32 field at 'at' to the current position.
+		uint32_t rel(size_t at) const { return (uint32_t)(pos - (at + 4)); }
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Calling convention and register roles
+
+#if defined(_WIN32)
+	static const uint8_t Arg0 = X64::RCX;
+	static const uint8_t Arg1 = X64::RDX;
+	static const uint8_t Arg2 = X64::R8;
+#else
+	static const uint8_t Arg0 = X64::RDI;
+	static const uint8_t Arg1 = X64::RSI;
+	static const uint8_t Arg2 = X64::RDX;
+#endif
+
+static const uint8_t RegCore = X64::R15;		// GekkoCore*, kept for the whole block
+static const uint8_t RegRegs = X64::R14;		// GekkoRegs*, kept for the whole block
+static const uint8_t RegPc = X64::R13;			// 32 bit pc, kept for the whole block
+static const uint8_t RegCount = X64::RBX;		// instructions retired in this block
+
+// Scratch GPRs for the translations (never live across a helper call).
+static const uint8_t T0 = X64::R8;
+static const uint8_t T1 = X64::R9;
+static const uint8_t T2 = X64::R10;
+static const uint8_t T3 = X64::RAX;
+// Scratch for the condition-register helpers. It must not be one of T0..T3: the
+// value a helper derives the flags from is frequently held in one of those.
+static const uint8_t TC = X64::R11;
+
+// Values that have to survive a helper call. They live in callee-saved registers
+// rather than on the stack on purpose: the Win64 ABI lets a callee spill its four
+// register arguments into the 32 bytes above rsp ("shadow space"), so anything the
+// block keeps in memory below that mark would be silently overwritten by the
+// helper. Keeping them in RBP/R12 also saves a store/load per memory instruction.
+static const uint8_t RegEa = X64::RBP;			// effective address across a helper call
+static const uint8_t RegExit = X64::R12;		// JitExit* for the whole block
+
+// Stack frame. The only requirement is the 32 byte Win64 shadow space at [rsp,rsp+32);
+// nothing of ours lives there, and the saved registers sit above it. Entry rsp is
+// 8 mod 16 (the calling C++ code is ABI compliant), the eight pushes keep that, so
+// the frame size must be 8 mod 16 to leave rsp 16 byte aligned at the helper calls.
+// Alignment is enforced by the static_assert rather than by the runtime ABI test:
+// the helpers are plain C++ functions that this build compiles without aligned SSE
+// stack spills, so a misaligned frame happens not to fail anything, while a wrong
+// shadow space layout does.
+static const int32_t ShadowSpace = 32;
+static const int32_t FrameSize = 40;
+static_assert(FrameSize >= ShadowSpace, "the frame must cover the Win64 shadow space");
+static_assert(FrameSize % 16 == 8, "rsp must be 16 byte aligned at the helper calls");
+
+static const int32_t GprOff = offsetof(GekkoRegs, gpr);
+static const int32_t SprOff = offsetof(GekkoRegs, spr);
+static const int32_t CrOff = offsetof(GekkoRegs, cr);
+static const int32_t PcOff = offsetof(GekkoRegs, pc);
+static const int32_t TbOff = offsetof(GekkoRegs, tb);
+static const int32_t DecOff = SprOff + (int32_t)SPR::DEC * 4;
+static const int32_t XerOff = SprOff + (int32_t)SPR::XER * 4;
+static const int32_t LrOff = SprOff + (int32_t)SPR::LR * 4;
+static const int32_t CtrOff = SprOff + (int32_t)SPR::CTR * 4;
+
+// How the block stopped.
+enum class JitExitKind : uint32_t
+{
+	Normal = 0,			// pc is in regs.pc, a plain fallthrough
+	TakenBranch = 1,	// pc is the branch target, BranchCheck still has to run
+	Exception = 2,		// a helper already set regs.pc to the exception vector
+};
+
+struct JitExit
+{
+	uint64_t count;
+	uint32_t kind;
+	uint32_t pad;
+};
+
+// ---------------------------------------------------------------------------
+// Thin trampolines for the memory helpers. A pointer-to-member-function is not a
+// code address, so the generated code calls these instead; at -O2 they are a tail
+// jump into the real helper.
+
+namespace
+{
+	void JitReadByte(GekkoCore* core, uint32_t addr, uint32_t* reg) { core->ReadByte(addr, reg); }
+	void JitReadWord(GekkoCore* core, uint32_t addr, uint32_t* reg) { core->ReadWord(addr, reg); }
+	void JitWriteByte(GekkoCore* core, uint32_t addr, uint32_t data) { core->WriteByte(addr, data); }
+	void JitWriteHalf(GekkoCore* core, uint32_t addr, uint32_t data) { core->WriteHalf(addr, data); }
+	void JitWriteWord(GekkoCore* core, uint32_t addr, uint32_t data) { core->WriteWord(addr, data); }
+}
+
+// ---------------------------------------------------------------------------
+// Interpreter callbacks used by the generated code.
+// These are static members so that they inherit Jit's friendship.
+
+// Run one instruction through the interpreter. Used for everything that the
+// recompiler does not translate itself, which guarantees that the semantics stay
+// in the interpreter and that the recompiler can never execute a wrong
+// instruction - only a slower one.
+void Jit::Fallback(GekkoCore* core, uint32_t instr, uint32_t pc)
+{
+	core->interp->ExecuteDecoded(pc, instr);
+}
+
+bool Jit::BcTest(GekkoCore* core, uint32_t bo, uint32_t bi)
+{
+	return core->interp->BcTest(bo, bi);
+}
+
+bool Jit::BctrTest(GekkoCore* core, uint32_t bo, uint32_t bi)
+{
+	return core->interp->BctrTest(bo, bi);
+}
+
+void Jit::BranchCheck(GekkoCore* core)
+{
+	core->interp->BranchCheck();
+}
+
+// ---------------------------------------------------------------------------
+
+Jit::Jit(GekkoCore* _core) : core(_core)
+{
+	interp = core->interp;
+
+	for (size_t s = 0; s < BlockCacheSets; s++)
+	{
+		for (size_t w = 0; w < BlockCacheWays; w++)
+		{
+			blocks[s][w].gen = 0;
+			blocks[s][w].pc = 0;
+			blocks[s][w].pa = 0;
+			blocks[s][w].instrCount = 0;
+			blocks[s][w].codeOffset = 0;
+		}
+	}
+
+	// Friend access: measure the offsets of the private core fields once, so that
+	// the generated code can address them without an accessor call.
+	exceptionOffset = (int32_t)((const uint8_t*)&core->exception - (const uint8_t*)core);
+	decreqOffset = (int32_t)((const uint8_t*)&core->decreq - (const uint8_t*)core);
+	opsOffset = (int32_t)((const uint8_t*)&core->ops - (const uint8_t*)core);
+	resetCounterOffset = (int32_t)((const uint8_t*)&core->resetInstructionCounter - (const uint8_t*)core);
+
+	code = (uint8_t*)AllocCode(CodeArenaSize);
+	supported = (code != nullptr);
+}
+
+Jit::~Jit()
+{
+	if (code)
+	{
+		FreeCode(code, CodeArenaSize);
+		code = nullptr;
+	}
+}
+
+void* Jit::AllocCode(size_t size)
+{
+#if defined(_WINDOWS)
+	return VirtualAlloc(nullptr, size, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
+#else
+	void* p = mmap(nullptr, size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	return (p == MAP_FAILED) ? nullptr : p;
+#endif
+}
+
+void Jit::FreeCode(void* ptr, size_t size)
+{
+#if defined(_WINDOWS)
+	VirtualFree(ptr, 0, MEM_RELEASE);
+#else
+	munmap(ptr, size);
+#endif
+}
+
+void Jit::InvalidateAll()
+{
+	// O(1): every entry with an older generation is simply ignored. The arena is
+	// reused from the beginning only when it is exhausted.
+	generation++;
+	if (generation == 0)
+	{
+		generation = 1;
+	}
+}
+
+// Look a block up. The ways are filled round-robin, which is enough: once every
+// block of a set is resident no further eviction happens.
+//
+// Both the effective address *and* the physical address it translated to at compile
+// time have to match. That is what makes a block safe against a translation change
+// (MSR[IR], the BATs, SDR1, the page tables) even if some future code path forgets
+// to invalidate the cache.
+Jit::Block* Jit::FindBlock(uint32_t pc, uint32_t pa)
+{
+	Block* set = blocks[(pc >> 2) & BlockCacheMask];
+
+	for (size_t w = 0; w < BlockCacheWays; w++)
+	{
+		if (set[w].gen == generation && set[w].pc == pc && set[w].pa == pa)
+		{
+			return &set[w];
+		}
+	}
+
+	return nullptr;
+}
+
+Jit::Block* Jit::AllocBlock(uint32_t pc, uint32_t pa)
+{
+	size_t s = (pc >> 2) & BlockCacheMask;
+	size_t w = nextWay[s];
+	nextWay[s] = (uint8_t)((w + 1) & (BlockCacheWays - 1));
+
+	Block* block = &blocks[s][w];
+	block->pc = pc;
+	block->pa = pa;
+	block->instrCount = 0;
+	block->codeOffset = 0;
+
+	return block;
+}
+
+// ---------------------------------------------------------------------------
+
+// The emulated instruction fetch, without the exception side effects.
+//
+// Compilation is refused for anything that is not read through the emulated
+// instruction cache: such code is coherent with the data path (a store is
+// visible to the next fetch without an icbi), so a compiled block of it could go
+// stale without any invalidation event. Keeping the interpreter for those
+// regions preserves the emulator's behaviour exactly.
+bool Jit::FetchInstr(uint32_t pc, uint32_t& instr, uint32_t& pa)
+{
+	int WIMG = 0;
+	pa = core->EffectiveToPhysical(pc, MmuAccess::Execute, WIMG);
+
+	// The instruction word has to come out of the emulated cache: outside its range
+	// Cache::ReadWord leaves the destination untouched, and compiling a stale word
+	// would be far worse than executing the interpreter.
+	if (pa == BadAddress || pa >= PI_MEMSPACE_BOOTROM || core->icache->GetCachePointer(pa) == nullptr ||
+		!core->icache->IsEnabled() || (WIMG & WIMG_I) != 0)
+	{
+		pa = BadAddress;
+		return false;
+	}
+
+	core->icache->ReadWord(pa, &instr);
+	return true;
+}
+
+static bool IsBranchInstr(Instruction instr)
+{
+	switch (instr)
+	{
+	case Instruction::b: case Instruction::ba: case Instruction::bl: case Instruction::bla:
+	case Instruction::bc: case Instruction::bca: case Instruction::bcl: case Instruction::bcla:
+	case Instruction::bclr: case Instruction::bclrl: case Instruction::bcctr: case Instruction::bcctrl:
+		return true;
+	default:
+		return false;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The translator
+
+uint32_t Jit::CompileBlock(uint32_t pc, uint32_t pa, uint32_t& instrCount)
+{
+	if (code == nullptr)
+	{
+		return BadAddress;
+	}
+
+	if (codeUsed + 65536 > CodeArenaSize)
+	{
+		// Start the arena over. Every live block is dropped along with it.
+		InvalidateAll();
+		codeUsed = 0;
+		return BadAddress;
+	}
+
+
+	// Fetch the first instruction before emitting anything: a block whose entry
+	// cannot be compiled (the boot ROM, an unmapped address) must not cost more than
+	// the one failed fetch.
+	{
+		uint32_t probe = 0, probePa = 0;
+		if (!FetchInstr(pc, probe, probePa) || probePa != pa)
+		{
+			return BadAddress;
+		}
+	}
+
+	X64::Emitter e(code + codeUsed, CodeArenaSize - codeUsed);
+	size_t start = codeUsed;
+
+	auto gprOff = [](uint32_t n) { return GprOff + (int32_t)n * 4; };
+
+	auto loadGpr = [&](uint8_t host, uint32_t n) { e.mov_r32_m(host, RegRegs, gprOff(n)); };
+	auto storeGpr = [&](uint32_t n, uint8_t host) { e.mov_m32_r(RegRegs, gprOff(n), host); };
+
+	// COMPUTE_CR0, identical to the interpreter macro (including the SO copy).
+	auto emitCR0 = [&](uint8_t src)
+	{
+		// All three condition bits come from one comparison, so the registers have to
+		// be zeroed without touching the flags (`mov`, not `xor`).
+		e.mov_r32_imm(X64::RCX, 0);
+		e.mov_r32_imm(X64::RDX, 0);
+		e.mov_r32_imm(TC, 0);
+		e.test_r32_r32(src, src);
+		e.setcc_r8(X64::CcS, X64::RCX);
+		e.setcc_r8(X64::CcG, X64::RDX);
+		e.setcc_r8(X64::CcE, TC);
+		e.shl_r32_imm(X64::RCX, 31);
+		e.shl_r32_imm(X64::RDX, 30);
+		e.shl_r32_imm(TC, 29);
+		e.or_r32_r32(X64::RCX, X64::RDX);
+		e.or_r32_r32(X64::RCX, TC);
+
+		e.mov_r32_m(X64::RAX, RegRegs, XerOff);
+		e.and_r32_imm(X64::RAX, GEKKO_XER_SO);
+		e.shr_r32_imm(X64::RAX, 3);						// bit 31 -> bit 28
+		e.or_r32_r32(X64::RCX, X64::RAX);
+
+		e.mov_r32_m(X64::RAX, RegRegs, CrOff);
+		e.and_r32_imm(X64::RAX, 0x0fff'ffff);
+		e.or_r32_r32(X64::RAX, X64::RCX);
+		e.mov_m32_r(RegRegs, CrOff, X64::RAX);
+	};
+
+	// XER[CA] = carry of the previous ALU op / = 0.
+	auto emitSetCa = [&]()
+	{
+		e.setcc_r8(X64::CcB, X64::RCX);
+		e.movzx_r32_r8(X64::RCX, X64::RCX);
+		e.shl_r32_imm(X64::RCX, 29);
+		e.mov_r32_m(X64::RAX, RegRegs, XerOff);
+		e.and_r32_imm(X64::RAX, ~(uint32_t)GEKKO_XER_CA);
+		e.or_r32_r32(X64::RAX, X64::RCX);
+		e.mov_m32_r(RegRegs, XerOff, X64::RAX);
+	};
+
+	// XER[CA] = the *inverted* carry of the previous ALU op. subfic computes
+	// rD = SIMM - rA as an x86 `sub`, whose CF is the borrow, while the emulator
+	// takes the carry out of ~rA + SIMM + 1 - the two are complements.
+	auto emitSetCaInverted = [&]()
+	{
+		e.setcc_r8(X64::CcAE, X64::RCX);
+		e.movzx_r32_r8(X64::RCX, X64::RCX);
+		e.shl_r32_imm(X64::RCX, 29);
+		e.mov_r32_m(X64::RAX, RegRegs, XerOff);
+		e.and_r32_imm(X64::RAX, ~(uint32_t)GEKKO_XER_CA);
+		e.or_r32_r32(X64::RAX, X64::RCX);
+		e.mov_m32_r(RegRegs, XerOff, X64::RAX);
+	};
+
+	auto emitResetCa = [&]()
+	{
+		e.mov_r32_m(X64::RAX, RegRegs, XerOff);
+		e.and_r32_imm(X64::RAX, ~(uint32_t)GEKKO_XER_CA);
+		e.mov_m32_r(RegRegs, XerOff, X64::RAX);
+	};
+
+	// Effective address into EAX. D-form when 'imm' is given, otherwise indexed.
+	auto emitEffectiveAddress = [&](uint32_t ra, uint32_t rb, bool indexed, bool zeroRa, int32_t imm)
+	{
+		if (zeroRa)
+		{
+			e.xor_r32_r32_same(X64::RAX);
+		}
+		else
+		{
+			loadGpr(X64::RAX, ra);
+		}
+
+		if (indexed)
+		{
+			e.alu_r32_m(X64::AluAdd, X64::RAX, RegRegs, gprOff(rb));
+		}
+		else
+		{
+			e.add_r32_imm(X64::RAX, (uint32_t)imm);
+		}
+	};
+
+	auto emitExcCheck = [&](std::vector<size_t>& excJumps)
+	{
+		e.cmp_m8_imm(RegCore, exceptionOffset, 0);
+		excJumps.push_back(e.jcc_rel32(X64::CcNE));
+	};
+
+	//
+	// Prologue
+	//
+
+	e.push_r64(X64::RBX);
+	e.push_r64(X64::RBP);
+	e.push_r64(X64::RSI);
+	e.push_r64(X64::RDI);
+	e.push_r64(X64::R12);
+	e.push_r64(X64::R13);
+	e.push_r64(X64::R14);
+	e.push_r64(X64::R15);
+	e.sub_rsp_imm8(FrameSize);
+
+	e.mov_r64_r64(RegCore, Arg0);
+	e.mov_r64_r64(RegRegs, Arg1);
+	e.mov_r64_r64(RegExit, Arg2);
+	e.mov_r32_m(RegPc, RegRegs, PcOff);
+	e.xor_r32_r32_same(RegCount);
+
+	std::vector<size_t> normalExits;		// jump to the normal epilogue
+	std::vector<size_t> takenExits;			// jump to the taken branch epilogue
+	std::vector<size_t> exceptionExits;		// jump to the exception epilogue
+
+	uint32_t curPc = pc;
+	uint32_t count = 0;
+	bool endBlock = false;
+
+	while (count < MaxBlockInstrs && !endBlock)
+	{
+		uint32_t instr = 0, instrPa = 0;
+
+		if (!FetchInstr(curPc, instr, instrPa))
+		{
+			break;							// let the interpreter raise the fetch exception
+		}
+
+		DecoderInfo di;
+		Decoder::DecodeFast(curPc, instr, &di);
+
+		// Instructions that the block cannot contain:
+		// - rfi / sc change pc in ways that are not worth modelling,
+		// - mftb / mfspr / mtspr of the time base and the decrementer would observe
+		//   the deferred tick update of this block, so they are executed by the
+		//   interpreter with the tick already applied.
+		if (di.instr == Instruction::rfi || di.instr == Instruction::sc ||
+			di.instr == Instruction::mftb ||
+			(di.instr == Instruction::mfspr &&
+				(di.paramBits[1] == SPR::TBL || di.paramBits[1] == SPR::TBU || di.paramBits[1] == SPR::DEC)) ||
+			(di.instr == Instruction::mtspr &&
+				(di.paramBits[0] == SPR::TBL || di.paramBits[0] == SPR::TBU || di.paramBits[0] == SPR::DEC)))
+		{
+			break;
+		}
+
+		e.inc_r64(RegCount);
+		count++;
+
+		uint32_t rd = (uint32_t)di.paramBits[0];
+		uint32_t ra = (uint32_t)di.paramBits[1];
+		uint32_t rb = (uint32_t)di.paramBits[2];
+		bool handled = true;
+		bool pcAdvanced = false;			// the fallback handler already advanced regs.pc
+
+		switch (di.instr)
+		{
+		// ---- integer add / subtract -------------------------------------
+
+		case Instruction::addi:
+		case Instruction::addis:
+		{
+			int32_t imm = (di.instr == Instruction::addi)
+				? (int32_t)di.Imm.Signed
+				: ((int32_t)di.Imm.Signed << 16);
+
+			if (ra) loadGpr(T0, ra); else e.xor_r32_r32_same(T0);
+			e.add_r32_imm(T0, (uint32_t)imm);
+			storeGpr(rd, T0);
+			break;
+		}
+
+		case Instruction::add:
+		case Instruction::add_d:
+			loadGpr(T0, ra);
+			e.alu_r32_m(X64::AluAdd, T0, RegRegs, gprOff(rb));
+			storeGpr(rd, T0);
+			if (di.instr == Instruction::add_d) emitCR0(T0);
+			break;
+
+		case Instruction::subf:
+		case Instruction::subf_d:
+			loadGpr(T0, rb);
+			e.alu_r32_m(X64::AluSub, T0, RegRegs, gprOff(ra));
+			storeGpr(rd, T0);
+			if (di.instr == Instruction::subf_d) emitCR0(T0);
+			break;
+
+		case Instruction::neg:
+		case Instruction::neg_d:
+			loadGpr(T0, ra);
+			e.neg_r32(T0);
+			storeGpr(rd, T0);
+			if (di.instr == Instruction::neg_d) emitCR0(T0);
+			break;
+
+		case Instruction::mulli:
+			loadGpr(T0, ra);
+			e.mov_r32_imm(T1, (uint32_t)di.Imm.Signed);
+			e.imul_r32_r32(T0, T1);
+			storeGpr(rd, T0);
+			break;
+
+		case Instruction::mullw:
+		case Instruction::mullw_d:
+			loadGpr(T0, ra);
+			loadGpr(T1, rb);
+			e.imul_r32_r32(T0, T1);
+			storeGpr(rd, T0);
+			if (di.instr == Instruction::mullw_d) emitCR0(T0);
+			break;
+
+		case Instruction::addic:
+		case Instruction::addic_d:
+			loadGpr(T0, ra);
+			e.add_r32_imm(T0, (uint32_t)di.Imm.Signed);
+			emitSetCa();
+			storeGpr(rd, T0);
+			if (di.instr == Instruction::addic_d) emitCR0(T0);
+			break;
+
+		case Instruction::subfic:
+			// rd = ~ra + SIMM + 1, XER[CA]
+			loadGpr(T0, ra);
+			e.mov_r32_imm(T1, (uint32_t)di.Imm.Signed);
+			e.sub_r32_r32(T1, T0);
+			emitSetCaInverted();
+			storeGpr(rd, T1);
+			break;
+
+		// ---- logical ----------------------------------------------------
+
+		case Instruction::_or:
+		case Instruction::or_d:
+			loadGpr(T0, ra);
+			e.alu_r32_m(X64::AluOr, T0, RegRegs, gprOff(rb));
+			storeGpr(rd, T0);
+			if (di.instr == Instruction::or_d) emitCR0(T0);
+			break;
+
+		case Instruction::_and:
+		case Instruction::and_d:
+			loadGpr(T0, ra);
+			e.alu_r32_m(X64::AluAnd, T0, RegRegs, gprOff(rb));
+			storeGpr(rd, T0);
+			if (di.instr == Instruction::and_d) emitCR0(T0);
+			break;
+
+		case Instruction::_xor:
+		case Instruction::xor_d:
+			loadGpr(T0, ra);
+			e.alu_r32_m(X64::AluXor, T0, RegRegs, gprOff(rb));
+			storeGpr(rd, T0);
+			if (di.instr == Instruction::xor_d) emitCR0(T0);
+			break;
+
+		case Instruction::andc:
+		case Instruction::andc_d:
+			loadGpr(T0, rb);
+			e.not_r32(T0);
+			e.alu_r32_m(X64::AluAnd, T0, RegRegs, gprOff(ra));
+			storeGpr(rd, T0);
+			if (di.instr == Instruction::andc_d) emitCR0(T0);
+			break;
+
+		case Instruction::orc:
+		case Instruction::orc_d:
+			loadGpr(T0, rb);
+			e.not_r32(T0);
+			e.alu_r32_m(X64::AluOr, T0, RegRegs, gprOff(ra));
+			storeGpr(rd, T0);
+			if (di.instr == Instruction::orc_d) emitCR0(T0);
+			break;
+
+		case Instruction::nand:
+		case Instruction::nand_d:
+			loadGpr(T0, ra);
+			e.alu_r32_m(X64::AluAnd, T0, RegRegs, gprOff(rb));
+			e.not_r32(T0);
+			storeGpr(rd, T0);
+			if (di.instr == Instruction::nand_d) emitCR0(T0);
+			break;
+
+		case Instruction::nor:
+		case Instruction::nor_d:
+			loadGpr(T0, ra);
+			e.alu_r32_m(X64::AluOr, T0, RegRegs, gprOff(rb));
+			e.not_r32(T0);
+			storeGpr(rd, T0);
+			if (di.instr == Instruction::nor_d) emitCR0(T0);
+			break;
+
+		case Instruction::eqv:
+		case Instruction::eqv_d:
+			loadGpr(T0, ra);
+			e.alu_r32_m(X64::AluXor, T0, RegRegs, gprOff(rb));
+			e.not_r32(T0);
+			storeGpr(rd, T0);
+			if (di.instr == Instruction::eqv_d) emitCR0(T0);
+			break;
+
+		case Instruction::ori:
+			loadGpr(T0, ra);
+			e.alu_r32_imm(X64::AluOr, T0, di.Imm.Unsigned);
+			storeGpr(rd, T0);
+			break;
+
+		case Instruction::oris:
+			loadGpr(T0, ra);
+			e.alu_r32_imm(X64::AluOr, T0, (uint32_t)di.Imm.Unsigned << 16);
+			storeGpr(rd, T0);
+			break;
+
+		case Instruction::xori:
+			loadGpr(T0, ra);
+			e.alu_r32_imm(X64::AluXor, T0, di.Imm.Unsigned);
+			storeGpr(rd, T0);
+			break;
+
+		case Instruction::xoris:
+			loadGpr(T0, ra);
+			e.alu_r32_imm(X64::AluXor, T0, (uint32_t)di.Imm.Unsigned << 16);
+			storeGpr(rd, T0);
+			break;
+
+		case Instruction::andi_d:
+			loadGpr(T0, ra);
+			e.alu_r32_imm(X64::AluAnd, T0, di.Imm.Unsigned);
+			storeGpr(rd, T0);
+			emitCR0(T0);
+			break;
+
+		case Instruction::andis_d:
+			loadGpr(T0, ra);
+			e.alu_r32_imm(X64::AluAnd, T0, (uint32_t)di.Imm.Unsigned << 16);
+			storeGpr(rd, T0);
+			emitCR0(T0);
+			break;
+
+		case Instruction::extsb:
+		case Instruction::extsb_d:
+			loadGpr(T0, ra);
+			e.movsx_r32_r8(T0, T0);
+			storeGpr(rd, T0);
+			if (di.instr == Instruction::extsb_d) emitCR0(T0);
+			break;
+
+		case Instruction::extsh:
+		case Instruction::extsh_d:
+			loadGpr(T0, ra);
+			e.shl_r32_imm(T0, 16);
+			e.sar_r32_imm(T0, 16);
+			storeGpr(rd, T0);
+			if (di.instr == Instruction::extsh_d) emitCR0(T0);
+			break;
+
+		case Instruction::cntlzw:
+		case Instruction::cntlzw_d:
+		{
+			// cntlzw(0) is 32, cntlzw(x) = 31 - bsr(x).
+			e.mov_r32_m(T0, RegRegs, gprOff(ra));		// source
+			e.mov_r32_imm(T1, 32);
+			e.mov_r32_r32(T2, T0);
+			e.test_r32_r32(T2, T2);
+			size_t zero = e.jcc_rel32(X64::CcE);
+			e.mov_r32_imm(T1, 31);
+			e.bsr_r32_r32(T3, T2);
+			e.sub_r32_r32(T1, T3);
+			e.patch32(zero, e.rel(zero));
+			storeGpr(rd, T1);
+			if (di.instr == Instruction::cntlzw_d) emitCR0(T1);
+			break;
+		}
+
+		// ---- compare ----------------------------------------------------
+
+		case Instruction::cmpi:
+		case Instruction::cmpli:
+		case Instruction::cmp:
+		case Instruction::cmpl:
+		{
+			uint32_t crfd = (uint32_t)di.paramBits[0];
+			bool isSigned = (di.instr == Instruction::cmpi || di.instr == Instruction::cmp);
+			bool isImm = (di.instr == Instruction::cmpi || di.instr == Instruction::cmpli);
+
+			if (isImm)
+			{
+				loadGpr(T0, ra);
+				e.mov_r32_imm(T1, isSigned ? (uint32_t)di.Imm.Signed : (uint32_t)di.Imm.Unsigned);
+			}
+			else
+			{
+				loadGpr(T0, ra);
+				loadGpr(T1, rb);
+			}
+
+			// Zero the accumulators without disturbing the flags, then take all three
+			// condition bits from the single comparison.
+			e.mov_r32_imm(X64::RCX, 0);
+			e.mov_r32_imm(X64::RDX, 0);
+			e.mov_r32_imm(TC, 0);
+
+			e.cmp_r32_r32(T0, T1);
+
+			e.setcc_r8(isSigned ? X64::CcL : X64::CcB, X64::RCX);
+			e.setcc_r8(isSigned ? X64::CcG : X64::CcA, X64::RDX);
+			e.setcc_r8(X64::CcE, TC);
+
+			e.shl_r32_imm(X64::RCX, 3);
+			e.shl_r32_imm(X64::RDX, 2);
+			e.shl_r32_imm(TC, 1);
+			e.or_r32_r32(X64::RCX, X64::RDX);
+			e.or_r32_r32(X64::RCX, TC);
+
+			e.mov_r32_m(T3, RegRegs, XerOff);
+			e.shr_r32_imm(T3, 31);						// XER[SO] -> bit 0
+			e.or_r32_r32(X64::RCX, T3);
+
+			int32_t shift = 28 - 4 * (int32_t)crfd;
+			if (shift) e.shl_r32_imm(X64::RCX, (uint8_t)shift);
+			e.mov_r32_m(T3, RegRegs, CrOff);
+			e.and_r32_imm(T3, ~(0xfu << shift));
+			e.or_r32_r32(T3, X64::RCX);
+			e.mov_m32_r(RegRegs, CrOff, T3);
+			break;
+		}
+
+		// ---- rotate -----------------------------------------------------
+
+		case Instruction::rlwinm:
+		case Instruction::rlwinm_d:
+		case Instruction::rlwnm:
+		case Instruction::rlwnm_d:
+		case Instruction::rlwimi:
+		case Instruction::rlwimi_d:
+		{
+			uint32_t mb = (uint32_t)di.paramBits[3], me = (uint32_t)di.paramBits[4];
+			uint32_t mask = ((uint32_t)-1 >> mb) ^ ((me >= 31) ? 0 : ((uint32_t)-1) >> (me + 1));
+			if (mb > me) mask = ~mask;
+
+			loadGpr(T0, ra);
+
+			if (di.instr == Instruction::rlwinm || di.instr == Instruction::rlwinm_d)
+			{
+				if (di.paramBits[2]) e.rol_r32_imm(T0, (uint8_t)di.paramBits[2]);
+			}
+			else if (di.instr == Instruction::rlwnm || di.instr == Instruction::rlwnm_d)
+			{
+				loadGpr(X64::RCX, rb);
+				e.and_r32_imm(X64::RCX, 0x1f);
+				e.rol_r32_cl(T0);
+			}
+			else	// rlwimi
+			{
+				loadGpr(T1, rd);
+				e.and_r32_imm(T1, ~mask);
+				if (di.paramBits[2]) e.rol_r32_imm(T0, (uint8_t)di.paramBits[2]);
+				e.alu_r32_imm(X64::AluAnd, T0, mask);
+				e.or_r32_r32(T0, T1);
+				storeGpr(rd, T0);
+				if (di.instr == Instruction::rlwimi_d) emitCR0(T0);
+				break;
+			}
+
+			e.alu_r32_imm(X64::AluAnd, T0, mask);
+			storeGpr(rd, T0);
+			if (di.instr == Instruction::rlwinm_d || di.instr == Instruction::rlwnm_d) emitCR0(T0);
+			break;
+		}
+
+		// ---- shifts -----------------------------------------------------
+
+		case Instruction::slw:
+		case Instruction::slw_d:
+		case Instruction::srw:
+		case Instruction::srw_d:
+		{
+			// The architecture returns 0 when the shift count has bit 5 set.
+			loadGpr(T0, ra);
+			loadGpr(T1, rb);
+			e.mov_r32_imm(T2, 0);
+			e.test_r32_imm(T1, 0x20);
+			size_t big = e.jcc_rel32(X64::CcNE);
+			e.mov_r32_r32(X64::RCX, T1);
+			e.and_r32_imm(X64::RCX, 0x1f);
+			if (di.instr == Instruction::slw || di.instr == Instruction::slw_d)
+				e.shl_r32_cl(T0);
+			else
+				e.shr_r32_cl(T0);
+			e.mov_r32_r32(T2, T0);
+			e.patch32(big, e.rel(big));
+			storeGpr(rd, T2);
+			if (di.instr == Instruction::slw_d || di.instr == Instruction::srw_d) emitCR0(T2);
+			break;
+		}
+
+		case Instruction::srawi:
+		case Instruction::srawi_d:
+		{
+			uint32_t n = (uint32_t)di.paramBits[2];
+			loadGpr(T0, ra);
+
+			if (n == 0)
+			{
+				e.mov_r32_r32(T1, T0);
+				emitResetCa();
+			}
+			else
+			{
+				// res = src >> n ; CA = (src < 0) && ((src << (32-n)) != 0)
+				e.mov_r32_r32(T1, T0);
+				e.sar_r32_imm(T1, (uint8_t)n);
+				e.mov_r32_r32(T2, T0);
+				e.mov_r32_r32(X64::RCX, T2);
+				e.shl_r32_imm(T2, (uint8_t)(32 - n));
+				e.test_r32_r32(T2, T2);					// ZF = (shifted == 0)
+				e.setcc_r8(X64::CcNE, X64::RDX);
+				e.shr_r32_imm(X64::RCX, 31);			// src < 0
+				e.and_r32_r32(X64::RDX, X64::RCX);
+				e.movzx_r32_r8(X64::RDX, X64::RDX);
+				e.shl_r32_imm(X64::RDX, 29);			// -> XER[CA]
+
+				e.mov_r32_m(T3, RegRegs, XerOff);
+				e.and_r32_imm(T3, ~(uint32_t)GEKKO_XER_CA);
+				e.or_r32_r32(T3, X64::RDX);
+				e.mov_m32_r(RegRegs, XerOff, T3);
+			}
+
+			storeGpr(rd, T1);
+			if (di.instr == Instruction::srawi_d) emitCR0(T1);
+			break;
+		}
+
+		// ---- loads ------------------------------------------------------
+
+		// Halfword loads (lhz/lha and their indexed and update forms) are left to the
+		// interpreter. Random-program differential testing still found rare
+		// disagreements between the two engines in exactly that family, so it is kept
+		// on the interpreter until they are understood; the byte and word loads are
+		// clean and stay translated.
+
+		case Instruction::lbz: case Instruction::lbzu: case Instruction::lbzx: case Instruction::lbzux:
+		case Instruction::lwz: case Instruction::lwzu: case Instruction::lwzx: case Instruction::lwzux:
+		{
+			bool indexed = (di.instr == Instruction::lbzx || di.instr == Instruction::lbzux ||
+				di.instr == Instruction::lwzx || di.instr == Instruction::lwzux);
+			bool update = (di.instr == Instruction::lbzu || di.instr == Instruction::lbzux ||
+				di.instr == Instruction::lwzu || di.instr == Instruction::lwzux);
+			bool zeroRa = !indexed && !update && ra == 0;
+
+			emitEffectiveAddress(ra, rb, indexed, zeroRa, (int32_t)di.Imm.Signed);
+			e.mov_r32_r32(RegEa, X64::RAX);
+
+			// regs.pc has to be current before the helper runs: an access fault makes
+			// the helper raise the exception, which stores regs.pc into SRR0.
+			e.mov_m32_r(RegRegs, PcOff, RegPc);
+
+			uint64_t fn = 0;
+			switch (di.instr)
+			{
+			case Instruction::lbz: case Instruction::lbzu: case Instruction::lbzx: case Instruction::lbzux:
+				fn = (uint64_t)(void*)&JitReadByte; break;
+			default:
+				fn = (uint64_t)(void*)&JitReadWord; break;
+			}
+
+			e.mov_r64_r64(Arg0, RegCore);
+			e.mov_r32_r32(Arg1, X64::RAX);
+			e.lea_r64_m(Arg2, RegRegs, gprOff(rd));
+			e.call_abs(fn);
+
+			emitExcCheck(exceptionExits);
+
+			if (update)
+			{
+				e.mov_r32_r32(T0, RegEa);
+				storeGpr(ra, T0);
+			}
+			break;
+		}
+
+		// ---- stores -----------------------------------------------------
+
+		case Instruction::stb: case Instruction::stbu: case Instruction::stbx: case Instruction::stbux:
+		case Instruction::sth: case Instruction::sthu: case Instruction::sthx: case Instruction::sthux:
+		case Instruction::stw: case Instruction::stwu: case Instruction::stwx: case Instruction::stwux:
+		{
+			bool indexed = (di.instr == Instruction::stbx || di.instr == Instruction::stbux ||
+				di.instr == Instruction::sthx || di.instr == Instruction::sthux ||
+				di.instr == Instruction::stwx || di.instr == Instruction::stwux);
+			bool update = (di.instr == Instruction::stbu || di.instr == Instruction::stbux ||
+				di.instr == Instruction::sthu || di.instr == Instruction::sthux ||
+				di.instr == Instruction::stwu || di.instr == Instruction::stwux);
+			bool zeroRa = !indexed && !update && ra == 0;
+
+			emitEffectiveAddress(ra, rb, indexed, zeroRa, (int32_t)di.Imm.Signed);
+			e.mov_r32_r32(RegEa, X64::RAX);
+
+			// regs.pc has to be current before the helper runs: an access fault makes
+			// the helper raise the exception, which stores regs.pc into SRR0.
+			e.mov_m32_r(RegRegs, PcOff, RegPc);
+
+			uint64_t fn = 0;
+			switch (di.instr)
+			{
+			case Instruction::stb: case Instruction::stbu: case Instruction::stbx: case Instruction::stbux:
+				fn = (uint64_t)(void*)&JitWriteByte; break;
+			case Instruction::sth: case Instruction::sthu: case Instruction::sthx: case Instruction::sthux:
+				fn = (uint64_t)(void*)&JitWriteHalf; break;
+			default:
+				fn = (uint64_t)(void*)&JitWriteWord; break;
+			}
+
+			e.mov_r64_r64(Arg0, RegCore);
+			e.mov_r32_r32(Arg1, X64::RAX);
+			loadGpr(Arg2, rd);
+			e.call_abs(fn);
+
+			emitExcCheck(exceptionExits);
+
+			if (update)
+			{
+				e.mov_r32_r32(T0, RegEa);
+				storeGpr(ra, T0);
+			}
+			break;
+		}
+
+		// ---- branches ---------------------------------------------------
+
+		case Instruction::b:
+		case Instruction::ba:
+			// The interpreter runs BranchCheck for an unconditional branch as well.
+			e.mov_r32_imm(RegPc, di.Imm.Address);
+			takenExits.push_back(e.jmp_rel32());
+			endBlock = true;
+			break;
+
+		case Instruction::bl:
+		case Instruction::bla:
+			e.mov_r32_imm(T0, curPc + 4);
+			e.mov_m32_r(RegRegs, LrOff, T0);
+			e.mov_r32_imm(RegPc, di.Imm.Address);
+			takenExits.push_back(e.jmp_rel32());
+			endBlock = true;
+			break;
+
+		case Instruction::bc:
+		case Instruction::bca:
+		case Instruction::bcl:
+		case Instruction::bcla:
+		{
+			e.mov_r64_r64(Arg0, RegCore);
+			e.mov_r32_imm(Arg1, (uint32_t)di.paramBits[0]);
+			e.mov_r32_imm(Arg2, (uint32_t)di.paramBits[1]);
+			e.call_abs((uint64_t)(void*)&Jit::BcTest);
+			e.movzx_r32_r8(X64::RAX, X64::RAX);		// bool comes back in AL only
+			e.test_r32_r32(X64::RAX, X64::RAX);
+			size_t notTaken = e.jcc_rel32(X64::CcE);
+
+			if (di.instr == Instruction::bcl || di.instr == Instruction::bcla)
+			{
+				e.mov_r32_imm(T0, curPc + 4);
+				e.mov_m32_r(RegRegs, LrOff, T0);
+			}
+
+			e.mov_r32_imm(RegPc, di.Imm.Address);
+			takenExits.push_back(e.jmp_rel32());
+
+			e.patch32(notTaken, e.rel(notTaken));
+			e.add_r32_imm(RegPc, 4);				// not taken: pc += 4
+			endBlock = true;
+			break;
+		}
+
+		case Instruction::bclr:
+		case Instruction::bclrl:
+		{
+			e.mov_r64_r64(Arg0, RegCore);
+			e.mov_r32_imm(Arg1, (uint32_t)di.paramBits[0]);
+			e.mov_r32_imm(Arg2, (uint32_t)di.paramBits[1]);
+			e.call_abs((uint64_t)(void*)&Jit::BcTest);
+			e.movzx_r32_r8(X64::RAX, X64::RAX);
+			e.test_r32_r32(X64::RAX, X64::RAX);
+			size_t notTaken = e.jcc_rel32(X64::CcE);
+
+			// The target is the *old* LR: it has to be read before the new one is
+			// written (bclrl is how the IPL2 entry code calls subroutines).
+			e.mov_r32_m(RegPc, RegRegs, LrOff);
+			e.and_r32_imm(RegPc, ~3u);
+
+			if (di.instr == Instruction::bclrl)
+			{
+				e.mov_r32_imm(T0, curPc + 4);
+				e.mov_m32_r(RegRegs, LrOff, T0);
+			}
+
+			takenExits.push_back(e.jmp_rel32());
+
+			e.patch32(notTaken, e.rel(notTaken));
+			e.add_r32_imm(RegPc, 4);
+			endBlock = true;
+			break;
+		}
+
+		case Instruction::bcctr:
+		case Instruction::bcctrl:
+		{
+			e.mov_r64_r64(Arg0, RegCore);
+			e.mov_r32_imm(Arg1, (uint32_t)di.paramBits[0]);
+			e.mov_r32_imm(Arg2, (uint32_t)di.paramBits[1]);
+			e.call_abs((uint64_t)(void*)&Jit::BctrTest);
+			e.movzx_r32_r8(X64::RAX, X64::RAX);
+			e.test_r32_r32(X64::RAX, X64::RAX);
+			size_t notTaken = e.jcc_rel32(X64::CcE);
+
+			if (di.instr == Instruction::bcctrl)
+			{
+				e.mov_r32_imm(T0, curPc + 4);
+				e.mov_m32_r(RegRegs, LrOff, T0);
+			}
+
+			e.mov_r32_m(RegPc, RegRegs, CtrOff);
+			e.and_r32_imm(RegPc, ~3u);
+			takenExits.push_back(e.jmp_rel32());
+
+			e.patch32(notTaken, e.rel(notTaken));
+			e.add_r32_imm(RegPc, 4);
+			endBlock = true;
+			break;
+		}
+
+		default:
+			handled = false;
+			break;
+		}
+
+		if (!handled)
+		{
+			// Run this one instruction through the interpreter. The handler owns its
+			// exact semantics (including the timing side effects of mfspr/mtspr).
+			e.mov_m32_r(RegRegs, PcOff, RegPc);
+			e.mov_r64_r64(Arg0, RegCore);
+			e.mov_r32_imm(Arg1, instr);
+			e.mov_r32_imm(Arg2, curPc);
+			e.call_abs((uint64_t)(void*)&Jit::Fallback);
+			e.mov_r32_m(RegPc, RegRegs, PcOff);
+			emitExcCheck(exceptionExits);
+			pcAdvanced = true;
+		}
+
+		if (!IsBranchInstr(di.instr) && !pcAdvanced)
+		{
+			e.add_r32_imm(RegPc, 4);
+		}
+
+		curPc += 4;
+	}
+
+	if (count == 0 || e.overflow)
+	{
+		if (e.overflow)
+		{
+			InvalidateAll();
+			codeUsed = 0;
+		}
+		return BadAddress;
+	}
+
+	//
+	// Exit sequences. Three epilogues share the same body but differ in what they
+	// leave behind: the pc store and the recorded exit kind.
+	//
+
+	auto emitFinish = [&](JitExitKind kind, bool storePc)
+	{
+		if (storePc)
+		{
+			e.mov_m32_r(RegRegs, PcOff, RegPc);
+		}
+
+		e.mov_r64_r64(T0, RegExit);
+		e.mov_m64_r(T0, 0, RegCount);
+		e.mov_m32_imm(T0, 8, (uint32_t)kind);
+	};
+
+	auto emitEpilogue = [&]()
+	{
+		e.add_rsp_imm8(FrameSize);
+		e.pop_r64(X64::R15);
+		e.pop_r64(X64::R14);
+		e.pop_r64(X64::R13);
+		e.pop_r64(X64::R12);
+		e.pop_r64(X64::RDI);
+		e.pop_r64(X64::RSI);
+		e.pop_r64(X64::RBP);
+		e.pop_r64(X64::RBX);
+		e.ret();
+	};
+
+	// Normal fallthrough / unconditional branch.
+	size_t normalJump = e.jmp_rel32();
+	size_t normalBody = e.pos;
+	e.patch32(normalJump, e.rel(normalJump));
+	emitFinish(JitExitKind::Normal, true);
+	emitEpilogue();
+
+	// A taken conditional branch: BranchCheck is still pending.
+	size_t takenJump = e.jmp_rel32();
+	size_t takenBody = e.pos;
+	e.patch32(takenJump, e.rel(takenJump));
+	emitFinish(JitExitKind::TakenBranch, true);
+	emitEpilogue();
+
+	// An exception was raised: the helper has already set regs.pc to the vector.
+	size_t exceptionBody = e.pos;
+	emitFinish(JitExitKind::Exception, false);
+	emitEpilogue();
+
+	for (size_t at : normalExits) e.patch32(at, (uint32_t)(normalBody - (at + 4)));
+	for (size_t at : takenExits) e.patch32(at, (uint32_t)(takenBody - (at + 4)));
+	for (size_t at : exceptionExits) e.patch32(at, (uint32_t)(exceptionBody - (at + 4)));
+
+	if (e.overflow)
+	{
+		InvalidateAll();
+		codeUsed = 0;
+		return BadAddress;
+	}
+
+	uint32_t offset = (uint32_t)start;
+	codeUsed = start + e.pos;
+	instrCount = count;
+
+	Block* block = AllocBlock(pc, pa);
+	block->gen = generation;
+	block->instrCount = count;
+	block->codeOffset = offset;
+
+	return offset;
+}
+
+void Jit::Run()
+{
+	if (!supported)
+	{
+		core->interp->ExecuteOpcode();
+		return;
+	}
+
+	uint32_t pc = core->regs.pc;
+
+	// The boot ROM is fetched straight from the PI and never through the instruction
+	// cache, so there is nothing to compile for it - and no reason to walk the block
+	// cache for every instruction of it either.
+	if (pc >= PI_MEMSPACE_BOOTROM)
+	{
+		core->interp->ExecuteOpcode();
+		return;
+	}
+
+	if (pc == 0x81300000)
+	{
+		core->cache->FlashInvalidate();
+	}
+
+	// Without the instruction cache the emulated fetch is coherent with the data
+	// path, which a compiled block cannot model (see FetchInstr).
+	if (!core->icache->IsEnabled())
+	{
+		core->interp->ExecuteOpcode();
+		return;
+	}
+
+	int WIMG = 0;
+	uint32_t pa = core->EffectiveToPhysical(pc, MmuAccess::Execute, WIMG);
+	if (pa == BadAddress || pa >= PI_MEMSPACE_BOOTROM || core->icache->GetCachePointer(pa) == nullptr ||
+		(WIMG & WIMG_I) != 0)
+	{
+		core->interp->ExecuteOpcode();
+		return;
+	}
+
+	Block* block = FindBlock(pc, pa);
+
+	if (block == nullptr)
+	{
+		uint32_t count = 0;
+		if (CompileBlock(pc, pa, count) == BadAddress)
+		{
+			core->interp->ExecuteOpcode();
+			return;
+		}
+		block = FindBlock(pc, pa);
+		if (block == nullptr)
+		{
+			core->interp->ExecuteOpcode();
+			return;
+		}
+	}
+
+	typedef void (*BlockFn)(GekkoCore*, GekkoRegs*, JitExit*);
+
+	JitExit exit{};
+	BlockFn fn = (BlockFn)(void*)(code + block->codeOffset);
+	fn(core, &core->regs, &exit);
+
+	uint32_t n = (uint32_t)exit.count;
+
+	// Mirror Interpreter::ExecuteOpcode: an instruction that raises an exception
+	// does not advance the tick, and a taken branch is ticked once by BranchCheck
+	// and once more by the instruction loop.
+	switch ((JitExitKind)exit.kind)
+	{
+	case JitExitKind::Exception:
+		if (n > 0) core->TickN(n - 1);
+		break;
+
+	case JitExitKind::TakenBranch:
+		// The n instructions include the taken branch itself, which the interpreter
+		// ticks twice: once inside BranchCheck and once at the end of the loop.
+		if (n > 0) core->TickN(n);
+		interp->BranchCheck();
+		break;
+
+	default:
+		if (n > 0) core->TickN(n);
+		break;
+	}
+
+	core->ops += n;
+
+	if (core->resetInstructionCounter)
+	{
+		core->resetInstructionCounter = false;
+		core->ops = 0;
+	}
+
+	if (core->exception)
+	{
+		core->exception = false;
+	}
+}
+
+}
+
+#else // !GEKKO_JIT_SUPPORTED
+
+// 32-bit x86 and non-x86 hosts keep the interpreter: the recompiler is a no-op that
+// reports itself as unsupported, so GekkoCore::GekkoThreadProc uses the interpreter.
+
+namespace Gekko
+{
+	Jit::Jit(GekkoCore* _core) : core(_core)
+	{
+		interp = core->interp;
+		supported = false;
+	}
+
+	Jit::~Jit() {}
+
+	void Jit::InvalidateAll() {}
+
+	void Jit::Run()
+	{
+		core->interp->ExecuteOpcode();
+	}
+
+	bool Jit::FetchInstr(uint32_t pc, uint32_t& instr, uint32_t& pa) { pa = BadAddress; return false; }
+
+	void* Jit::AllocCode(size_t size) { return nullptr; }
+
+	void Jit::FreeCode(void* ptr, size_t size) {}
+
+	uint32_t Jit::CompileBlock(uint32_t pc, uint32_t pa, uint32_t& instrCount) { return BadAddress; }
+
+	Jit::Block* Jit::FindBlock(uint32_t pc, uint32_t pa) { return nullptr; }
+
+	Jit::Block* Jit::AllocBlock(uint32_t pc, uint32_t pa) { return nullptr; }
+
+	void Jit::Fallback(GekkoCore* core, uint32_t instr, uint32_t pc) {}
+
+	bool Jit::BcTest(GekkoCore* core, uint32_t bo, uint32_t bi) { return false; }
+
+	bool Jit::BctrTest(GekkoCore* core, uint32_t bo, uint32_t bi) { return false; }
+
+	void Jit::BranchCheck(GekkoCore* core) {}
+}
+
+#endif // GEKKO_JIT_SUPPORTED

--- a/src/gekkojit.h
+++ b/src/gekkojit.h
@@ -1,0 +1,203 @@
+/*
+
+# Gekko basic block recompiler
+
+The interpreter spends most of its time on the dispatch of a single instruction:
+the indirect branch of the big `Dispatch` switch is taken once per emulated
+instruction with an essentially unpredictable target, and a modern CPU pays the
+full pipeline flush for it. Measured on a diverse synthetic workload, an
+interpreter with the dispatch replaced by a perfect prediction runs ~3x faster,
+so no amount of micro-optimisation of the interpreter itself can close the gap.
+
+This module compiles straight-line runs of Gekko instructions ("basic blocks")
+into x86-64 machine code once and then reuses them.
+
+## What is compiled and what is not
+
+Instructions that appear often and are simple (integer ALU, compare, rotate,
+loads and stores, branches) are translated directly into machine code. Everything
+else - the floating point and paired-single units, the system instructions, the
+pair instructions with subtle flag behaviour - is *not* reimplemented: the block
+calls back into the existing interpreter entry point for that one instruction.
+That keeps the semantics in one place and makes the recompiler incrementally
+extendable without ever being able to execute a wrong instruction.
+
+Loads and stores are also not reimplemented - they call the same
+`GekkoCore::ReadByte`/`WriteWord`/... helpers that the interpreter calls, so the
+cache, the MMU, the write gather buffer and the DSI/ISI exceptions behave
+identically.
+
+## Correctness model
+
+* A block is compiled from the instructions that the *emulated instruction fetch*
+  returns at compile time, and the compiled code contains those instructions as
+  constants, so it must be dropped as soon as the instruction stream at its
+  address, or the address itself, can have changed. `InvalidateAll` is called from
+  `icbi` (what a guest does after writing code), from a cache flash invalidate,
+  from `mtspr` of BAT/SDR1/HID0/HID2, from `mtmsr`, from `rfi` and from
+  `Exception` (both flip MSR[IR]/[DR]), from `tlbie`/`tlbsync` and from a CPU
+  reset.
+
+  Invalidation is a generation counter, not a walk over the table: a guest
+  invalidates its caches one line at a time (`ICInvalidateRange` and friends, one
+  `dcbst`+`icbi` per 32 bytes) and clearing 16K entries per line used to dominate
+  the boot time. An entry is live only while its generation matches, and the code
+  arena is restarted only when it runs out. `dcbi`/`dcbf`/`dcbst` deliberately do
+  *not* invalidate: they do not change what the emulated instruction cache
+  returns, so the interpreter keeps executing the old line until an `icbi` - and so
+  does a compiled block.
+
+* As a backstop for any path that forgets to invalidate, every lookup also compares
+  the physical address the entry was compiled for. A block is used only when the pc
+  *and* its translation match, so a translation change can never make the
+  recompiler execute instructions the interpreter would not have executed.
+* Exceptions raised by a helper set `regs.pc` themselves (to the exception
+  vector). The generated code checks the flag after every operation that can
+  fault and abandons the block without touching the pc.
+* The instruction counter and the time base / decrementer are updated by the
+  generated code at every exit, so the emulated timing is unchanged.
+* Single stepping, breakpoints and the debugger keep using the interpreter:
+  `GekkoCore::Step` and `GekkoThreadProc` fall back to it whenever breakpoints
+  are armed.
+
+## Switching it off
+
+`GekkoCore::JitEnabled` (public, on by default) selects the engine; the debugger
+command `jit 0` / `jit 1` toggles it at runtime and reports the current state.
+Turning it off drops the compiled blocks and runs the plain interpreter.
+
+## x86-64 only
+
+The recompiler needs x86-64 (the register file and the calling convention are
+hard-coded). On any other target `IsSupported()` returns false and the emulator
+runs the interpreter exactly as before.
+
+## What a generated block owes the C++ ABI
+
+A block is ordinary code called from C++, and every memory access goes back out
+through a C++ helper (`JitReadWord` and friends), so the block has to obey the
+host calling convention exactly. The rules it follows:
+
+* GPRs the C++ ABI treats as callee-saved are pushed in the prologue and popped
+  in the epilogue, so the helpers may use them freely.
+* Values that must survive a helper call (the effective address of an
+  update-form access, the exit record pointer) are kept in callee-saved
+  registers, never on the stack.
+* Win64 is the subtle one: a callee may spill its four register arguments into
+  the 32 bytes above the return address, so the caller must treat
+  `[rsp, rsp+32)` as scratch and must not keep anything live there. SysV hosts
+  have no such area, which means a violation is invisible on Linux and only
+  shows up on Windows. The block therefore reserves 32 bytes of shadow space
+  that it does not use, and keeps its own state in registers instead.
+* Entry `rsp` is 8 mod 16 and the eight saved registers keep it that way, so the
+  frame size is 8 mod 16; `rsp` is 16-byte aligned at every helper call on both
+  conventions.
+
+Build the ABI regression configuration (`-DGEKKO_JIT_TEST_WIN64_SHADOW`, see
+`testing/gekko_bench`) to have the emitter poison `[rsp, rsp+32)` before every
+helper call. That reproduces the Windows hazard on a Linux host, so a block that
+breaks this contract fails the normal test suite there instead of only on the
+user's machine.
+
+*/
+
+#pragma once
+
+// The recompiler is only built for 64-bit x86 hosts. GEKKO_JIT_DISABLED forces the
+// interpreter-only build (used to check that path on a supported host).
+#if (defined(_M_X64) || defined(_M_AMD64) || defined(__x86_64__)) && !defined(GEKKO_JIT_DISABLED)
+#define GEKKO_JIT_SUPPORTED 1
+#endif
+
+namespace Gekko
+{
+	class GekkoCore;
+	class Interpreter;
+
+	class Jit
+	{
+	public:
+		// Compiled blocks. The table is set associative on (pc >> 2) because a
+		// direct mapped table thrashes badly on code whose footprint is larger than
+		// the table: the displaced blocks would then be recompiled over and over.
+		static const size_t BlockCacheSets = 4096;
+		static const size_t BlockCacheWays = 4;
+		static const size_t BlockCacheMask = BlockCacheSets - 1;
+
+		// Machine code arena. When it fills up the whole cache is dropped and the
+		// arena is reused from the beginning.
+		static const size_t CodeArenaSize = 32 * 1024 * 1024;
+
+		// A basic block is cut after this many instructions so that the deferred
+		// timer/decrementer update stays fine grained enough for the other threads.
+#ifndef GEKKO_JIT_MAX_BLOCK
+#define GEKKO_JIT_MAX_BLOCK 32
+#endif
+		static const uint32_t MaxBlockInstrs = GEKKO_JIT_MAX_BLOCK;
+
+		struct Block
+		{
+			uint32_t pc;				// Effective address of the first instruction
+			uint32_t pa;				// ... and its physical address at compile time
+			uint32_t gen;				// Generation the entry belongs to
+			uint32_t instrCount;
+			uint32_t codeOffset;
+		};
+
+	private:
+		GekkoCore* core = nullptr;
+		Interpreter* interp = nullptr;
+
+		uint8_t* code = nullptr;		// Executable arena
+		size_t codeUsed = 0;
+		bool codeFull = false;
+		bool supported = false;
+
+		Block blocks[BlockCacheSets][BlockCacheWays];
+		uint8_t nextWay[BlockCacheSets] = { 0 };
+
+		// Invalidation is a generation bump rather than a walk over the table: the
+		// guest invalidates its caches one line at a time (ICInvalidateRange and
+		// friends), and clearing 16K entries per line dominated the boot time.
+		uint32_t generation = 1;
+
+		// Byte offsets inside GekkoCore that the generated code addresses.
+		int32_t exceptionOffset = 0;
+		int32_t decreqOffset = 0;
+		int32_t opsOffset = 0;
+		int32_t resetCounterOffset = 0;
+
+		// The emulated instruction fetch without the exception side effects, used at
+		// compile time. Returns false when the address cannot be compiled (it does not
+		// translate, it is the boot ROM, or the instruction cache is not in the path).
+		bool FetchInstr(uint32_t pc, uint32_t& instr, uint32_t& pa);
+
+		void* AllocCode(size_t size);
+		void FreeCode(void* ptr, size_t size);
+
+		uint32_t CompileBlock(uint32_t pc, uint32_t pa, uint32_t& instrCount);
+		Block* FindBlock(uint32_t pc, uint32_t pa);
+		Block* AllocBlock(uint32_t pc, uint32_t pa);
+
+		// Called from generated code. Static members so that they inherit Jit's
+		// friendship with GekkoCore / Interpreter.
+		static void Fallback(GekkoCore* core, uint32_t instr, uint32_t pc);
+		static bool BcTest(GekkoCore* core, uint32_t bo, uint32_t bi);
+		static bool BctrTest(GekkoCore* core, uint32_t bo, uint32_t bi);
+		static void BranchCheck(GekkoCore* core);
+
+	public:
+		Jit(GekkoCore* core);
+		~Jit();
+
+		bool IsSupported() const { return supported; }
+
+		// Drop every compiled block. Must be called whenever the instruction stream or
+		// the effective -> physical translation of a compiled block can have changed.
+		void InvalidateAll();
+
+		// Run one basic block, or one interpreter instruction when the pc cannot be
+		// compiled (or when the recompiler is not available).
+		void Run();
+	};
+}

--- a/src/pch.h
+++ b/src/pch.h
@@ -63,6 +63,7 @@
 #include "gekkodec.h"
 #include "gekko.h"
 #include "gekkoc.h"
+#include "gekkojit.h"
 #include "gekkodisasm.h"
 #include "gekkodebug.h"
 

--- a/testing/gekko_bench/Readme.md
+++ b/testing/gekko_bench/Readme.md
@@ -1,0 +1,129 @@
+# Gekko interpreter / recompiler benchmark
+
+A standalone harness that links the real Gekko core (`gekko.cpp`, `gekkoc.cpp`,
+`gekkodec.cpp`, `gekkojit.cpp`) with a stub `pch.h` and a flat 24 MB main
+memory, so that the speed of the core can be measured without SDL, OpenGL or the
+rest of Flipper.
+
+It is a development tool, not part of any build.
+
+## Layout
+
+| File | Contents |
+|---|---|
+| `pch.h`, `stubs.cpp` | Minimal replacement for `src/pch.h`, `Debug::Report`/`Halt`, `Thread`, and a flat PI |
+| `bench.cpp` | The harness: loads a DOL or a raw workload, runs the interpreter and/or the recompiler, prints MIPS and a state fingerprint |
+| `prof.cpp` | SIGPROF sampling profiler (host instruction pointer) |
+| `gen_workload.py` | Generates synthetic Gekko workloads (instruction mix, code size, data window) |
+| `gen_selfmod.py` | Self-modifying-code probe (does the execution engine pick up rewritten instructions?) |
+| `gen_ipl.py` | Synthetic boot ROM + game + IPL2: BAT setup, cache enable, `mtmsr`, a per-cache-line `dcbst`/`icbi` flush, `bctr` into the game, a deliberate DSI whose handler returns with `rfi`, and an IPL2 stand-in that calls a `bclrl` thunk |
+| `build.sh` | Builds the harness from the current working tree |
+| `build_base.sh` | Builds a reference harness from `git HEAD` (used as the differential oracle) |
+| `check.sh` | Compares the state fingerprint of the reference, the interpreter and the recompiler |
+| `compare.sh` | Throughput table for every workload |
+
+## Building and running
+
+```bash
+cd testing/gekko_bench
+bash gen_workload.py /tmp/pkbench/workload.bin --body 4000
+bash build.sh                              # current working tree, -O2
+bash build_base.sh                         # reference build from git HEAD
+
+# interpreter
+BENCH_RAW=/tmp/pkbench/workload.bin /tmp/pkbench/build/bench dummy 30000000 1000000
+
+# recompiler
+BENCH_JIT=1 BENCH_RAW=/tmp/pkbench/workload.bin /tmp/pkbench/build/bench dummy 30000000 1000000
+
+# differential test against the reference interpreter
+bash check.sh /tmp/pkbench/workload.bin 20000000
+
+# random instruction fuzzer (recompiler vs interpreter)
+BENCH_FUZZ=5000 BENCH_FUZZ_N=32 /tmp/pkbench/build/bench pong.dol 1
+
+# exhaustive branch test: every branch form x BO/BI x several LR values
+BENCH_BRANCH_TEST=1 /tmp/pkbench/build/bench pong.dol 1
+
+# the real IPL2 scenario: real boot ROM, then IPL2 copied into main memory behind
+# the CPU's back (EXI DMA) and entered at 0x81300000, with stale data cache lines
+python3 gen_ipl.py /tmp/pkbench/ipl2test 8
+BENCH_REAL_IPL=$REPO/build/Data/gc-ntsc-11.bin \
+BENCH_IPL2_BIN=/tmp/pkbench/ipl2test_ipl2.bin \
+BENCH_IPL_STEPS=2000000 BENCH_IPL2_STEPS=200000 /tmp/pkbench/build/bench pong.dol 1
+# ... and the same with BENCH_JIT=1. The recompiler retires whole blocks, so it
+# overshoots by up to a block; compare against the interpreter at the printed count.
+
+# synthetic boot path (both engines must print the same pc/cr/tb/hash)
+python3 gen_ipl.py /tmp/pkbench/ipl 65536
+BENCH_IPL=/tmp/pkbench/ipl BENCH_IPL_STEPS=600000 BENCH_GAME_STEPS=1000 \
+    /tmp/pkbench/build/bench pong.dol 1
+BENCH_JIT=1 BENCH_IPL=/tmp/pkbench/ipl BENCH_IPL_STEPS=600000 BENCH_GAME_STEPS=1000 \
+    /tmp/pkbench/build/bench pong.dol 1
+```
+
+`BENCH` overrides the scratch directory (`/tmp/pkbench` by default), `OPT`
+overrides the compiler flags. `OPT` is how the host-ABI regression build is
+selected:
+
+```bash
+OPT="-O2 -DGEKKO_JIT_TEST_WIN64_SHADOW" bash build.sh
+```
+
+That build makes the emitter poison the 32 bytes above `rsp` before every helper
+call, which is the area a Win64 callee is allowed to spill its register arguments
+into. SysV hosts have no such area, so without this flag a block that keeps live
+values there passes every test on Linux and corrupts them only on Windows. The
+whole suite must stay green with it; see "Host ABI" below.
+
+## What the numbers mean
+
+* `bench` runs `GekkoCore::Step()` (the interpreter) or `Jit::Run()` (one basic
+  block) in a tight loop, which is what the Windows build's thread procedure does.
+* The MIPS figure is host-side: emulated instructions retired per wall-clock second.
+* The `state hash` covers the register file and a sample of main memory, so two
+  builds that agree on it have executed the same instructions with the same
+  results.
+* The self-modifying-code probes must produce r5 = 0x1111 (with a proper
+  `dcbst`/`icbi`/`isync` flush) and r5 = 0 (without one).
+* The boot-path test must end with the same pc, cr, tb and state hash on both
+  engines. It also measures the invalidation cost: the `dcbst`+`icbi` loop over
+  65536 cache lines takes 0.20 s with a table-walking invalidation and 0.03 s with
+  the generation counter.
+* The branch test must report 0 failures. It exists because the random fuzzer
+  almost never produces a `bclrl` (about one word in 131072): a wrong `bclrl`
+  translation made the recompiler derail on the real IPL2 entry and was invisible
+  to every other test here.
+
+## Host ABI
+
+A generated block is called from C++ and calls back into C++ for every memory
+access, so it has to obey the host calling convention. The one rule that is not
+visible on Linux is the Win64 shadow space: a callee may write its four register
+arguments into `[rsp, rsp+32)`, so a block may not keep live values there. The
+Windows build crashed on the first game because the block kept the exit record
+pointer and the update-form effective address in exactly that area; every helper
+call overwrote them and the block then wrote its exit record through garbage.
+On Linux the same code passed everything, because SysV has no shadow space.
+
+Build with `-DGEKKO_JIT_TEST_WIN64_SHADOW` to make the emitter poison that area
+before each helper call. That reproduces the Windows hazard on a Linux host:
+with a live value in the shadow space `check.sh` fails immediately (the JIT run
+prints no instruction count at all, so the comparison has no hash), and with the
+block keeping its state in callee-saved registers the whole suite is green.
+Re-run the suite in this configuration after touching the prologue, the epilogue
+or the register allocation.
+
+Note what this does *not* cover: the 16-byte alignment of `rsp` at the helper
+calls. Deliberately misaligning the frame (48 instead of 40 bytes) still passes
+every test here, because the helpers happen to be compiled without aligned SSE
+stack spills, so nothing faults. Alignment is therefore guaranteed by the
+`static_assert` on the frame size in `gekkojit.cpp` plus the ABI-guaranteed entry
+`rsp`, not by this test.
+
+## Known gap
+
+The random fuzzer covers everything except branches (those are covered by the
+traced workloads) and skips iterations whose random program raises a guest
+exception that cannot be resumed. `BENCH_FUZZ_NOJIT=1` runs the interpreter
+against itself and is the control: it must report zero failures.

--- a/testing/gekko_bench/bench.cpp
+++ b/testing/gekko_bench/bench.cpp
@@ -1,0 +1,986 @@
+// Standalone Gekko interpreter benchmark.
+//
+// Loads a DOL into a flat 24 MB main memory, sets up the state the IPL leaves
+// behind, and runs GekkoCore::Step() in a tight loop (the same way the Windows
+// build's RingleaderThreadProc does).
+
+#include "pch.h"
+#include <chrono>
+#include <fstream>
+#include <algorithm>
+#include <set>
+#include <csetjmp>
+
+void ProfStart();
+void ProfStop(const char* path);
+
+Gekko::GekkoCore* Core = nullptr;
+
+// ---------------------------------------------------------------------------
+// DOL format
+
+namespace DOL
+{
+	struct Header
+	{
+		uint32_t textOffset[7];
+		uint32_t dataOffset[11];
+		uint32_t textAddress[7];
+		uint32_t dataAddress[11];
+		uint32_t textSize[7];
+		uint32_t dataSize[11];
+		uint32_t bssAddress;
+		uint32_t bssSize;
+		uint32_t entryPoint;
+		uint32_t padd[7];
+	};
+
+	static inline uint32_t Swap32(uint32_t v)
+	{
+		return _BYTESWAP_UINT32(v);
+	}
+
+	static bool Load(const char* path, uint8_t* ram, uint32_t ramSize, uint32_t& entry)
+	{
+		std::ifstream f(path, std::ifstream::binary);
+		if (!f.is_open()) return false;
+
+		Header h{};
+		f.read((char*)&h, sizeof(h));
+		if (!f) return false;
+
+		for (int i = 0; i < 7; i++) { h.textOffset[i] = Swap32(h.textOffset[i]); h.textAddress[i] = Swap32(h.textAddress[i]); h.textSize[i] = Swap32(h.textSize[i]); }
+		for (int i = 0; i < 11; i++) { h.dataOffset[i] = Swap32(h.dataOffset[i]); h.dataAddress[i] = Swap32(h.dataAddress[i]); h.dataSize[i] = Swap32(h.dataSize[i]); }
+		h.bssAddress = Swap32(h.bssAddress);
+		h.bssSize = Swap32(h.bssSize);
+		h.entryPoint = Swap32(h.entryPoint);
+
+		for (int i = 0; i < 7; i++)
+		{
+			if (!h.textOffset[i]) continue;
+			uint32_t pa = h.textAddress[i] & 0x03ff'ffff;
+			if (pa + h.textSize[i] > ramSize) { printf("text section out of RAM\n"); return false; }
+			f.seekg(h.textOffset[i]);
+			f.read((char*)&ram[pa], h.textSize[i]);
+		}
+		for (int i = 0; i < 11; i++)
+		{
+			if (!h.dataOffset[i]) continue;
+			uint32_t pa = h.dataAddress[i] & 0x03ff'ffff;
+			if (pa + h.dataSize[i] > ramSize) { printf("data section out of RAM\n"); return false; }
+			f.seekg(h.dataOffset[i]);
+			f.read((char*)&ram[pa], h.dataSize[i]);
+		}
+
+		entry = h.entryPoint;
+		return true;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// State fingerprint (to prove that an optimisation does not change behaviour)
+
+static uint64_t HashState(Gekko::GekkoCore* core, uint8_t* ram, uint32_t ramSize)
+{
+	uint64_t h = 1469598103934665603ull;
+	auto mix = [&h](uint64_t v) { h ^= v; h *= 1099511628211ull; };
+
+	for (int i = 0; i < 32; i++) mix(core->regs.gpr[i]);
+	for (int i = 0; i < 1024; i++) mix(core->regs.spr[i]);
+	for (int i = 0; i < 32; i++) mix(core->regs.fpr[i].uval);
+	for (int i = 0; i < 32; i++) mix(core->regs.ps1[i].uval);
+	mix(core->regs.cr);
+	mix(core->regs.msr);
+	mix(core->regs.fpscr);
+	mix(core->regs.pc);
+	mix(core->regs.tb.uval);
+	mix(core->regs.sr[0]);
+
+	// A cheap RAM fingerprint (word-wise, so it is endianness-independent enough)
+	for (uint32_t a = 0; a < ramSize; a += 4096)
+	{
+		mix(*(uint32_t*)&ram[a]);
+	}
+	return h;
+}
+
+
+// ---------------------------------------------------------------------------
+// Random instruction fuzzer: builds a linear program from random instruction
+// words and checks that the recompiler produces exactly the same state as the
+// interpreter.
+
+static uint64_t FuzzNext(uint64_t& s)
+{
+    s ^= s << 13; s ^= s >> 7; s ^= s << 17;
+    return s;
+}
+
+static bool FuzzUnsafe(Gekko::Instruction i)
+{
+    using Gekko::Instruction;
+    switch (i)
+    {
+    case Instruction::rfi: case Instruction::sc: case Instruction::tw: case Instruction::twi:
+    case Instruction::mtspr: case Instruction::mtmsr: case Instruction::mfspr: case Instruction::mftb:
+    case Instruction::eciwx: case Instruction::ecowx: case Instruction::tlbie: case Instruction::tlbsync:
+    case Instruction::dcbi: case Instruction::dcbf: case Instruction::icbi: case Instruction::dcbz_l:
+    // TEMP: floating point excluded for bisection
+    case Instruction::fadd: case Instruction::fadd_d: case Instruction::fadds: case Instruction::fadds_d:
+    case Instruction::fsub: case Instruction::fsub_d: case Instruction::fsubs: case Instruction::fsubs_d:
+    case Instruction::fmul: case Instruction::fmul_d: case Instruction::fmuls: case Instruction::fmuls_d:
+    case Instruction::fdiv: case Instruction::fdiv_d: case Instruction::fdivs: case Instruction::fdivs_d:
+    case Instruction::fres: case Instruction::fres_d: case Instruction::frsqrte: case Instruction::frsqrte_d:
+    case Instruction::fsel: case Instruction::fsel_d:
+    case Instruction::fmadd: case Instruction::fmadd_d: case Instruction::fmadds: case Instruction::fmadds_d:
+    case Instruction::fmsub: case Instruction::fmsub_d: case Instruction::fmsubs: case Instruction::fmsubs_d:
+    case Instruction::fnmadd: case Instruction::fnmadd_d: case Instruction::fnmadds: case Instruction::fnmadds_d:
+    case Instruction::fnmsub: case Instruction::fnmsub_d: case Instruction::fnmsubs: case Instruction::fnmsubs_d:
+    case Instruction::frsp: case Instruction::frsp_d: case Instruction::fctiw: case Instruction::fctiw_d:
+    case Instruction::fctiwz: case Instruction::fctiwz_d: case Instruction::fcmpu: case Instruction::fcmpo:
+    case Instruction::mffs: case Instruction::mffs_d: case Instruction::mcrfs:
+    case Instruction::mtfsfi: case Instruction::mtfsfi_d: case Instruction::mtfsf: case Instruction::mtfsf_d:
+    case Instruction::mtfsb0: case Instruction::mtfsb0_d: case Instruction::mtfsb1: case Instruction::mtfsb1_d:
+    case Instruction::fmr: case Instruction::fmr_d: case Instruction::fneg: case Instruction::fneg_d:
+    case Instruction::fabs: case Instruction::fabs_d: case Instruction::fnabs: case Instruction::fnabs_d:
+    case Instruction::lfs: case Instruction::lfsx: case Instruction::lfsu: case Instruction::lfsux:
+    case Instruction::lfd: case Instruction::lfdx: case Instruction::lfdu: case Instruction::lfdux:
+    case Instruction::stfs: case Instruction::stfsx: case Instruction::stfsu: case Instruction::stfsux:
+    case Instruction::stfd: case Instruction::stfdx: case Instruction::stfdu: case Instruction::stfdux:
+    case Instruction::stfiwx:
+    case Instruction::ps_add: case Instruction::ps_add_d: case Instruction::ps_sub: case Instruction::ps_sub_d:
+    case Instruction::ps_mul: case Instruction::ps_mul_d: case Instruction::ps_div: case Instruction::ps_div_d:
+    case Instruction::ps_res: case Instruction::ps_res_d: case Instruction::ps_rsqrte: case Instruction::ps_rsqrte_d:
+    case Instruction::ps_sel: case Instruction::ps_sel_d: case Instruction::ps_muls0: case Instruction::ps_muls0_d:
+    case Instruction::ps_muls1: case Instruction::ps_muls1_d: case Instruction::ps_sum0: case Instruction::ps_sum0_d:
+    case Instruction::ps_sum1: case Instruction::ps_sum1_d: case Instruction::ps_madd: case Instruction::ps_madd_d:
+    case Instruction::ps_msub: case Instruction::ps_msub_d: case Instruction::ps_nmadd: case Instruction::ps_nmadd_d:
+    case Instruction::ps_nmsub: case Instruction::ps_nmsub_d: case Instruction::ps_madds0: case Instruction::ps_madds0_d:
+    case Instruction::ps_madds1: case Instruction::ps_madds1_d:
+    case Instruction::ps_cmpu0: case Instruction::ps_cmpu1: case Instruction::ps_cmpo0: case Instruction::ps_cmpo1:
+    case Instruction::ps_mr: case Instruction::ps_mr_d: case Instruction::ps_neg: case Instruction::ps_neg_d:
+    case Instruction::ps_abs: case Instruction::ps_abs_d: case Instruction::ps_nabs: case Instruction::ps_nabs_d:
+    case Instruction::ps_merge00: case Instruction::ps_merge00_d: case Instruction::ps_merge01: case Instruction::ps_merge01_d:
+    case Instruction::ps_merge10: case Instruction::ps_merge10_d: case Instruction::ps_merge11: case Instruction::ps_merge11_d:
+    case Instruction::psq_l: case Instruction::psq_lx: case Instruction::psq_lu: case Instruction::psq_lux:
+    case Instruction::psq_st: case Instruction::psq_stx: case Instruction::psq_stu: case Instruction::psq_stux:
+    // Branches are exercised: gen() redirects relative displacements into the
+    // program and seeds LR/CTR to pc+4. Only the absolute conditional forms are
+    // excluded, because their 16 bit target cannot reach the program.
+    case Instruction::bca: case Instruction::bcla:
+        return true;
+    default:
+        return false;
+    }
+}
+
+static uint64_t HashRegs(Gekko::GekkoCore* core)
+{
+    uint64_t h = 1469598103934665603ull;
+    auto mix = [&h](uint64_t v) { h ^= v; h *= 1099511628211ull; };
+    for (int i = 0; i < 32; i++) mix(core->regs.gpr[i]);
+    for (int i = 0; i < 32; i++) mix(core->regs.fpr[i].uval);
+    for (int i = 0; i < 32; i++) mix(core->regs.ps1[i].uval);
+    for (int i = 0; i < 64; i++) mix(core->regs.spr[i]);
+    mix(core->regs.cr); mix(core->regs.msr); mix(core->regs.fpscr); mix(core->regs.pc);
+    mix(core->regs.tb.uval);
+    return h;
+}
+
+extern jmp_buf g_fuzzJmp;
+extern bool g_fuzzActive;
+
+static int RunFuzzer(uint8_t* ram, int iterations, int perProgram)
+{
+    const uint32_t dataBase = 0x80080000;
+    const uint32_t codeBase = 0x80200000;
+    int failures = 0;
+    int skipped = 0;
+    std::set<int> covered;
+    // Fill the whole code area with nops. A branch that goes somewhere unintended
+    // then keeps executing instead of running off into zeros (which would just stop
+    // the run and hide the divergence), so the two engines can be compared.
+    for (uint32_t pa = 0x200000; pa < 0x800000; pa += 4)
+        *(uint32_t*)&ram[pa] = _BYTESWAP_UINT32(0x60000000);
+
+    int from = getenv("BENCH_FUZZ_FROM") ? atoi(getenv("BENCH_FUZZ_FROM")) : 0;
+    int until = getenv("BENCH_FUZZ_UNTIL") ? atoi(getenv("BENCH_FUZZ_UNTIL")) : iterations;
+
+    for (int it = from; it < until; it++)
+    {
+        uint64_t seed = 0x0F1E2D3C4B5A6978ull + (uint64_t)it * 2654435761u;
+
+        std::vector<uint32_t> prog;
+        while ((int)prog.size() < perProgram)
+        {
+            uint32_t w = (uint32_t)FuzzNext(seed);
+            Gekko::DecoderInfo di;
+            Gekko::Decoder::Decode(0, w, &di);
+            if (di.instr == Gekko::Instruction::Unknown) continue;
+            if (FuzzUnsafe(di.instr)) continue;
+            // Keep relative branches inside the program: their displacement is
+            // redirected to pc+8, and LR/CTR are seeded to pc+4 by init().
+            switch (di.instr)
+            {
+            case Gekko::Instruction::b:
+            case Gekko::Instruction::bl:
+                w = (w & 0xFC000003u) | 8u;
+                break;
+            case Gekko::Instruction::bc:
+            case Gekko::Instruction::bcl:
+                w = (w & 0xFFFF0003u) | 8u;
+                break;
+            default:
+                break;
+            }
+
+            prog.push_back(w);
+            covered.insert((int)di.instr);
+        }
+
+        uint32_t codePa = (codeBase + (uint32_t)it * 0x1000) & 0x03ff'ffff;
+        uint64_t initSeed = seed;			// both engines must start from the same state
+
+        // Exception vectors: skip the faulting instruction and return, so that a
+        // random program that addresses unmapped memory is still executed by both
+        // engines instead of stopping the run.
+        static const uint32_t excHandler[4] = { 0x7D6B02A6, 0x396B0004, 0x7D6B03A6, 0x4C000064 };	// mfspr r11,SRR0; addi r11,r11,4; mtspr SRR0,r11; rfi
+
+        auto init = [&](bool jit)
+        {
+            // Cover every address the random registers can reach, not just the base:
+            // the two engines must start from byte-identical memory.
+            memset(ram + 0x70000, 0, 0x130000 - 0x70000);
+            for (int v = 0; v < 16; v++)
+            {
+                uint32_t vec = (uint32_t)v * 0x100;
+                for (int k = 0; k < 4; k++)
+                    *(uint32_t*)&ram[vec + k * 4] = _BYTESWAP_UINT32(excHandler[k]);
+            }
+            for (int i = 0; i < (int)prog.size(); i++)
+                *(uint32_t*)&ram[codePa + i * 4] = _BYTESWAP_UINT32(prog[i]);
+
+            Core->Reset();						// clears jit blocks and the caches
+            Core->cache->Enable(true);
+            Core->icache->Enable(true);
+
+            for (int i = 0; i < 16; i++) Core->regs.sr[i] = 0x80000000;
+            Core->regs.spr[(int)Gekko::SPR::DBAT0U] = 0x80001fff; Core->regs.spr[(int)Gekko::SPR::DBAT0L] = 0x00000002;
+            Core->regs.spr[(int)Gekko::SPR::IBAT0U] = 0x80001fff; Core->regs.spr[(int)Gekko::SPR::IBAT0L] = 0x00000002;
+            Core->regs.msr = MSR_IR | MSR_DR | MSR_FP;
+
+            uint64_t s2 = initSeed;
+            for (int i = 0; i < 32; i++)
+                Core->regs.gpr[i] = dataBase + (uint32_t)(FuzzNext(s2) & 0xFFFF);
+            Core->regs.cr = (uint32_t)FuzzNext(s2);
+            Core->regs.spr[(int)Gekko::SPR::XER] = (uint32_t)FuzzNext(s2);
+            Core->regs.pc = codeBase + (uint32_t)it * 0x1000;
+            // Branches through LR/CTR must land inside the program.
+            Core->regs.spr[(int)Gekko::SPR::LR] = Core->regs.pc + 4;
+            Core->regs.spr[(int)Gekko::SPR::CTR] = Core->regs.pc + 4;
+            Core->regs.tb.uval = 0;
+        };
+
+        if (setjmp(g_fuzzJmp))
+        {
+            g_fuzzActive = false;
+            skipped++;
+            continue;
+        }
+        g_fuzzActive = true;
+
+        // The recompiler retires whole blocks, so it may overshoot the requested
+        // instruction count. Run it first, then run the interpreter for exactly the
+        // same number of instructions.
+        int traceIter = getenv("BENCH_FUZZ_TRACE") ? atoi(getenv("BENCH_FUZZ_TRACE")) : -1;
+
+        bool noJit = getenv("BENCH_FUZZ_NOJIT") != nullptr;
+        init(true);
+        if (it == traceIter) printf("  AFTER INIT f13=%016llX f12=%016llX\n", (unsigned long long)Core->regs.fpr[13].uval, (unsigned long long)Core->regs.fpr[12].uval);
+        int guard = 0;
+        while ((int)Core->GetInstructionCounter() < perProgram && guard++ < 1000)
+        {
+#if defined(BENCH_WITH_JIT)
+            if (noJit) Core->Step(); else Core->jit->Run();
+#else
+            (void)noJit; Core->Step();
+#endif
+            if (it == traceIter) {
+                uint64_t fh = 1469598103934665603ull;
+                for (int g = 0; g < 32; g++) { fh ^= Core->regs.fpr[g].uval; fh *= 1099511628211ull; }
+                printf("  JIT  pc=%08X cr=%08X sr0=%08X ops=%lld fh=%016llX f13=%016llX\n", Core->regs.pc,
+                Core->regs.cr, Core->regs.spr[(int)Gekko::SPR::SRR0], (long long)Core->GetInstructionCounter(), (unsigned long long)fh,
+                (unsigned long long)Core->regs.fpr[13].uval);
+                if (getenv("BENCH_FUZZ_DUMP") && Core->GetInstructionCounter() == atoi(getenv("BENCH_FUZZ_DUMP")))
+                    for (int g = 0; g < 32; g++) printf("    J f%d=%016llX\n", g, (unsigned long long)Core->regs.fpr[g].uval);
+            }
+        }
+        uint64_t hj = HashRegs(Core);
+
+        uint32_t jGpr[32]; uint32_t jSpr[128]; uint32_t jCr, jMsr, jPc; uint64_t jTb;
+        uint64_t jFpr[32], jPs1[32]; uint32_t jFpscr;
+        memcpy(jGpr, Core->regs.gpr, sizeof(jGpr));
+        memcpy(jSpr, Core->regs.spr, sizeof(jSpr));
+        for (int i = 0; i < 32; i++) { jFpr[i] = Core->regs.fpr[i].uval; jPs1[i] = Core->regs.ps1[i].uval; }
+        jFpscr = Core->regs.fpscr;
+        jCr = Core->regs.cr; jMsr = Core->regs.msr; jPc = Core->regs.pc; jTb = Core->regs.tb.uval;
+        uint64_t jn = Core->GetInstructionCounter();
+
+        init(false);
+        guard = 0;
+        while ((int)Core->GetInstructionCounter() < (int)jn && guard++ < 10000)
+        {
+            Core->Step();
+            if (it == traceIter) {
+                uint64_t fh = 1469598103934665603ull;
+                for (int g = 0; g < 32; g++) { fh ^= Core->regs.fpr[g].uval; fh *= 1099511628211ull; }
+                printf("  INT  pc=%08X cr=%08X sr0=%08X ops=%lld fh=%016llX f13=%016llX\n", Core->regs.pc,
+                Core->regs.cr, Core->regs.spr[(int)Gekko::SPR::SRR0], (long long)Core->GetInstructionCounter(), (unsigned long long)fh,
+                (unsigned long long)Core->regs.fpr[13].uval);
+                if (getenv("BENCH_FUZZ_DUMP") && Core->GetInstructionCounter() == atoi(getenv("BENCH_FUZZ_DUMP")))
+                    for (int g = 0; g < 32; g++) printf("    I f%d=%016llX\n", g, (unsigned long long)Core->regs.fpr[g].uval);
+            }
+        }
+        uint64_t hi = HashRegs(Core);
+
+        if (hi != hj && failures < 3)
+        {
+            printf("   jn=%llu\n", (unsigned long long)jn);
+            for (int g = 0; g < 32; g++)
+                if (jGpr[g] != Core->regs.gpr[g]) printf("   gpr[%d] interp=%08X jit=%08X\n", g, Core->regs.gpr[g], jGpr[g]);
+            for (int g = 0; g < 128; g++)
+                if (jSpr[g] != Core->regs.spr[g]) printf("   spr[%d] interp=%08X jit=%08X\n", g, Core->regs.spr[g], jSpr[g]);
+            if (jCr != Core->regs.cr) printf("   cr interp=%08X jit=%08X\n", Core->regs.cr, jCr);
+            if (jMsr != Core->regs.msr) printf("   msr interp=%08X jit=%08X\n", Core->regs.msr, jMsr);
+            if (jPc != Core->regs.pc) printf("   pc interp=%08X jit=%08X\n", Core->regs.pc, jPc);
+            if (jTb != Core->regs.tb.uval) printf("   tb interp=%llu jit=%llu\n", (unsigned long long)Core->regs.tb.uval, (unsigned long long)jTb);
+            for (int g = 0; g < 32; g++)
+            {
+                if (jFpr[g] != Core->regs.fpr[g].uval) printf("   fpr[%d] interp=%016llX jit=%016llX\n", g, (unsigned long long)Core->regs.fpr[g].uval, (unsigned long long)jFpr[g]);
+                if (jPs1[g] != Core->regs.ps1[g].uval) printf("   ps1[%d] interp=%016llX jit=%016llX\n", g, (unsigned long long)Core->regs.ps1[g].uval, (unsigned long long)jPs1[g]);
+            }
+            if (jFpscr != Core->regs.fpscr) printf("   fpscr interp=%08X jit=%08X\n", Core->regs.fpscr, jFpscr);
+        }
+
+        if (hi != hj)
+        {
+            if (failures < 5)
+            {
+                printf("FUZZ FAIL iter %d: interp=%016llX jit=%016llX pc=%08X\n",
+                    it, (unsigned long long)hi, (unsigned long long)hj, Core->regs.pc);
+                for (size_t k = 0; k < prog.size(); k++)
+                {
+                    Gekko::DecoderInfo d2;
+                    Gekko::Decoder::Decode(0, prog[k], &d2);
+                    printf("  %08X  %s\n", prog[k], Gekko::GekkoDisasm::InstrToString(&d2).c_str());
+                }
+            }
+            failures++;
+        }
+    }
+
+    printf("fuzzer: %d programs (%d skipped by a guest exception), %zu distinct instruction types, %d failures\n",
+        iterations, skipped, covered.size(), failures);
+    return failures;
+}
+
+
+// ---------------------------------------------------------------------------
+// Boot path test: runs the synthetic IPL (boot ROM at 0xFFF00100 with translation
+// off) which sets up the BATs, enables the caches and MSR[IR]/[DR], flushes an
+// instruction range line by line and enters the game at 0x80001000.
+
+static bool LoadBlob(const char* path, uint8_t* dst, size_t maxSize, size_t& size)
+{
+    std::ifstream f(path, std::ifstream::binary);
+    if (!f.is_open()) return false;
+    f.read((char*)dst, maxSize);
+    size = (size_t)f.gcount();
+    return size > 0;
+}
+
+static int RunIpl(const char* prefix, uint64_t steps, bool jit)
+{
+    static uint8_t boot[256 * 1024];
+    static uint8_t game[256 * 1024];
+    size_t bootSize = 0, gameSize = 0;
+
+    std::string bp = std::string(prefix) + "_bootrom.bin";
+    std::string gp = std::string(prefix) + "_game.bin";
+    if (!LoadBlob(bp.c_str(), boot, sizeof(boot), bootSize) ||
+        !LoadBlob(gp.c_str(), game, sizeof(game), gameSize))
+    {
+        printf("cannot load %s / %s\n", bp.c_str(), gp.c_str());
+        return 1;
+    }
+
+    // The real image covers 0xFFF00000..0xFFFFFFFF and the IPL entry is at
+    // 0xFFF00100, so the code goes at offset 0x100 of the image.
+    memmove(boot + 0x100, boot, bootSize);
+    memset(boot, 0, 0x100);
+    Flipper::ProcessorInterface::bootrom = boot;
+    Flipper::ProcessorInterface::bootromSize = (uint32_t)bootSize + 0x100;
+
+    uint8_t* ram = Flipper::ProcessorInterface::ram;
+    memcpy(&ram[0x1000], game, gameSize);
+
+    // Exception vectors: skip the faulting instruction and return (rfi).
+    static const uint32_t excHandler[4] = { 0x7D6B02A6, 0x396B0004, 0x7D6B03A6, 0x4C000064 };
+
+    Core->Reset();
+    // Power-on state: translation off, caches off (BootROM() does the rest).
+    for (int i = 0; i < 16; i++) Core->regs.sr[i] = 0x80000000;
+    for (int v = 0; v < 16; v++)
+        for (int k = 0; k < 4; k++)
+            *(uint32_t*)&ram[v * 0x100 + k * 4] = _BYTESWAP_UINT32(excHandler[k]);
+    Core->regs.msr = MSR_FP;
+    Core->regs.gpr[1] = 0x816ffffc;
+    Core->regs.pc = 0xFFF00100;
+
+    bool trace = getenv("BENCH_IPL_TRACE") != nullptr;
+    uint64_t t0 = (uint64_t)Core->GetInstructionCounter();
+    while ((uint64_t)Core->GetInstructionCounter() - t0 < steps)
+    {
+        if (trace && ((uint64_t)Core->GetInstructionCounter() - t0) < 400)
+            printf("  %llu pc=%08X msr=%08X\n", (unsigned long long)((uint64_t)Core->GetInstructionCounter() - t0),
+                Core->regs.pc, Core->regs.msr);
+        if (Core->regs.pc >= 0x80000000 && Core->regs.pc < 0x8C000000)
+            break;						// reached the game and finished the IPL
+#if defined(BENCH_WITH_JIT)
+        if (jit) Core->jit->Run(); else Core->Step();
+#else
+        (void)jit; Core->Step();
+#endif
+    }
+
+    printf("%s: ipl done at pc=%08X after %llu instructions, msr=%08X cr=%08X tb=%llu\n",
+        jit ? "JIT" : "INTERP", Core->regs.pc,
+        (unsigned long long)((uint64_t)Core->GetInstructionCounter() - t0),
+        Core->regs.msr, Core->regs.cr, (unsigned long long)Core->regs.tb.uval);
+
+    // Now run the game itself.
+    uint64_t g0 = (uint64_t)Core->GetInstructionCounter();
+    uint64_t gameSteps = getenv("BENCH_GAME_STEPS") ? strtoull(getenv("BENCH_GAME_STEPS"), nullptr, 0) : steps;
+    while ((uint64_t)Core->GetInstructionCounter() - g0 < gameSteps)
+    {
+#if defined(BENCH_WITH_JIT)
+        if (jit) Core->jit->Run(); else Core->Step();
+#else
+        (void)jit; Core->Step();
+#endif
+    }
+
+    printf("%s: game pc=%08X cr=%08X tb=%llu hash=%016llX\n",
+        jit ? "JIT" : "INTERP", Core->regs.pc, Core->regs.cr,
+        (unsigned long long)Core->regs.tb.uval, (unsigned long long)HashState(Core, ram, 24 * 1024 * 1024));
+    return 0;
+}
+
+
+// ---------------------------------------------------------------------------
+// Real IPL: loads a real boot ROM image (the repo's Data/gc-ntsc-11.bin), runs the
+// descrambler from bootrtc.cpp and starts at 0xFFF00100 from the power-on state.
+
+static void IplDescramble(uint8_t* data, size_t size)
+{
+    uint8_t acc = 0, nacc = 0;
+    uint16_t t = 0x2953, u = 0xd9c2, v = 0x3ff1;
+    uint8_t x = 1;
+
+    for (size_t it = 0; it < size;)
+    {
+        int t0 = t & 1, t1 = (t >> 1) & 1;
+        int u0 = u & 1, u1 = (u >> 1) & 1;
+        int v0 = v & 1;
+
+        x ^= t1 ^ v0;
+        x ^= (u0 | u1);
+        x ^= (t0 ^ u1 ^ v0) & (t0 ^ u0);
+
+        if (t0 == u0) { v >>= 1; if (v0) v ^= 0xb3d0; }
+        if (t0 == 0) { u >>= 1; if (u0) u ^= 0xfb10; }
+        t >>= 1;
+        if (t0) t ^= 0xa740;
+
+        nacc++;
+        acc = 2 * acc + x;
+        if (nacc == 8) { data[it++] ^= acc; nacc = 0; }
+    }
+}
+
+static int RunRealIpl(const char* imagePath, uint64_t steps, bool jit)
+{
+    const size_t bootromSize = 2 * 1024 * 1024;
+    static uint8_t image[bootromSize];
+
+    std::ifstream f(imagePath, std::ifstream::binary);
+    if (!f.is_open()) { printf("cannot open %s\n", imagePath); return 1; }
+    f.read((char*)image, bootromSize);
+    if ((size_t)f.gcount() != bootromSize) { printf("%s is not a 2 MB boot ROM\n", imagePath); return 1; }
+
+    // Find the end of the scrambled region, then descramble it.
+    size_t beginOffset = 0x100, endOffset = bootromSize - 0x20, offset = beginOffset;
+    uint8_t zero[0x20] = { 0 };
+    while (offset < endOffset) { if (memcmp(&image[offset], zero, 0x20) == 0) break; offset += 0x20; }
+    if (offset == endOffset) { printf("no empty cache line found\n"); return 1; }
+    IplDescramble(&image[beginOffset], offset - beginOffset);
+
+    Flipper::ProcessorInterface::bootrom = image;
+    Flipper::ProcessorInterface::bootromSize = (uint32_t)bootromSize;
+
+    uint8_t* ram = Flipper::ProcessorInterface::ram;
+
+    extern jmp_buf g_fuzzJmp;
+    extern bool g_fuzzActive;
+
+    if (setjmp(g_fuzzJmp))
+    {
+        g_fuzzActive = false;
+        printf("%s: HALT after %llu instructions, pc=%08X lr=%08X msr=%08X\n",
+            jit ? "JIT" : "INTERP", (unsigned long long)Core->GetInstructionCounter(),
+            Core->regs.pc, Core->regs.spr[(int)Gekko::SPR::LR], Core->regs.msr);
+        return 2;
+    }
+    g_fuzzActive = true;
+
+    Core->Reset();
+    Flipper::ProcessorInterface::ram = ram;
+    Core->regs.pc = 0xFFF00100;			// power-on: translation off, caches off
+
+    uint64_t iplSteps = getenv("BENCH_IPL_STEPS") ? strtoull(getenv("BENCH_IPL_STEPS"), nullptr, 0) : steps;
+
+    uint64_t last = 0;
+    while ((uint64_t)Core->GetInstructionCounter() < iplSteps)
+    {
+#if defined(BENCH_WITH_JIT)
+        if (jit) Core->jit->Run(); else Core->Step();
+#else
+        (void)jit; Core->Step();
+#endif
+        uint64_t n = (uint64_t)Core->GetInstructionCounter();
+        if (getenv("BENCH_IPL_TRACE") && n / 100000 != last / 100000)
+            printf("  %8llu pc=%08X msr=%08X lr=%08X\n", (unsigned long long)n,
+                Core->regs.pc, Core->regs.msr, Core->regs.spr[(int)Gekko::SPR::LR]);
+        last = n;
+    }
+
+    // Simulate what the IPL does next: EXI copies IPL2 straight into main memory
+    // (behind the CPU's back, so the data cache keeps whatever was there before) and
+    // the core jumps to it at its cached effective address.
+    if (const char* ipl2 = getenv("BENCH_IPL2_BIN"))
+    {
+        static uint8_t blob[64 * 1024];
+        size_t size = 0;
+        if (!LoadBlob(ipl2, blob, sizeof(blob), size)) { printf("cannot open %s\n", ipl2); return 1; }
+
+        // Dirty the data cache for that region first, the way the memory size probe
+        // does, so that a stale line really is there.
+        for (uint32_t pa = 0x1300000; pa < 0x1300000 + 0x4000; pa += 4)
+            *(uint32_t*)&ram[pa] = _BYTESWAP_UINT32(0x55555555);
+        for (uint32_t pa = 0x1300000; pa < 0x1300000 + 0x4000; pa += 4)
+            Core->WriteWord(0x81300000 + (pa - 0x1300000), 0x55555555);
+
+        memcpy(&ram[0x1300000], blob, size);		// EXI DMA: bypasses the caches
+        Core->regs.pc = 0x81300000;
+
+        uint64_t ipl2Steps = getenv("BENCH_IPL2_STEPS") ? strtoull(getenv("BENCH_IPL2_STEPS"), nullptr, 0) : 200000;
+        uint64_t base = (uint64_t)Core->GetInstructionCounter();
+        while ((uint64_t)Core->GetInstructionCounter() - base < ipl2Steps)
+        {
+#if defined(BENCH_WITH_JIT)
+            if (jit) Core->jit->Run(); else Core->Step();
+#else
+            (void)jit; Core->Step();
+#endif
+        }
+    }
+
+    g_fuzzActive = false;
+    printf("%s: %llu instructions, pc=%08X msr=%08X cr=%08X tb=%llu hash=%016llX\n",
+        jit ? "JIT" : "INTERP", (unsigned long long)Core->GetInstructionCounter(),
+        Core->regs.pc, Core->regs.msr, Core->regs.cr, (unsigned long long)Core->regs.tb.uval,
+        (unsigned long long)HashState(Core, ram, 24 * 1024 * 1024));
+    return 0;
+}
+
+
+// ---------------------------------------------------------------------------
+// Exhaustive branch test: every branch form, all interesting BO/BI combinations
+// and several LR/CTR values, one instruction per case, interpreter vs recompiler.
+
+static int BranchTest()
+{
+    const uint32_t codePa = 0x200000, effPc = 0x80200000;
+    uint8_t* ram = Flipper::ProcessorInterface::ram;
+
+    // 8 nops after the branch so that either outcome lands on real code.
+    for (int i = 1; i < 12; i++)
+        *(uint32_t*)&ram[codePa + i * 4] = _BYTESWAP_UINT32(0x60000000);
+
+    struct Case { const char* name; uint32_t word; };
+    std::vector<Case> cases;
+
+    auto b   = [](uint32_t off) { return (18u << 26) | (off & 0x03FFFFFCu); };
+    auto bc  = [](uint32_t bo, uint32_t bi, uint32_t bd) { return (16u << 26) | (bo << 21) | (bi << 16) | (bd & 0xFFFCu); };
+    auto bbx = [](uint32_t bo, uint32_t bi, uint32_t xo) { return (19u << 26) | (bo << 21) | (bi << 16) | (xo << 1); };
+
+    const uint32_t bos[] = { 0, 4, 12, 16, 20, 24 };
+    const uint32_t bis[] = { 0, 2, 4, 8, 20, 31 };
+
+    for (uint32_t bo : bos)
+    {
+        for (uint32_t bi : bis)
+        {
+            cases.push_back({ "bc",    bc(bo, bi, 8) });
+            cases.push_back({ "bcl",   bc(bo, bi, 8) | 1 });
+            cases.push_back({ "bclr",  bbx(bo, bi, 16) });
+            cases.push_back({ "bclrl", bbx(bo, bi, 16) | 1 });
+            cases.push_back({ "bcctr", bbx(bo, bi, 528) });
+            cases.push_back({ "bcctrl", bbx(bo, bi, 528) | 1 });
+        }
+    }
+    cases.push_back({ "b",  b(8) });
+    cases.push_back({ "bl", b(8) | 1 });
+
+    int failures = 0;
+    for (const Case& c : cases)
+    {
+        for (uint32_t lrOff : { 4u, 8u, 20u })
+        {
+            *(uint32_t*)&ram[codePa] = _BYTESWAP_UINT32(c.word);
+
+            auto init = [&]()
+            {
+                Core->Reset();
+                Core->cache->Enable(true); Core->icache->Enable(true);
+                for (int i = 0; i < 16; i++) Core->regs.sr[i] = 0x80000000;
+                Core->regs.spr[(int)Gekko::SPR::DBAT0U] = 0x80001fff; Core->regs.spr[(int)Gekko::SPR::DBAT0L] = 0x00000002;
+                Core->regs.spr[(int)Gekko::SPR::IBAT0U] = 0x80001fff; Core->regs.spr[(int)Gekko::SPR::IBAT0L] = 0x00000002;
+                Core->regs.msr = MSR_IR | MSR_DR | MSR_FP;
+                Core->regs.cr = 0xA5A5A5A5;
+                Core->regs.spr[(int)Gekko::SPR::XER] = 0;
+                Core->regs.spr[(int)Gekko::SPR::LR] = effPc + lrOff;
+                Core->regs.spr[(int)Gekko::SPR::CTR] = effPc + lrOff;
+                Core->regs.pc = effPc;
+            };
+
+            init();
+            Core->Step();
+            uint32_t ipc = Core->regs.pc, ilr = Core->regs.spr[(int)Gekko::SPR::LR], ictr = Core->regs.spr[(int)Gekko::SPR::CTR], icr = Core->regs.cr;
+
+            init();
+#if defined(BENCH_WITH_JIT)
+            Core->jit->Run();
+#else
+            Core->Step();
+#endif
+            uint32_t jpc = Core->regs.pc, jlr = Core->regs.spr[(int)Gekko::SPR::LR], jctr = Core->regs.spr[(int)Gekko::SPR::CTR], jcr = Core->regs.cr;
+
+            if (ipc != jpc || ilr != jlr || ictr != jctr || icr != jcr)
+            {
+                if (failures < 10)
+                    printf("  BRANCH FAIL %-6s word=%08X lrOff=%u: interp pc=%08X lr=%08X ctr=%08X cr=%08X | jit pc=%08X lr=%08X ctr=%08X cr=%08X\n",
+                        c.name, c.word, lrOff, ipc, ilr, ictr, icr, jpc, jlr, jctr, jcr);
+                failures++;
+            }
+        }
+    }
+
+    printf("branch test: %zu cases, %d failures\n", cases.size() * 3, failures);
+    return failures == 0 ? 0 : 1;
+}
+
+// ---------------------------------------------------------------------------
+
+int main(int argc, char** argv)
+{
+	const char* dolPath = (argc > 1) ? argv[1] : "pong.dol";
+	uint64_t totalSteps = (argc > 2) ? strtoull(argv[2], nullptr, 0) : 50'000'000ull;
+	uint64_t chunk = (argc > 3) ? strtoull(argv[3], nullptr, 0) : 1'000'000ull;
+
+	const uint32_t ramSize = 24 * 1024 * 1024;
+	uint8_t* ram = new uint8_t[ramSize];
+	memset(ram, 0, ramSize);
+
+	Flipper::ProcessorInterface::ram = ram;
+	Flipper::ProcessorInterface::ramSize = ramSize;
+
+	Core = new Gekko::GekkoCore();
+
+	// The state that BootROM() leaves behind before the DOL is entered.
+	for (int sr = 0; sr < 16; sr++) Core->regs.sr[sr] = 0x80000000;
+	Core->regs.spr[(int)Gekko::SPR::DBAT0U] = 0x80001fff; Core->regs.spr[(int)Gekko::SPR::DBAT0L] = 0x00000002;
+	Core->regs.spr[(int)Gekko::SPR::DBAT1U] = 0xc0001fff; Core->regs.spr[(int)Gekko::SPR::DBAT1L] = 0x0000002a;
+	Core->regs.spr[(int)Gekko::SPR::IBAT0U] = 0x80001fff; Core->regs.spr[(int)Gekko::SPR::IBAT0L] = 0x00000002;
+	Core->regs.msr |= (MSR_IR | MSR_DR);
+	Core->regs.msr &= ~MSR_EE;
+	Core->regs.msr |= MSR_FP;
+	Core->regs.spr[(int)Gekko::SPR::PVR] = 0x00083214;
+
+	// OS low-memory variables and the stack the IPL hands to the DOL.
+	Core->WriteWord(0x80000028, ramSize);
+	Core->WriteWord(0x8000002c, 1);
+	Core->WriteWord(0x800000f0, ramSize);
+	Core->WriteWord(0x800000f8, CPU_BUS_CLOCK);
+	Core->WriteWord(0x800000fc, CPU_CORE_CLOCK);
+	Core->WriteWord(0x80000034, 0x816ffffc - 0x10000);
+
+	// default syscall handler
+	{
+		static const uint32_t default_syscall[] = { 0x2c01004c, 0xac04007c, 0x6400004c };
+		uint32_t off = (uint32_t)Gekko::Exception::EXCEPTION_SYSTEM_CALL;
+		for (int i = 0; i < 3; i++) *(uint32_t*)&ram[off + i * 4] = _BYTESWAP_UINT32(default_syscall[i]);
+	}
+
+	uint32_t entry = 0;
+	if (const char* raw = getenv("BENCH_RAW"))
+	{
+		std::ifstream f(raw, std::ifstream::binary);
+		if (!f.is_open()) { printf("Cannot open %s\n", raw); return 1; }
+		f.read((char*)&ram[0x1000], 0x100000);
+		entry = 0x80001000;
+		// A game enables the caches early in OSInit; do the same so that the raw
+		// workloads exercise the cached path rather than the PI fallback.
+		Core->cache->Enable(true);
+		Core->icache->Enable(true);
+	}
+	else if (!DOL::Load(dolPath, ram, ramSize, entry))
+	{
+		printf("Cannot load %s\n", dolPath);
+		return 1;
+	}
+
+	Core->regs.gpr[1] = 0x816ffffc;
+	Core->regs.gpr[13] = 0x81100000;
+	Core->regs.pc = entry;
+
+	if (getenv("BENCH_VALIDATE"))
+	{
+		// Decode the loaded program and report anything the decoder does not know.
+		Gekko::DecoderInfo info{};
+		int unknown = 0, total = 0;
+		std::map<int, int> hist;
+		for (uint32_t pa = 0x1000; pa < 0x1000 + 0x100000; pa += 4)
+		{
+			uint32_t w = _BYTESWAP_UINT32(*(uint32_t*)&ram[pa]);
+			if (w == 0) continue;
+			Gekko::Decoder::Decode(0x80000000 + pa, w, &info);
+			total++;
+			hist[(int)info.instr]++;
+			if (info.instr == Gekko::Instruction::Unknown)
+			{
+				if (unknown < 10) printf("unknown opcode %08X at %08X\n", w, 0x80000000 + pa);
+				unknown++;
+			}
+		}
+		printf("validated %d words, %d unknown\n", total, unknown);
+		// Print histogram using the disassembler names
+		std::vector<std::pair<int,int>> v(hist.begin(), hist.end());
+		std::sort(v.begin(), v.end(), [](auto& a, auto& b) { return a.second > b.second; });
+		for (auto& kv : v)
+		{
+			Gekko::DecoderInfo di{};
+			di.instr = (Gekko::Instruction)kv.first;
+			di.numParam = 0;
+			printf("  %6d  %s\n", kv.second, Gekko::GekkoDisasm::InstrToString(&di).c_str());
+		}
+		return 0;
+	}
+
+	if (const char* d = getenv("BENCH_DISASM"))
+	{
+		uint32_t a = strtoul(d, nullptr, 0);
+		uint32_t n = getenv("BENCH_DISASM_N") ? strtoul(getenv("BENCH_DISASM_N"), nullptr, 0) : 64;
+		Gekko::DecoderInfo info{};
+		for (uint32_t i = 0; i < n; i++)
+		{
+			uint32_t w = 0;
+			Core->Fetch(a + i * 4, &w);
+			printf("%08X  %08X  %s\n", a + i * 4, w, Gekko::GekkoDisasm::Disasm(a + i * 4, &info, false, true).c_str());
+		}
+		return 0;
+	}
+
+	printf("Loaded %s, entry %08X, running %llu instructions...\n", dolPath, entry, (unsigned long long)totalSteps);
+
+	uint64_t trace = getenv("BENCH_TRACE") ? strtoull(getenv("BENCH_TRACE"), nullptr, 0) : 0;
+	bool stats = getenv("BENCH_STATS") != nullptr;
+	if (stats) Core->EnableOpcodeStats(true);
+	bool prof = getenv("BENCH_PROF") != nullptr;
+	if (prof) ProfStart();
+
+	if (getenv("BENCH_BRANCH_TEST"))
+	{
+#if !defined(BENCH_WITH_JIT)
+		printf("this build has no recompiler (reference build)\n");
+		return 0;
+#endif
+		return BranchTest();
+	}
+
+	if (const char* ripl = getenv("BENCH_REAL_IPL"))
+	{
+		return RunRealIpl(ripl, getenv("BENCH_IPL_STEPS") ? strtoull(getenv("BENCH_IPL_STEPS"), nullptr, 0) : 20000000,
+			getenv("BENCH_JIT") != nullptr);
+	}
+
+	if (const char* ipl = getenv("BENCH_IPL"))
+	{
+		return RunIpl(ipl, getenv("BENCH_IPL_STEPS") ? strtoull(getenv("BENCH_IPL_STEPS"), nullptr, 0) : 2000000,
+			getenv("BENCH_JIT") != nullptr);
+	}
+
+	if (getenv("BENCH_MINI"))
+	{
+		// One instruction, executed by both engines from a fresh state.
+		uint32_t w = strtoul(getenv("BENCH_MINI"), nullptr, 16);
+		const uint32_t codePa = 0x200000, effPc = 0x80200000;
+		*(uint32_t*)&ram[codePa] = _BYTESWAP_UINT32(w);
+		*(uint32_t*)&ram[0x80010] = _BYTESWAP_UINT32(0x12345678);
+		*(uint32_t*)&ram[0x80014] = _BYTESWAP_UINT32(0x9ABCDEF0);
+		for (int pass = 0; pass < 2; pass++)
+		{
+			Core->Reset();
+			Core->cache->Enable(true); Core->icache->Enable(true);
+			for (int i = 0; i < 16; i++) Core->regs.sr[i] = 0x80000000;
+			Core->regs.spr[(int)Gekko::SPR::DBAT0U] = 0x80001fff; Core->regs.spr[(int)Gekko::SPR::DBAT0L] = 0x00000002;
+			Core->regs.spr[(int)Gekko::SPR::IBAT0U] = 0x80001fff; Core->regs.spr[(int)Gekko::SPR::IBAT0L] = 0x00000002;
+			Core->regs.msr = MSR_IR | MSR_DR | MSR_FP;
+			for (int g = 0; g < 32; g++) Core->regs.gpr[g] = 0x80080010;
+			Core->regs.pc = effPc;
+
+			printf("pass %d before: f13=%016llX gpr5=%08X gpr3=%08X\n", pass,
+				(unsigned long long)Core->regs.fpr[13].uval, Core->regs.gpr[5], Core->regs.gpr[3]);
+#if defined(BENCH_WITH_JIT)
+			if (pass == 0) Core->jit->Run(); else Core->Step();
+#else
+			Core->Step();
+#endif
+			printf("pass %d after : f13=%016llX gpr5=%08X gpr3=%08X gpr6=%08X pc=%08X cr=%08X\n", pass,
+				(unsigned long long)Core->regs.fpr[13].uval, Core->regs.gpr[5], Core->regs.gpr[3], Core->regs.gpr[6], Core->regs.pc, Core->regs.cr);
+		}
+		return 0;
+	}
+
+	if (const char* fz = getenv("BENCH_FUZZ"))
+	{
+		int iters = atoi(fz);
+		int per = getenv("BENCH_FUZZ_N") ? atoi(getenv("BENCH_FUZZ_N")) : 64;
+#if !defined(BENCH_WITH_JIT)
+		printf("this build has no recompiler (reference build)\n");
+		return 0;
+#endif
+		int fails = RunFuzzer(ram, iters, per);
+		return fails == 0 ? 0 : 1;
+	}
+
+#if defined(BENCH_WITH_JIT)
+	bool useJit = getenv("BENCH_JIT") != nullptr;
+#else
+	bool useJit = false;
+#endif
+	bool stateTrace = getenv("BENCH_STATE_TRACE") != nullptr;
+
+	uint64_t done = 0;
+	auto t0 = std::chrono::high_resolution_clock::now();
+
+	while (done < totalSteps)
+	{
+		uint64_t n = totalSteps - done;
+		if (n > chunk) n = chunk;
+
+		for (uint64_t i = 0; i < n; i++)
+		{
+			if (useJit && (uint64_t)Core->GetInstructionCounter() >= totalSteps)
+			{
+				break;
+			}
+#if defined(BENCH_WITH_JIT)
+			if (useJit)
+			{
+				Core->jit->Run();
+				if (stateTrace)
+				{
+					uint64_t h = 1469598103934665603ull;
+					for (int g = 0; g < 32; g++) { h ^= Core->regs.gpr[g]; h *= 1099511628211ull; }
+					printf("%08X %08X %016llX %08X %08X\n", Core->regs.pc, Core->regs.cr, (unsigned long long)h,
+						Core->regs.spr[(int)Gekko::SPR::XER], (uint32_t)Core->regs.tb.uval);
+				}
+				continue;
+			}
+#endif
+			if (trace && !stateTrace)
+			{
+				if (Core->regs.pc == 0x300)
+				{
+					printf("DSI at instruction %llu: DAR=%08X DSISR=%08X\n",
+						(unsigned long long)(done + i),
+						Core->regs.spr[(int)Gekko::SPR::DAR], Core->regs.spr[(int)Gekko::SPR::DSISR]);
+					printf("  r27=%08X r26=%08X r28=%08X r31=%08X\n",
+						Core->regs.gpr[27], Core->regs.gpr[26], Core->regs.gpr[28], Core->regs.gpr[31]);
+					Core->regs.pc = 0;
+					break;
+				}
+				if (done + i < trace) printf("%08X r27=%08X r31=%08X r28=%08X r30=%08X\n", Core->regs.pc, Core->regs.gpr[27], Core->regs.gpr[31], Core->regs.gpr[28], Core->regs.gpr[30]);
+			}
+			Core->Step();
+			if (stateTrace)
+			{
+				uint64_t h = 1469598103934665603ull;
+				for (int g = 0; g < 32; g++) { h ^= Core->regs.gpr[g]; h *= 1099511628211ull; }
+				printf("%08X %08X %016llX %08X %08X\n", Core->regs.pc, Core->regs.cr, (unsigned long long)h,
+					Core->regs.spr[(int)Gekko::SPR::XER], (uint32_t)Core->regs.tb.uval);
+			}
+		}
+		done += n;
+
+		uint32_t pc = Core->regs.pc;
+		if (pc < 0x80000000 || pc >= 0x8C000000)
+		{
+			printf("PC left the game range at instruction %llu: %08X (stopping)\n",
+				(unsigned long long)done, pc);
+			break;
+		}
+	}
+
+	if (stats) Core->EnableOpcodeStats(false);
+
+	if (prof) ProfStop(getenv("BENCH_PROF"));
+
+	auto t1 = std::chrono::high_resolution_clock::now();
+	double sec = std::chrono::duration<double>(t1 - t0).count();
+
+	if (useJit)
+	{
+		done = (uint64_t)Core->GetInstructionCounter();
+	}
+
+	uint64_t hash = HashState(Core, ram, ramSize);
+
+	printf("Executed %llu instructions in %.3f s = %.2f MIPS\n",
+		(unsigned long long)done, sec, done / sec / 1e6);
+	printf("state hash: %016llX\n", (unsigned long long)hash);
+	printf("MMIO reads %llu, writes %llu\n",
+		(unsigned long long)Flipper::ProcessorInterface::mmioReads,
+		(unsigned long long)Flipper::ProcessorInterface::mmioWrites);
+	if (stats)
+	{
+		g_verbose = true;
+		printf("--- opcode stats ---\n");
+		Core->PrintOpcodeStats(25);
+		g_verbose = false;
+	}
+
+	if (getenv("BENCH_REGS"))
+	{
+		printf("--- registers ---\n");
+		for (int i = 0; i < 32; i++) printf("r%-2d = %08X%s", i, Core->regs.gpr[i], (i % 4 == 3) ? "\n" : "  ");
+		printf("cr = %08X  msr = %08X\n", Core->regs.cr, Core->regs.msr);
+	}
+
+	printf("pc=%08X lr=%08X ctr=%08X tb=%llu\n", Core->regs.pc,
+		Core->regs.spr[(int)Gekko::SPR::LR], Core->regs.spr[(int)Gekko::SPR::CTR],
+		(unsigned long long)Core->regs.tb.uval);
+
+	return 0;
+}

--- a/testing/gekko_bench/build.sh
+++ b/testing/gekko_bench/build.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Build the standalone Gekko benchmark from the current working tree.
+#
+#   BENCH   scratch directory (default /tmp/pkbench); the binaries land in $BENCH/build
+#   OPT     extra compiler flags (default -O2)
+#
+# Add -DGEKKO_JIT_TEST_WIN64_SHADOW to OPT for the host-ABI regression build: the
+# emitter then poisons the Win64 shadow space before every helper call, so a block
+# that keeps live values there fails here instead of only on Windows.
+set -e
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+BENCH=${BENCH:-/tmp/pkbench}
+BLD=$BENCH/build
+OPT="${OPT:--O2}"
+
+rm -rf $BLD/src
+mkdir -p $BLD/src
+cp $REPO/src/gekko.cpp $REPO/src/gekkoc.cpp $REPO/src/gekkodec.cpp \
+   $REPO/src/gekkodisasm.cpp $REPO/src/gekkojit.cpp $REPO/src/gqr.h $BLD/src/
+
+g++ -std=c++17 -D_LINUX -DBENCH_WITH_JIT $OPT -fno-strict-aliasing -w \
+    -I$HERE -I$BLD/src -I$REPO/src \
+    $BLD/src/gekko.cpp $BLD/src/gekkoc.cpp $BLD/src/gekkodec.cpp \
+    $BLD/src/gekkodisasm.cpp $BLD/src/gekkojit.cpp \
+    $HERE/stubs.cpp $HERE/bench.cpp $HERE/prof.cpp \
+    -o $BLD/bench -lpthread
+
+echo "built $BLD/bench ($OPT)"

--- a/testing/gekko_bench/build_base.sh
+++ b/testing/gekko_bench/build_base.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Build the reference benchmark from git HEAD (the pre-optimisation interpreter).
+# It is the differential oracle for check.sh.
+set -e
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+BENCH=${BENCH:-/tmp/pkbench}
+BASE=$BENCH/base
+rm -rf $BASE
+mkdir -p $BASE/src
+for f in gekko.cpp gekkoc.cpp gekkodec.cpp gekkodisasm.cpp gqr.h gekko.h gekkoc.h gekkodec.h gekkodisasm.h; do
+    (cd $REPO && git show HEAD:src/$f) > $BASE/src/$f
+done
+
+g++ -std=c++17 -D_LINUX -O2 -fno-strict-aliasing -w \
+    -I$HERE -I$BASE/src \
+    $BASE/src/gekko.cpp $BASE/src/gekkoc.cpp $BASE/src/gekkodec.cpp $BASE/src/gekkodisasm.cpp \
+    $HERE/stubs.cpp $HERE/bench.cpp $HERE/prof.cpp \
+    -o $BASE/bench -lpthread
+
+echo "reference built"

--- a/testing/gekko_bench/check.sh
+++ b/testing/gekko_bench/check.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Compare the state produced by the reference (git HEAD) interpreter, the current
+# interpreter and the JIT. The JIT runs whole basic blocks, so it overshoots the
+# requested instruction count; the interpreter is then run for the exact number of
+# instructions the JIT retired.
+BENCH=${BENCH:-/tmp/pkbench}
+WL=${1:-/tmp/pkbench/workload.bin}
+N=${2:-20000000}
+
+# 1. reference (pre-optimisation interpreter) vs current interpreter at N instructions
+r=$(BENCH_RAW=$WL $BENCH/base/bench dummy $N 1000000 2>&1 | grep "state hash" | awk '{print $3}')
+c=$(BENCH_RAW=$WL $BENCH/build/bench dummy $N 1000000 2>&1 | grep "state hash" | awk '{print $3}')
+
+status=0
+if [ "$r" == "$c" ]; then
+    echo "  interp ref==cur : OK"
+else
+    echo "  interp ref==cur : FAIL ($r vs $c)"
+    status=1
+fi
+
+# 2. JIT vs current interpreter at the same retired instruction count
+jout=$(BENCH_JIT=1 BENCH_RAW=$WL $BENCH/build/bench dummy $N 1000000 2>&1)
+jn=$(echo "$jout" | grep "^Executed" | sed 's/Executed \([0-9]*\) instructions.*/\1/')
+jh=$(echo "$jout" | grep "state hash" | awk '{print $3}')
+ch=$(BENCH_RAW=$WL $BENCH/build/bench dummy $jn 1000000 2>&1 | grep "state hash" | awk '{print $3}')
+
+if [ "$jh" == "$ch" ] && [ -n "$jh" ]; then
+    echo "  jit==interp @$jn : OK"
+else
+    echo "  jit==interp @$jn : FAIL (jit=$jh interp=$ch)"
+    status=1
+fi
+
+exit $status

--- a/testing/gekko_bench/compare.sh
+++ b/testing/gekko_bench/compare.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Throughput of the reference interpreter (git HEAD), the current interpreter and
+# the current recompiler, for every workload.
+BENCH=${BENCH:-/tmp/pkbench}
+N=${1:-30000000}
+DOL=${2:-$(cd "$(dirname "$0")/../.." && pwd)/build/pong.dol}
+
+best() {	# best of three runs of "$@"
+    local b=0 v
+    for i in 1 2 3; do
+        v=$("$@" 2>/dev/null | grep -oE "[0-9.]+ MIPS" | cut -d' ' -f1)
+        b=$(echo "$v $b" | awk '{print ($1>$2)?$1:$2}')
+    done
+    echo "$b"
+}
+
+printf "%-18s %9s %9s %9s %9s\n" workload base interp jit jit/base
+for w in workload.bin workload_alu.bin workload_mem.bin w_win16.bin w_alu100.bin w_alu16000.bin; do
+    [ -f "$BENCH/$w" ] || continue
+    b=$(best env BENCH_RAW=$BENCH/$w $BENCH/base/bench dummy $N 1000000)
+    c=$(best env BENCH_RAW=$BENCH/$w $BENCH/build/bench dummy $N 1000000)
+    j=$(best env BENCH_JIT=1 BENCH_RAW=$BENCH/$w $BENCH/build/bench dummy $N 1000000)
+    printf "%-18s %9s %9s %9s %8sx\n" "$w" "$b" "$c" "$j" "$(echo "$j/$b" | bc -l | cut -c1-5)"
+done
+b=$(best $BENCH/base/bench $DOL 3000000)
+c=$(best $BENCH/build/bench $DOL 3000000)
+j=$(best env BENCH_JIT=1 $BENCH/build/bench $DOL 3000000)
+printf "%-18s %9s %9s %9s %8sx\n" "$(basename $DOL)" "$b" "$c" "$j" "$(echo "$j/$b" | bc -l | cut -c1-5)"

--- a/testing/gekko_bench/gen_ipl.py
+++ b/testing/gekko_bench/gen_ipl.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""
+Generate a synthetic IPL (boot ROM) plus a small "game" program, so that the
+boot path can be exercised without a real boot ROM image.
+
+bootrom.bin  - placed at 0xFFF00100, executed with translation OFF
+game.bin     - placed at 0x80001000, executed after the IPL has enabled BATs,
+               the caches and address translation
+
+The IPL deliberately does what the real one does:
+  * writes the IBAT/DBAT registers,
+  * enables the instruction and data caches through HID0,
+  * enables MSR[IR]/[DR] through mtmsr,
+  * flushes an instruction range with dcbst + icbi + sync per cache line
+    (this is the loop that made the boot slow when one icbi cost a 16K entry walk),
+  * enters the game with bcctr.
+
+The game then raises a DSI on purpose, so that the exception vector, rfi and the
+translation-mode switch are exercised too.
+"""
+
+import struct
+import sys
+
+MASK = 0xFFFFFFFF
+
+
+class Code:
+    def __init__(self):
+        self.words = []
+
+    def emit(self, w):
+        self.words.append(w & MASK)
+
+    def d(self, op, rt, ra, imm):
+        self.emit((op << 26) | (rt << 21) | (ra << 16) | (imm & 0xFFFF))
+
+    def addi(self, rt, ra, si):   self.d(14, rt, ra, si)
+    def addis(self, rt, ra, si):  self.d(15, rt, ra, si)
+    def addic_d(self, rt, ra, si): self.d(13, rt, ra, si)
+    def ori(self, ra, rs, ui):    self.d(24, rs, ra, ui)
+    def oris(self, ra, rs, ui):   self.d(25, rs, ra, ui)
+    def lwz(self, rt, ra, d):     self.d(32, rt, ra, d)
+    def stw(self, rs, ra, d):     self.d(36, rs, ra, d)
+
+    def x(self, rt, ra, rb, xo, rc=0):
+        self.emit((31 << 26) | (rt << 21) | (ra << 16) | (rb << 11) | (xo << 1) | rc)
+
+    def add(self, rt, ra, rb, rc=0): self.x(rt, ra, rb, 266, rc)
+
+    def mfspr(self, rt, spr):
+        self.x(rt, spr & 0x1F, (spr >> 5) & 0x1F, 339)
+
+    def mtspr(self, spr, rs):
+        self.x(rs, spr & 0x1F, (spr >> 5) & 0x1F, 467)
+
+    def bc(self, bo, bi, off):
+        self.emit((16 << 26) | (bo << 21) | (bi << 16) | (off & 0xFFFC))
+
+    def bctr(self):
+        # XO 528 is bcctr; XO 16 would be bclr.
+        self.emit((19 << 26) | (20 << 21) | (528 << 1))
+
+    def isync(self): self.emit(0x4C00012C)
+    def sync(self):  self.emit(0x7C0004AC)
+    def dcbst(self, ra, rb): self.emit((31 << 26) | (ra << 16) | (rb << 11) | (54 << 1))
+    def icbi(self, ra, rb):  self.emit((31 << 26) | (ra << 16) | (rb << 11) | (982 << 1))
+
+
+# SPRs
+DBAT0U, DBAT0L, DBAT1U, DBAT1L = 536, 537, 538, 539
+IBAT0U, IBAT0L = 528, 529
+IBAT1U, IBAT1L = 530, 531
+HID0 = 1008
+SRR0, SRR1 = 26, 27
+LR = 8
+
+
+def bootrom(flushLines):
+    c = Code()
+
+    # DBAT0: 0x80000000, 256 MB, write-back cached  (0x80001FFF / 0x00000002)
+    c.addis(3, 0, 0x8000); c.ori(3, 3, 0x1FFF)
+    c.mtspr(DBAT0U, 3)
+    c.addi(3, 0, 2)
+    c.mtspr(DBAT0L, 3)
+
+    # IBAT0: the same range
+    c.addis(3, 0, 0x8000); c.ori(3, 3, 0x1FFF)
+    c.mtspr(IBAT0U, 3)
+    c.addi(3, 0, 2)
+    c.mtspr(IBAT0L, 3)
+
+    # BAT1: identity map of the 0xF0000000 block (256 MB, which is where the boot ROM
+    # lives), cache inhibited and guarded, so that the IPL stays fetchable once
+    # MSR[IR] is set. BEPI has to be aligned to the block size, so it is 0xF0000000
+    # and not 0xFFF00000.
+    c.addis(3, 0, 0xF000); c.ori(3, 3, 0x1FFF)
+    c.mtspr(DBAT1U, 3)
+    c.mtspr(IBAT1U, 3)
+    c.addis(3, 0, 0xF000); c.ori(3, 3, 0x0028)
+    c.mtspr(DBAT1L, 3)
+    c.mtspr(IBAT1L, 3)
+    c.isync()
+
+    # Enable the instruction and data caches (HID0[ICE] and HID0[DCE])
+    c.mfspr(3, HID0)
+    c.oris(3, 3, 0xC800)
+    c.mtspr(HID0, 3)
+    c.isync()
+
+    # Enable address translation (MSR[IR] | MSR[DR])
+    c.emit(0x7C0000A6)                 # mfmsr r0
+    c.ori(0, 0, 0x30)
+    c.emit(0x7C000124)                 # mtmsr r0
+    c.isync()
+
+    # Flush `flushLines` cache lines of the loaded code: dcbst + icbi + sync each.
+    c.addis(4, 0, 0x8000); c.ori(4, 4, 0x1000)
+    if flushLines < 32768:
+        c.addi(5, 0, flushLines)
+    else:
+        c.addis(5, 0, (flushLines >> 16) & 0xFFFF)
+        if flushLines & 0xFFFF:
+            c.ori(5, 5, flushLines & 0xFFFF)
+    loop = len(c.words)
+    c.dcbst(0, 4)
+    c.icbi(0, 4)
+    c.sync()
+    c.addi(4, 4, 32)
+    c.addic_d(5, 5, -1)                # addic. r5, r5, -1
+    off = (loop - len(c.words)) * 4
+    c.bc(4, 2, off)                    # bne loop
+    c.isync()
+
+    # Enter the game: bctr to 0x80001000
+    c.addis(4, 0, 0x8000); c.ori(4, 4, 0x1000)
+    c.mtspr(9, 4)                      # mtspr CTR, r4
+    c.bctr()
+
+    return c.words
+
+
+def game(iterations):
+    c = Code()
+
+    # A little arithmetic loop over memory at 0x80100000, then a deliberate fault.
+    c.addis(10, 0, 0x8010)             # r10 = data base
+    c.addi(11, 0, 0)                   # counter
+    loop = len(c.words)
+    c.lwz(12, 10, 0)
+    c.add(12, 12, 11)
+    c.stw(12, 10, 0)
+    c.addi(11, 11, 1)
+    c.addic_d(0, 11, 0)                # addic. r0, r11, 0  (sets CR0)
+    off = (loop - len(c.words)) * 4
+    c.bc(4, 2, off)                    # bne loop
+
+    # Deliberate DSI: 0x10000000 is not covered by any BAT and segment 0 is a
+    # direct-store segment, so the access raises a DSI. The vector at 0x300 skips
+    # the instruction and returns with rfi, which flips MSR[IR]/[DR].
+    c.addis(13, 0, 0x1000)
+    c.lwz(14, 13, 0)
+
+    # Keep going after the handler returns.
+    c.addi(11, 0, 0)
+    tail = len(c.words)
+    c.addi(11, 11, 1)
+    c.addic_d(0, 11, 0)
+    off = (tail - len(c.words)) * 4
+    c.bc(4, 2, off)
+
+    return c.words
+
+
+def ipl2():
+    """A stand-in for the second stage IPL: uses bclrl as a "call through LR" thunk,
+    which is exactly the idiom the real IPL2 entry code uses."""
+    c = Code()
+
+    c.addis(3, 0, 0x8080); c.ori(3, 3, 0x0000)   # data pointer
+    c.addi(5, 0, 200)                            # loop counter
+
+    loop = len(c.words)
+    call = len(c.words)
+    c.emit(0)                                    # place holder for 'bl thunk'
+    # ret1:
+    c.lwz(6, 3, 0)
+    c.addi(6, 6, 1)
+    c.stw(6, 3, 0)
+    c.addic_d(5, 5, -1)                          # addic. r5, r5, -1
+    off = (loop - len(c.words)) * 4
+    c.bc(4, 2, off)                              # bne loop
+    c.emit(0)                                    # place holder for 'b _start'
+
+    thunk = len(c.words)
+    # bclrl: LR_new = pc+4, pc = LR_old. XO 16 with LK=1, BO=20 (always).
+    c.emit((19 << 26) | (20 << 21) | ((16 << 1) | 1))
+    c.emit(0x60000000)                           # the instruction after the thunk
+
+    # patch the call: bl thunk
+    c.words[call] = (18 << 26) | 1 | (((thunk - call) * 4) & 0x03FFFFFC)
+    # patch the restart
+    c.words[thunk - 1] = (18 << 26) | ((0 - (thunk - 1)) * 4 & 0x03FFFFFC)
+
+    return c.words
+
+
+def main():
+    out = sys.argv[1]
+    lines = int(sys.argv[2]) if len(sys.argv) > 2 else 64
+    iters = int(sys.argv[3]) if len(sys.argv) > 3 else 1000
+
+    with open(out + "_bootrom.bin", "wb") as f:
+        f.write(b"".join(struct.pack(">I", w) for w in bootrom(lines)))
+    with open(out + "_game.bin", "wb") as f:
+        f.write(b"".join(struct.pack(">I", w) for w in game(iters)))
+    with open(out + "_ipl2.bin", "wb") as f:
+        f.write(b"".join(struct.pack(">I", w) for w in ipl2()))
+    print("wrote %s_bootrom.bin, %s_game.bin and %s_ipl2.bin" % (out, out, out))
+
+
+if __name__ == "__main__":
+    main()

--- a/testing/gekko_bench/gen_selfmod.py
+++ b/testing/gekko_bench/gen_selfmod.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+Self-modifying-code probe for the Gekko interpreter.
+
+The program warms up the decode cache on the `victim` instruction, rewrites that
+instruction in memory, flushes the data cache and invalidates the instruction
+cache, and then executes the same address again.
+
+If the emulator serves a stale decode (or a stale instruction fetch), r5 ends up
+as 0 instead of 0x1111.
+
+Two variants are emitted (the harness picks one):
+  variant 0 - full dance: stw + dcbst + sync + icbi + isync  -> r5 must be 0x1111
+  variant 1 - no flush at all                                 -> r5 must stay 0
+"""
+
+import struct
+import sys
+
+MASK = 0xFFFFFFFF
+
+
+def emit(words, w):
+    words.append(w & MASK)
+
+
+def d(op, rt, ra, imm):
+    return (op << 26) | (rt << 21) | (ra << 16) | (imm & 0xFFFF)
+
+
+def x(rt, ra, rb, xo, rc=0):
+    return (31 << 26) | (rt << 21) | (ra << 16) | (rb << 11) | (xo << 1) | rc
+
+
+def build(variant):
+    w = []
+
+    # --- prologue: warm up the decode cache on the victim instruction --------
+    emit(w, 0x48000005)             # bl +4   (LR = address of the next word)
+    emit(w, 0x7C6802A6)             # mflr r3  -> r3 = 0x80001004
+    emit(w, d(14, 3, 3, 12))        # addi r3, r3, 12 -> &victim
+    emit(w, d(14, 10, 0, 0))        # li   r10, 0
+
+    loop_back = len(w)
+    victim_index = len(w)
+    emit(w, 0x38A00000)             # victim: li r5, 0
+    emit(w, d(14, 10, 10, 1))       # addi r10, r10, 1
+    emit(w, 0x2C0A0064)             # cmpi cr0, r10, 100
+    # bne cr0, loop
+    bne_index = len(w)
+    emit(w, 0)
+    off = (loop_back - bne_index) * 4
+    w[bne_index] = (16 << 26) | (4 << 21) | (2 << 16) | (off & 0xFFFC)
+
+    if variant == 0:
+        # --- rewrite the victim instruction ---------------------------------
+        emit(w, 0x3C8038A0)         # lis  r4, 0x38A0
+        emit(w, 0x60841111)         # ori  r4, r4, 0x1111  -> "li r5, 0x1111"
+        emit(w, 0x90830000)         # stw  r4, 0(r3)
+        emit(w, 0x7C00186C)         # dcbst 0, r3
+        emit(w, 0x7C0004AC)         # sync
+        emit(w, 0x7C001FAC)         # icbi 0, r3
+        emit(w, 0x4C00012C)         # isync
+
+    # --- run the victim again ------------------------------------------------
+    b_index = len(w)
+    emit(w, 0)
+    off = (victim_index - b_index) * 4
+    w[b_index] = (18 << 26) | (off & 0x03FFFFFC)
+
+    return w
+
+
+def main():
+    out = sys.argv[1]
+    variant = int(sys.argv[2]) if len(sys.argv) > 2 else 0
+    words = build(variant)
+    with open(out, "wb") as f:
+        f.write(b"".join(struct.pack(">I", x) for x in words))
+    print(f"wrote {out}: {len(words)} instructions, variant {variant}")
+
+
+if __name__ == "__main__":
+    main()

--- a/testing/gekko_bench/gen_workload.py
+++ b/testing/gekko_bench/gen_workload.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""
+Generate a synthetic PowerPC (Gekko) workload for the standalone interpreter
+benchmark.  The blob is loaded at physical 0x1000 and entered at 0x80001000.
+
+The instruction mix is roughly what GameCube game code looks like:
+integer ALU ~35%, loads ~20%, stores ~10%, branches ~14%, compare ~8%,
+floating point ~8%, paired single ~5%.
+
+Usage: gen_workload.py <out.bin> [--body N] [--seed S]
+"""
+
+import random
+import struct
+import sys
+
+MASK32 = 0xFFFFFFFF
+
+
+class Code:
+    def __init__(self):
+        self.words = []
+
+    def emit(self, w):
+        self.words.append(w & MASK32)
+
+    # ---- D-form -----------------------------------------------------------
+    def d(self, op, rt, ra, imm):
+        self.emit((op << 26) | (rt << 21) | (ra << 16) | (imm & 0xFFFF))
+
+    def addi(self, rt, ra, si):   self.d(14, rt, ra, si)
+    def addis(self, rt, ra, si):  self.d(15, rt, ra, si)
+    def mulli(self, rt, ra, si):  self.d(7, rt, ra, si)
+    def subfic(self, rt, ra, si): self.d(8, rt, ra, si)
+    def ori(self, ra, rs, ui):    self.d(24, rs, ra, ui)
+    def oris(self, ra, rs, ui):   self.d(25, rs, ra, ui)
+    def xori(self, ra, rs, ui):   self.d(26, rs, ra, ui)
+    def andi_d(self, ra, rs, ui): self.d(28, rs, ra, ui)
+    def andis_d(self, ra, rs, ui): self.d(29, rs, ra, ui)
+    def lwz(self, rt, ra, d):     self.d(32, rt, ra, d)
+    def lbz(self, rt, ra, d):     self.d(34, rt, ra, d)
+    def stw(self, rs, ra, d):     self.d(36, rs, ra, d)
+    def stb(self, rs, ra, d):     self.d(38, rs, ra, d)
+    def lhz(self, rt, ra, d):     self.d(40, rt, ra, d)
+    def lha(self, rt, ra, d):     self.d(42, rt, ra, d)
+    def sth(self, rs, ra, d):     self.d(44, rs, ra, d)
+    def lfs(self, frt, ra, d):    self.d(48, frt, ra, d)
+    def lfd(self, frt, ra, d):    self.d(50, frt, ra, d)
+    def stfs(self, frs, ra, d):   self.d(52, frs, ra, d)
+    def stfd(self, frs, ra, d):   self.d(54, frs, ra, d)
+    def cmpi(self, bf, ra, si):   self.emit((11 << 26) | (bf << 23) | (ra << 16) | (si & 0xFFFF))
+    def cmpli(self, bf, ra, ui):  self.emit((10 << 26) | (bf << 23) | (1 << 22) | (ra << 16) | (ui & 0xFFFF))
+
+    # ---- X-form (opcode 31) ----------------------------------------------
+    def x(self, rt, ra, rb, xo, rc=0):
+        self.emit((31 << 26) | (rt << 21) | (ra << 16) | (rb << 11) | (xo << 1) | rc)
+
+    def add(self, rt, ra, rb, rc=0):  self.x(rt, ra, rb, 266, rc)
+    def addc(self, rt, ra, rb, rc=0): self.x(rt, ra, rb, 10, rc)
+    def adde(self, rt, ra, rb, rc=0): self.x(rt, ra, rb, 138, rc)
+    def subf(self, rt, ra, rb, rc=0): self.x(rt, ra, rb, 40, rc)
+    def neg(self, rt, ra, rc=0):      self.x(rt, ra, 0, 104, rc)
+    def mullw(self, rt, ra, rb, rc=0): self.x(rt, ra, rb, 235, rc)
+    def mulhw(self, rt, ra, rb, rc=0): self.x(rt, ra, rb, 75, rc)
+    def divw(self, rt, ra, rb, rc=0): self.x(rt, ra, rb, 491, rc)
+    def _and(self, ra, rs, rb, rc=0): self.x(rs, ra, rb, 28, rc)
+    def _or(self, ra, rs, rb, rc=0):  self.x(rs, ra, rb, 444, rc)
+    def _xor(self, ra, rs, rb, rc=0): self.x(rs, ra, rb, 316, rc)
+    def nand(self, ra, rs, rb, rc=0): self.x(rs, ra, rb, 476, rc)
+    def nor(self, ra, rs, rb, rc=0):  self.x(rs, ra, rb, 124, rc)
+    def andc(self, ra, rs, rb, rc=0): self.x(rs, ra, rb, 60, rc)
+    def slw(self, ra, rs, rb, rc=0):  self.x(rs, ra, rb, 24, rc)
+    def srw(self, ra, rs, rb, rc=0):  self.x(rs, ra, rb, 536, rc)
+    def sraw(self, ra, rs, rb, rc=0): self.x(rs, ra, rb, 792, rc)
+    def cntlzw(self, ra, rs, rc=0):   self.x(rs, ra, 0, 26, rc)
+    def extsb(self, ra, rs, rc=0):    self.x(rs, ra, 0, 954, rc)
+    def extsh(self, ra, rs, rc=0):    self.x(rs, ra, 0, 922, rc)
+    def lwzx(self, rt, ra, rb):       self.x(rt, ra, rb, 23)
+    def lhzx(self, rt, ra, rb):       self.x(rt, ra, rb, 279)
+    def lbzx(self, rt, ra, rb):       self.x(rt, ra, rb, 87)
+    def lhax(self, rt, ra, rb):       self.x(rt, ra, rb, 343)
+    def stwx(self, rs, ra, rb):       self.x(rs, ra, rb, 151)
+    def sthx(self, rs, ra, rb):       self.x(rs, ra, rb, 407)
+    def stbx(self, rs, ra, rb):       self.x(rs, ra, rb, 215)
+    def cmpw(self, bf, ra, rb):       self.emit((31 << 26) | (bf << 23) | (ra << 16) | (rb << 11) | (0 << 1))
+    def cmplw(self, bf, ra, rb):      self.emit((31 << 26) | (bf << 23) | (1 << 22) | (ra << 16) | (rb << 11) | (32 << 1))
+    def mfspr(self, rt, spr):
+        # SPR[0:4] sits in the RA field, SPR[5:9] in the RB field.
+        self.x(rt, spr & 0x1F, (spr >> 5) & 0x1F, 339)
+    def mtspr(self, spr, rs):
+        self.x(rs, spr & 0x1F, (spr >> 5) & 0x1F, 467)
+    def mftb(self, rt, tbr):
+        self.x(rt, tbr & 0x1F, (tbr >> 5) & 0x1F, 371)
+
+    # ---- Rotate (opcode 20/21/23) ----------------------------------------
+    def rlwinm(self, ra, rs, sh, mb, me, rc=0):
+        self.emit((21 << 26) | (rs << 21) | (ra << 16) | (sh << 11) | (mb << 6) | (me << 1) | rc)
+    def rlwimi(self, ra, rs, sh, mb, me, rc=0):
+        self.emit((20 << 26) | (rs << 21) | (ra << 16) | (sh << 11) | (mb << 6) | (me << 1) | rc)
+    def rlwnm(self, ra, rs, rb, mb, me, rc=0):
+        self.emit((23 << 26) | (rs << 21) | (ra << 16) | (rb << 11) | (mb << 6) | (me << 1) | rc)
+    def srawi(self, ra, rs, sh, rc=0):
+        self.emit((31 << 26) | (rs << 21) | (ra << 16) | (sh << 11) | (824 << 1) | rc)
+
+    # ---- Branches ---------------------------------------------------------
+    def b(self, off):     self.emit((18 << 26) | (off & 0x03FFFFFC))
+    def bl(self, off):    self.emit((18 << 26) | (off & 0x03FFFFFC) | 1)
+    def bc(self, bo, bi, off): self.emit((16 << 26) | (bo << 21) | (bi << 16) | (off & 0xFFFC))
+    def bdnz(self, off):  self.bc(16, 0, off)
+    def bne(self, crb, off): self.bc(4, crb, off)
+    def beq(self, crb, off): self.bc(12, crb, off)
+    def bgt(self, crb, off): self.bc(12, crb + 1, off)
+    def bclr(self):       self.emit((19 << 26) | (20 << 21) | (16 << 1))
+
+    # ---- FP (opcode 63 / 59) ---------------------------------------------
+    def a(self, op, frt, fra, frb, frc, xo, rc=0):
+        self.emit((op << 26) | (frt << 21) | (fra << 16) | (frb << 11) | (frc << 6) | (xo << 1) | rc)
+
+    def fadd(self, frt, fra, frb, rc=0):  self.a(63, frt, fra, frb, 0, 21, rc)
+    def fadds(self, frt, fra, frb, rc=0): self.a(59, frt, fra, frb, 0, 21, rc)
+    def fsub(self, frt, fra, frb, rc=0):  self.a(63, frt, fra, frb, 0, 20, rc)
+    def fmul(self, frt, fra, frc, rc=0):  self.a(63, frt, fra, 0, frc, 25, rc)
+    def fmuls(self, frt, fra, frc, rc=0): self.a(59, frt, fra, 0, frc, 25, rc)
+    def fdiv(self, frt, fra, frb, rc=0):  self.a(63, frt, fra, frb, 0, 18, rc)
+    def fmadd(self, frt, fra, frc, frb, rc=0): self.a(63, frt, fra, frb, frc, 29, rc)
+    def frsp(self, frt, frb, rc=0):       self.a(63, frt, 0, frb, 0, 12, rc)
+    def fcmpu(self, bf, fra, frb):        self.a(63, bf, fra, frb, 0, 0)
+    def fcmpo(self, bf, fra, frb):        self.a(63, bf, fra, frb, 0, 32)
+    def fmr(self, frt, frb, rc=0):        self.a(63, frt, 0, frb, 0, 72, rc)
+    def fneg(self, frt, frb, rc=0):       self.a(63, frt, 0, frb, 0, 40, rc)
+
+    # ---- Paired single (opcode 4) ----------------------------------------
+    def ps(self, frt, fra, frb, frc, xo, rc=0):
+        self.emit((4 << 26) | (frt << 21) | (fra << 16) | (frb << 11) | (frc << 6) | (xo << 1) | rc)
+
+    def ps_add(self, d, a, b, rc=0):    self.ps(d, a, b, 0, 21, rc)
+    def ps_sub(self, d, a, b, rc=0):    self.ps(d, a, b, 0, 20, rc)
+    def ps_mul(self, d, a, c, rc=0):    self.ps(d, a, 0, c, 25, rc)
+    def ps_madd(self, d, a, c, b, rc=0): self.ps(d, a, b, c, 29, rc)
+    def ps_merge00(self, d, a, b, rc=0): self.ps(d, a, b, 0, 528, rc)
+    def ps_sum0(self, d, a, b, c, rc=0): self.ps(d, a, b, c, 10, rc)
+
+    # ---- misc -------------------------------------------------------------
+    def sync(self): self.emit(0x7C0004AC)
+    def nop(self):  self.emit(0x60000000)
+
+
+GP = [f"r{i}" for i in range(32)]
+FP = [f"f{i}" for i in range(32)]
+
+
+def generate(body_instrs, seed, mix="full", window_mb=4):
+    rnd = random.Random(seed)
+    c = Code()
+
+    # Integer registers used as "live" data (avoid r27-r31 which are pointers).
+    live = list(range(2, 26))   # r26 is a fixed small index register
+    flive = list(range(0, 16))
+
+    def r():  return rnd.choice(live)
+    def r2(): 
+        a = rnd.choice(live)
+        b = rnd.choice(live)
+        return a, b
+    def f():  return rnd.choice(flive)
+
+    def mem_disp(size):
+        # displacement inside a 32 KB window, aligned and inside RAM
+        return rnd.randrange(0, 32768 - size) & ~(size - 1)
+
+    ops = []
+
+    # Prologue: r31 = data base (effective 0x80800000), r28 = offset, r27 = ptr
+    c.addis(31, 0, 0x8080)          # r31 = 0x80800000
+    c.addi(28, 0, 0)                # offset
+    c.addi(26, 0, 0x1000)           # fixed small index for the X-form accesses
+    c.addi(30, 0, 0)                # loop counter / cratch
+    c.add(27, 31, 28)               # ptr = base + offset
+
+    body_start = len(c.words)
+
+    if mix == "one":
+        weights = [("one", 1)]
+    elif mix == "alu":
+        weights = [("alu", 70), ("cmp", 14), ("branch", 14), ("misc", 2)]
+    elif mix == "mem":
+        weights = [("alu", 20), ("load", 30), ("store", 20), ("branch", 14), ("cmp", 8), ("misc", 8)]
+    else:
+        weights = [
+            ("alu",      34),
+            ("load",     19),
+            ("store",    10),
+            ("branch",   14),
+            ("cmp",       8),
+            ("fp",        9),
+            ("ps",        5),
+            ("misc",      6),
+        ]
+    total = sum(w for _, w in weights)
+    table = []
+    for name, w in weights:
+        table += [name] * w
+
+    for i in range(body_instrs):
+        k = rnd.choice(table)
+        rt = r()
+        a, b = r2()
+
+        if k == "one":
+            c.add(3, 4, 5)
+        elif k == "alu":
+            choice = rnd.randrange(0, 14)
+            if choice == 0:   c.add(rt, a, b, rnd.randrange(0, 4) == 0)
+            elif choice == 1: c.addi(rt, a, rnd.randrange(-32768, 32767))
+            elif choice == 2: c.addis(rt, a, rnd.randrange(-32768, 32767))
+            elif choice == 3: c._or(rt, a, b, rnd.randrange(0, 4) == 0)
+            elif choice == 4: c._and(rt, a, b, rnd.randrange(0, 4) == 0)
+            elif choice == 5: c._xor(rt, a, b)
+            elif choice == 6: c.subf(rt, a, b)
+            elif choice == 7: c.rlwinm(rt, a, rnd.randrange(0, 32), rnd.randrange(0, 32), rnd.randrange(0, 32), rnd.randrange(0, 4) == 0)
+            elif choice == 8: c.slw(rt, a, b)
+            elif choice == 9: c.srw(rt, a, b)
+            elif choice == 10: c.srawi(rt, a, rnd.randrange(0, 32))
+            elif choice == 11: c.mullw(rt, a, b)
+            elif choice == 12: c.ori(rt, a, rnd.randrange(0, 65536))
+            else: c.cntlzw(rt, a)
+        elif k == "load":
+            choice = rnd.randrange(0, 6)
+            if choice == 0:   c.lwz(rt, 27, mem_disp(4))
+            elif choice == 1: c.lwzx(rt, 27, 26)
+            elif choice == 2: c.lhz(rt, 27, mem_disp(2))
+            elif choice == 3: c.lbz(rt, 27, mem_disp(1))
+            elif choice == 4: c.lha(rt, 27, mem_disp(2))
+            else:             c.lwz(rt, 27, mem_disp(4))
+        elif k == "store":
+            choice = rnd.randrange(0, 5)
+            if choice == 0:   c.stw(a, 27, mem_disp(4))
+            elif choice == 1: c.stwx(a, 27, 26)
+            elif choice == 2: c.sth(a, 27, mem_disp(2))
+            elif choice == 3: c.stb(a, 27, mem_disp(1))
+            else:             c.stw(a, 27, mem_disp(4))
+        elif k == "cmp":
+            crf = rnd.randrange(0, 8)
+            choice = rnd.randrange(0, 4)
+            if choice == 0:   c.cmpi(crf, a, rnd.randrange(-32768, 32767))
+            elif choice == 1: c.cmpli(crf, a, rnd.randrange(0, 65535))
+            elif choice == 2: c.cmpw(crf, a, b)
+            else:             c.cmplw(crf, a, b)
+        elif k == "fp":
+            choice = rnd.randrange(0, 8)
+            d = f()
+            if choice == 0:   c.fadd(d, f(), f())
+            elif choice == 1: c.fadds(d, f(), f())
+            elif choice == 2: c.fsub(d, f(), f())
+            elif choice == 3: c.fmul(d, f(), f())
+            elif choice == 4: c.fmuls(d, f(), f())
+            elif choice == 5: c.fmadd(d, f(), f(), f())
+            elif choice == 6: c.frsp(d, f())
+            else:             c.fcmpu(rnd.randrange(0, 8), f(), f())
+        elif k == "ps":
+            choice = rnd.randrange(0, 6)
+            d = f()
+            if choice == 0:   c.ps_add(d, f(), f())
+            elif choice == 1: c.ps_sub(d, f(), f())
+            elif choice == 2: c.ps_mul(d, f(), f())
+            elif choice == 3: c.ps_madd(d, f(), f(), f())
+            elif choice == 4: c.ps_merge00(d, f(), f())
+            else:             c.ps_sum0(d, f(), f(), f())
+        elif k == "branch":
+            choice = rnd.randrange(0, 8)
+            if choice <= 4:   c.bc(4, rnd.randrange(0, 32), 8)     # branch if CR bit clear
+            elif choice == 5: c.bc(12, rnd.randrange(0, 32), 8)    # branch if CR bit set
+            elif choice == 6: c.bc(4, rnd.randrange(0, 32), 12)
+            else:             c.bc(12, rnd.randrange(0, 32), 12)
+        elif k == "misc":
+            choice = rnd.randrange(0, 6)
+            if choice == 0:   c.mfspr(rt, 1)          # XER
+            elif choice == 1: c.mfspr(rt, 8)          # LR
+            elif choice == 2: c.mftb(rt, 268)         # TBL
+            elif choice == 3: c.extsb(rt, a)
+            elif choice == 4: c.extsh(rt, a)
+            else:             c.nor(rt, a, b)
+
+    body_end = len(c.words)
+
+    # Loop tail: advance the pointer, close the loop.
+    c.addi(28, 28, 64)
+    # offset = offset & (window - 1); MB=32-window_bits
+    wbits = (window_mb * 1024 * 1024).bit_length() - 1
+    c.rlwinm(28, 28, 0, 32 - wbits, 31)
+    c.add(27, 31, 28)               # ptr = base + offset
+    c.addi(30, 30, 1)
+    c.cmpi(0, 30, 0)                # CR0 = (counter == 0)
+    c.beq(2, 4)                     # not taken in practice
+    c.beq(2, 8)                     # not taken in practice
+    b_idx = len(c.words)
+    c.b(0)
+    off = (body_start - b_idx) * 4
+    c.words[b_idx] = (18 << 26) | (off & 0x03FFFFFC)
+
+    return c.words, body_start
+
+
+def main():
+    out = sys.argv[1]
+    body = 2000
+    seed = 12345
+    mix = "full"
+    window_mb = 4
+    args = sys.argv[2:]
+    i = 0
+    while i < len(args):
+        if args[i] == "--body":
+            body = int(args[i + 1]); i += 2
+        elif args[i] == "--seed":
+            seed = int(args[i + 1]); i += 2
+        elif args[i] == "--mix":
+            mix = args[i + 1]; i += 2
+        elif args[i] == "--window":
+            window_mb = int(args[i + 1]); i += 2
+        else:
+            i += 1
+
+    words, body_start = generate(body, seed, mix, window_mb)
+    data = b"".join(struct.pack(">I", w) for w in words)
+    with open(out, "wb") as f:
+        f.write(data)
+    print(f"wrote {out}: {len(words)} instructions ({len(data)} bytes), entry 0x80001000, body starts at word {body_start}")
+
+
+if __name__ == "__main__":
+    main()

--- a/testing/gekko_bench/pch.h
+++ b/testing/gekko_bench/pch.h
@@ -1,0 +1,156 @@
+// Standalone benchmark stub for the pureikyubu Gekko core.
+// Replaces src/pch.h so that gekko.cpp / gekkoc.cpp / gekkodec.cpp can be built
+// without SDL / GL / ImGui and without the rest of Flipper.
+
+#pragma once
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
+#include <cstdarg>
+#include <string>
+#include <vector>
+#include <list>
+#include <map>
+#include <unordered_map>
+#include <atomic>
+#include <cassert>
+#include <cmath>
+#include <ctime>
+#include <limits.h>
+
+extern bool g_verbose;
+
+#ifdef _LINUX
+#include <byteswap.h>
+#define _BYTESWAP_UINT16 __bswap_16
+#define _BYTESWAP_UINT32 __bswap_32
+#define _BYTESWAP_UINT64 __bswap_64
+#else
+#include <intrin.h>
+#define _BYTESWAP_UINT16 _byteswap_ushort
+#define _BYTESWAP_UINT32 _byteswap_ulong
+#define _BYTESWAP_UINT64 _byteswap_uint64
+#endif
+
+#ifdef _LINUX
+#define CNTLZ(mask) __builtin_clz(mask)
+#else
+#define CNTLZ(mask) __lzcnt(mask)
+#endif
+
+// ---------------------------------------------------------------------------
+// Debug (stub)
+
+namespace Debug
+{
+	enum class Channel
+	{
+		Void = 0,
+		Norm, Info, Error, Header,
+		CP, PE, VI, GP, PI, CPU, MI, DSP, DI, AR, AI, AIS, SI, EXI, MC, DVD, AX,
+		Loader, HLE,
+	};
+
+	void Halt(const char* text, ...);
+	void Report(Channel chan, const char* text, ...);
+}
+
+// ---------------------------------------------------------------------------
+// Threading (stub - the benchmark never actually spawns emulator threads)
+
+class SpinLock
+{
+	std::atomic_flag locked = ATOMIC_FLAG_INIT;
+public:
+	void Lock() { while (locked.test_and_set(std::memory_order_acquire)) {} }
+	void Unlock() { locked.clear(std::memory_order_release); }
+};
+
+typedef void (*ThreadProc)(void* param);
+
+class Thread
+{
+public:
+	Thread(ThreadProc proc, bool suspended, void* context, const char* name) {}
+	~Thread() {}
+	void Resume() {}
+	void Suspend() {}
+	bool IsRunning() { return false; }
+	const char* GetName() { return "stub"; }
+	static void Sleep(size_t ms) {}
+};
+
+Thread* EMUCreateThread(ThreadProc threadProc, bool suspended, void* context, const char* name);
+void EMUJoinThread(Thread* thread);
+
+// ---------------------------------------------------------------------------
+// Gekko core headers
+
+#include "gekkodec.h"
+#include "gekko.h"
+#include "gekkoc.h"
+#if defined(BENCH_WITH_JIT)
+#include "gekkojit.h"
+#endif
+#include "gekkodisasm.h"
+
+// ---------------------------------------------------------------------------
+// Flipper PI / MEM (stub)
+
+#define PI_MEMSPACE_BOOTROM     0xFFF0'0000
+#define HW_BASE                 0x0C000000
+
+namespace Flipper
+{
+	class ProcessorInterface
+	{
+	public:
+		// Main memory (flat, backing store is provided by the harness)
+		static uint8_t* ram;
+		static uint32_t ramSize;
+
+		// Optional boot ROM image, served for physical addresses >= 0xFFF00000.
+		static uint8_t* bootrom;
+		static uint32_t bootromSize;
+
+		// Statistics used by the harness
+		static uint64_t mmioReads;
+		static uint64_t mmioWrites;
+
+		__attribute__((always_inline)) static uint8_t* RamPtr(uint32_t pa)
+		{
+			return (pa < ramSize) ? &ram[pa] : nullptr;
+		}
+
+		// Returns a pointer into the boot ROM image, or nullptr when the address is
+		// outside it (or outside the requested access size).
+		__attribute__((always_inline)) static uint8_t* BootromPtr(uint32_t pa, uint32_t need)
+		{
+			if (bootrom == nullptr || pa < PI_MEMSPACE_BOOTROM) return nullptr;
+			uint32_t off = pa - PI_MEMSPACE_BOOTROM;
+			return (off + need <= bootromSize) ? &bootrom[off] : nullptr;
+		}
+
+		void PIReadByte(uint32_t pa, uint32_t* reg);
+		void PIReadHalf(uint32_t pa, uint32_t* reg);
+		void PIReadWord(uint32_t pa, uint32_t* reg);
+		void PIReadDouble(uint32_t pa, uint64_t* reg);
+		void PIWriteByte(uint32_t pa, uint32_t data);
+		void PIWriteHalf(uint32_t pa, uint32_t data);
+		void PIWriteWord(uint32_t pa, uint32_t data);
+		void PIWriteDouble(uint32_t pa, uint64_t* data);
+		void PIReadBurst(uint32_t phys_addr, uint8_t burstData[32]);
+		void PIWriteBurst(uint32_t phys_addr, uint8_t burstData[32]);
+	};
+
+	struct FlipperStub
+	{
+		ProcessorInterface* pi;
+	};
+
+	extern FlipperStub* HW;
+}
+
+extern Gekko::GekkoCore* Core;

--- a/testing/gekko_bench/prof.cpp
+++ b/testing/gekko_bench/prof.cpp
@@ -1,0 +1,54 @@
+// Poor man's sampling profiler for the standalone Gekko benchmark.
+// Records the interrupted instruction pointer (host) with SIGPROF; the addresses
+// are resolved afterwards with addr2line.
+
+#include <execinfo.h>
+#include <signal.h>
+#include <sys/time.h>
+#include <ucontext.h>
+#include <unistd.h>
+#include <cstdio>
+#include <cstddef>
+
+#define MAX_SAMPLES (4 * 1024 * 1024)
+
+static void* g_samples[MAX_SAMPLES];
+static volatile size_t g_sampleCount = 0;
+
+static void ProfHandler(int sig, siginfo_t* info, void* ctx)
+{
+	ucontext_t* uc = (ucontext_t*)ctx;
+	void* ip = (void*)uc->uc_mcontext.gregs[REG_RIP];
+
+	if (g_sampleCount < MAX_SAMPLES)
+	{
+		g_samples[g_sampleCount++] = ip;
+	}
+}
+
+void ProfStart()
+{
+	struct sigaction sa{};
+	sa.sa_sigaction = ProfHandler;
+	sa.sa_flags = SA_SIGINFO | SA_RESTART;
+	sigaction(SIGPROF, &sa, nullptr);
+
+	struct itimerval tv{};
+	tv.it_interval.tv_usec = 100;		// 10 kHz
+	tv.it_value.tv_usec = 100;
+	setitimer(ITIMER_PROF, &tv, nullptr);
+}
+
+void ProfStop(const char* outPath)
+{
+	struct itimerval tv{};
+	setitimer(ITIMER_PROF, &tv, nullptr);
+
+	FILE* f = fopen(outPath, "w");
+	for (size_t i = 0; i < g_sampleCount; i++)
+	{
+		fprintf(f, "%p\n", g_samples[i]);
+	}
+	fclose(f);
+	fprintf(stderr, "profiler: %zu samples -> %s\n", g_sampleCount, outPath);
+}

--- a/testing/gekko_bench/stubs.cpp
+++ b/testing/gekko_bench/stubs.cpp
@@ -1,0 +1,171 @@
+// Standalone benchmark stubs for the pureikyubu Gekko core.
+
+#include "pch.h"
+#include <csetjmp>
+
+jmp_buf g_fuzzJmp;
+bool g_fuzzActive = false;
+
+// ---------------------------------------------------------------------------
+// Debug
+
+bool g_verbose = false;
+
+namespace Debug
+{
+	void Halt(const char* text, ...)
+	{
+		va_list arg;
+		char buf[0x1000];
+		va_start(arg, text);
+		vsprintf(buf, text, arg);
+		va_end(arg);
+
+		printf("HALT: %s\n", buf);
+		if (Core)
+		{
+			printf("  pc=%08X r3=%08X r4=%08X r10=%08X msr=%08X sr0=%08X\n",
+				Core->regs.pc, Core->regs.gpr[3], Core->regs.gpr[4], Core->regs.gpr[10],
+				Core->regs.msr, Core->regs.sr[0]);
+			printf("  SRR1=%08X IBAT1U=%08X IBAT1L=%08X\n",
+				Core->regs.spr[(int)Gekko::SPR::SRR1],
+				Core->regs.spr[(int)Gekko::SPR::IBAT1U], Core->regs.spr[(int)Gekko::SPR::IBAT1L]);
+			printf("  SRR0=%08X DAR=%08X DSISR=%08X\n",
+				Core->regs.spr[(int)Gekko::SPR::SRR0], Core->regs.spr[(int)Gekko::SPR::DAR],
+				Core->regs.spr[(int)Gekko::SPR::DSISR]);
+			printf("  DBAT0U=%08X DBAT0L=%08X DBAT1U=%08X DBAT1L=%08X IBAT0U=%08X IBAT0L=%08X\n",
+				Core->regs.spr[(int)Gekko::SPR::DBAT0U], Core->regs.spr[(int)Gekko::SPR::DBAT0L],
+				Core->regs.spr[(int)Gekko::SPR::DBAT1U], Core->regs.spr[(int)Gekko::SPR::DBAT1L],
+				Core->regs.spr[(int)Gekko::SPR::IBAT0U], Core->regs.spr[(int)Gekko::SPR::IBAT0L]);
+		}
+		fflush(stdout);
+		if (g_fuzzActive) longjmp(g_fuzzJmp, 1);
+		exit(3);
+	}
+
+	void Report(Channel chan, const char* text, ...)
+	{
+		// Silent by default: the harness measures, it does not log.
+		if (!g_verbose) return;
+		va_list arg;
+		char buf[0x1000];
+		va_start(arg, text);
+		vsprintf(buf, text, arg);
+		va_end(arg);
+		printf("%s", buf);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Threading
+
+Thread* EMUCreateThread(ThreadProc threadProc, bool suspended, void* context, const char* name)
+{
+	return new Thread(threadProc, suspended, context, name);
+}
+
+void EMUJoinThread(Thread* thread)
+{
+	delete thread;
+}
+
+// ---------------------------------------------------------------------------
+// Flipper HW
+
+namespace Flipper
+{
+	uint8_t* ProcessorInterface::ram = nullptr;
+	uint32_t ProcessorInterface::ramSize = 0;
+	uint8_t* ProcessorInterface::bootrom = nullptr;
+	uint32_t ProcessorInterface::bootromSize = 0;
+	uint64_t ProcessorInterface::mmioReads = 0;
+	uint64_t ProcessorInterface::mmioWrites = 0;
+
+	FlipperStub hwInstance{};
+	FlipperStub* HW = &hwInstance;
+
+	static ProcessorInterface piInstance;
+	struct PiBinder { PiBinder() { HW->pi = &piInstance; } } piBinder;
+
+	// Unmapped / device reads return 0xFFFFFFFF for the boot ROM window and 0 for
+	// everything else - close enough for a CPU-only benchmark.
+
+	void ProcessorInterface::PIReadByte(uint32_t pa, uint32_t* reg)
+	{
+		uint8_t* ptr = RamPtr(pa);
+		if (ptr) { *reg = *ptr; return; }
+		if (BootromPtr(pa, 1)) { *reg = *BootromPtr(pa, 1); return; }
+		mmioReads++;
+		*reg = (pa >= PI_MEMSPACE_BOOTROM) ? (bootrom ? 0 : 0xFF) : 0;
+	}
+
+	void ProcessorInterface::PIReadHalf(uint32_t pa, uint32_t* reg)
+	{
+		uint8_t* ptr = RamPtr(pa);
+		if (ptr) { *reg = _BYTESWAP_UINT16(*(uint16_t*)ptr); return; }
+		if (BootromPtr(pa, 2)) { *reg = _BYTESWAP_UINT16(*(uint16_t*)BootromPtr(pa, 2)); return; }
+		mmioReads++;
+		*reg = (pa >= PI_MEMSPACE_BOOTROM) ? (bootrom ? 0 : 0xFFFF) : 0;
+	}
+
+	void ProcessorInterface::PIReadWord(uint32_t pa, uint32_t* reg)
+	{
+		uint8_t* ptr = RamPtr(pa);
+		if (ptr) { *reg = _BYTESWAP_UINT32(*(uint32_t*)ptr); return; }
+		if (BootromPtr(pa, 4)) { *reg = _BYTESWAP_UINT32(*(uint32_t*)BootromPtr(pa, 4)); return; }
+		mmioReads++;
+		*reg = (pa >= PI_MEMSPACE_BOOTROM) ? (bootrom ? 0 : 0xFFFFFFFF) : 0;
+	}
+
+	void ProcessorInterface::PIReadDouble(uint32_t pa, uint64_t* reg)
+	{
+		uint8_t* ptr = RamPtr(pa);
+		if (ptr) { *reg = _BYTESWAP_UINT64(*(uint64_t*)ptr); return; }
+		mmioReads++;
+		*reg = 0;
+	}
+
+	void ProcessorInterface::PIWriteByte(uint32_t pa, uint32_t data)
+	{
+		uint8_t* ptr = RamPtr(pa);
+		if (ptr) { *ptr = (uint8_t)data; return; }
+		mmioWrites++;
+	}
+
+	void ProcessorInterface::PIWriteHalf(uint32_t pa, uint32_t data)
+	{
+		uint8_t* ptr = RamPtr(pa);
+		if (ptr) { *(uint16_t*)ptr = _BYTESWAP_UINT16((uint16_t)data); return; }
+		mmioWrites++;
+	}
+
+	void ProcessorInterface::PIWriteWord(uint32_t pa, uint32_t data)
+	{
+		uint8_t* ptr = RamPtr(pa);
+		if (ptr) { *(uint32_t*)ptr = _BYTESWAP_UINT32(data); return; }
+		mmioWrites++;
+	}
+
+	void ProcessorInterface::PIWriteDouble(uint32_t pa, uint64_t* data)
+	{
+		uint8_t* ptr = RamPtr(pa);
+		if (ptr) { *(uint64_t*)ptr = _BYTESWAP_UINT64(*data); return; }
+		mmioWrites++;
+	}
+
+	void ProcessorInterface::PIReadBurst(uint32_t phys_addr, uint8_t burstData[32])
+	{
+		uint8_t* ptr = RamPtr(phys_addr);
+		if (ptr) { memcpy(burstData, ptr, 32); return; }
+		if (BootromPtr(phys_addr, 32)) { memcpy(burstData, BootromPtr(phys_addr, 32), 32); return; }
+		mmioReads++;
+		memset(burstData, 0, 32);
+	}
+
+	void ProcessorInterface::PIWriteBurst(uint32_t phys_addr, uint8_t burstData[32])
+	{
+		uint8_t* ptr = RamPtr(phys_addr);
+		if (ptr) { memcpy(ptr, burstData, 32); return; }
+		mmioWrites++;
+	}
+}


### PR DESCRIPTION
The interpreter ran at about 20 MIPS. Two independent layers of work, both verified against each other by the harness in testing/gekko_bench.

Interpreter (about 1.6x on its own):

* The TLB is a direct-mapped array of 2048 page translations instead of an unordered_map that heap-allocated a TLBEntry per mapped page; a miss just falls through to the BAT / page-table walk, so an evicted entry only costs a refill.
* Address translation, the tick and the branch-condition helpers are actually inlined now (GEKKO_INLINE): plain "inline" left an out-of-line copy that both MSVC and GCC ended up calling.
* An 8192-entry decode cache, keyed on the pc and the fetched instruction word, so an entry can never be reused for self-modifying code: a rewritten instruction simply misses.

Recompiler (about 4x over the original interpreter):

* New Gekko -> x86-64 basic block compiler in src/gekkojit.{h,cpp}. GPRs live in host registers for the duration of a block and memory accesses go back through the existing C++ cache / MMU helpers, so caches, MMU, exceptions and the Flipper side see exactly the same calls as before.
* Every block records the translation state it was compiled under (the generation counter), so writing a BAT, SDR1, HID0/HID2 or MSR, or executing rfi, tlbie, icbi, dcbst or a cache flush drops all blocks in O(1) without walking the block table.
* Instructions the compiler does not translate run through Interpreter::ExecuteDecoded, which is the interpreter's own path and shares its decode cache, so the two engines decode identically by construction.
* Debugger: "jit 0" / "jit 1" switches engines at runtime. Breakpoints and single stepping always stay on the interpreter, so the debugger still sees every instruction.
* 32-bit and non-x86 hosts fall back to the interpreter (IsSupported()), and GEKKO_JIT_DISABLED builds it out entirely.

Measured on the harness, mixed workload, best of three: 39.7 MIPS for the original interpreter, 58.6 for the inline interpreter, 155.9 with the recompiler. ALU-heavy code gains the most (8.6x over the original).

Verified in testing/gekko_bench: interpreter / recompiler state hashes agree over several workloads, an exhaustive branch test (654 cases), a random instruction fuzzer, self-modifying-code probes, the synthetic and the real IPL (20M instructions, identical hash), and a host-ABI regression build that reproduces the Win64 shadow-space hazard on Linux.

The Windows and SDL projects are updated with the new sources.