### PR TITLE
Fix #357: Port pad to SDL — keyboard/gamepad backend and the controller settings dialog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ add_executable (pureikyubu
 	src/memcard.cpp
 	src/os.cpp
 	src/osdebug.cpp
-	src/padnull.cpp
+	src/padsdl.cpp
 	src/pe.cpp
 	src/pi.cpp
 	src/ras.cpp

--- a/scripts/VS2022/pureikyubu.vcxproj
+++ b/scripts/VS2022/pureikyubu.vcxproj
@@ -196,7 +196,18 @@
     <ClCompile Include="..\..\src\memcard.cpp" />
     <ClCompile Include="..\..\src\os.cpp" />
     <ClCompile Include="..\..\src\osdebug.cpp" />
-    <ClCompile Include="..\..\src\pad.cpp" />
+    <ClCompile Include="..\..\src\pad.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug SDL|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release SDL|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug SDL|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release SDL|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\padsdl.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\padnull.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug SDL|Win32'">true</ExcludedFromBuild>

--- a/scripts/VS2022/pureikyubu.vcxproj.filters
+++ b/scripts/VS2022/pureikyubu.vcxproj.filters
@@ -333,6 +333,9 @@
     <ClCompile Include="..\..\src\pad.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\padsdl.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\pch.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/scripts/VS2026/pureikyubu.vcxproj
+++ b/scripts/VS2026/pureikyubu.vcxproj
@@ -197,7 +197,18 @@
     <ClCompile Include="..\..\src\memcard.cpp" />
     <ClCompile Include="..\..\src\os.cpp" />
     <ClCompile Include="..\..\src\osdebug.cpp" />
-    <ClCompile Include="..\..\src\pad.cpp" />
+    <ClCompile Include="..\..\src\pad.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug SDL|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release SDL|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug SDL|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release SDL|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\..\src\padsdl.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\padnull.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug SDL|Win32'">true</ExcludedFromBuild>

--- a/scripts/VS2026/pureikyubu.vcxproj.filters
+++ b/scripts/VS2026/pureikyubu.vcxproj.filters
@@ -336,6 +336,9 @@
     <ClCompile Include="..\..\src\pad.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\padsdl.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\pch.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/src/main.h
+++ b/src/main.h
@@ -1,7 +1,7 @@
 // Emulator main deck control
 #pragma once
 
-#define EMU_VERSION L"1.7"
+#define EMU_VERSION L"1.8"
 
 void    EMUGetHwConfig(HWConfig* config);
 

--- a/src/pad.cpp
+++ b/src/pad.cpp
@@ -2,7 +2,7 @@
 
 GameCube controllers emulation backend. This is shitty code in every way, don't look.
 
-Will be gradually superseded by DirectInput/SDL implementation.
+The SDL port uses its own backend, padsdl.cpp.
 
 ## Technical features
 

--- a/src/pad.h
+++ b/src/pad.h
@@ -1,6 +1,8 @@
 
 #pragma once
 
+// The index of a GameCube controller control. Every pad has two bindings per control: a keyboard
+// key (vkeys) and a game controller button or axis (gckeys, the SDL build only).
 enum
 {
 	VKEY_FOR_UP = 0,
@@ -34,8 +36,26 @@ enum
 struct PADCONF
 {
 	bool    plugged;
-	int     vkeys[VKEY_FOR_MAX];    // -1 - undefined
+	int     vkeys[VKEY_FOR_MAX];    // keyboard binding (-1 or 0 - undefined)
+	int     gckeys[VKEY_FOR_MAX];   // game controller binding (SDL build only), see PAD_GCKEY_*
 };
+
+// The game controller binding of a control is stored as a single integer, so that it fits the
+// existing configuration variables (GCKEY_FOR_*_N in the "controllers" section). It is either an
+// SDL game controller button or an SDL game controller axis with the direction that drives
+// the control.
+#define PAD_GCKEY_BUTTON_BASE   0x00010000
+#define PAD_GCKEY_AXIS_BASE     0x00020000
+
+#define PAD_GCKEY_IS_BUTTON(v)  ((v) >= PAD_GCKEY_BUTTON_BASE && (v) < PAD_GCKEY_AXIS_BASE)
+#define PAD_GCKEY_IS_AXIS(v)    ((v) >= PAD_GCKEY_AXIS_BASE)
+
+#define PAD_GCKEY_BUTTON(v)     ((v) - PAD_GCKEY_BUTTON_BASE)
+#define PAD_GCKEY_AXIS(v)       (((v) - PAD_GCKEY_AXIS_BASE) >> 1)
+#define PAD_GCKEY_AXIS_POS(v)   (((v) & 1) != 0)        // 1: positive direction, 0: negative
+
+#define PAD_GCKEY_MAKE_BUTTON(b)     (PAD_GCKEY_BUTTON_BASE + (b))
+#define PAD_GCKEY_MAKE_AXIS(a, pos)  (PAD_GCKEY_AXIS_BASE + ((a) << 1) + ((pos) ? 1 : 0))
 
 // PAD (input) interface
 // (padnum = 0...3)
@@ -74,6 +94,14 @@ struct PADState
 // plugin. PADClose() is called, when emulation is stopped, to shutdown plugin.
 bool PADOpen();
 void PADClose();
+
+// (Re)read the bindings of the specified pad from the configuration. Called by PADOpen(), and by
+// the controller settings dialog, so that the new bindings are applied without restarting the emulation.
+void PADLoadConfig(int padToConfigure);
+
+// SDL build only. Keep the SDL game controllers of the ports open and refresh their cached state.
+// Must be called from the thread that pumps the SDL events (the UI thread), see padsdl.cpp.
+void PADUpdateControllers();
 
 // read controller buttons state. returns 1, if ok, and 0, if PAD not connected
 bool PADReadButtons(long padnum, PADState* state);

--- a/src/padsdl.cpp
+++ b/src/padsdl.cpp
@@ -1,0 +1,445 @@
+/*
+
+GameCube controllers emulation backend (SDL2).
+
+This is the SDL counterpart of the Win32 backend (pad.cpp). A pad can be driven by the keyboard
+(polled with SDL_GetKeyboardState) and by an SDL game controller, both at the same time.
+
+The key bindings are stored in the configuration (SettingsSdl.json, "controllers" section) as SDL
+scancodes, and the game controller bindings as SDL game controller button or axis identifiers (see
+PAD_GCKEY_* in pad.h). The settings dialog is a part of the SDL UI and captures the SDL key and
+controller events (see the "Controller settings" section in uisdl.cpp).
+
+Unlike the Win32 backend, the key bindings are SDL scancodes (SDL_Scancode), not virtual-key codes.
+The SDL and the Win32 builds keep their settings in separate files (SettingsSdl.json /
+SettingsWin.json, see config.h), so the same VKEY_FOR_* variable names may hold the two different
+encodings without clashing. The game controller bindings live in the GCKEY_FOR_* variables.
+
+The Nth SDL game controller that is currently connected drives the Nth pad, so a single gamepad
+always works with Port 1, two gamepads with Port 1 and Port 2, and so on.
+
+The backend consumer is the `si.cpp` module.
+
+*/
+
+// PAD API for emulator
+#include "pch.h"
+
+using namespace Debug;
+
+// The names of the VKEY_FOR_* / GCKEY_FOR_* variables in the "controllers" section (in the enum order).
+static const char* vkey_suffix[VKEY_FOR_MAX] =
+{
+	"UP",
+	"DOWN",
+	"LEFT",
+	"RIGHT",
+	"XUP50",
+	"XUP100",
+	"XDOWN50",
+	"XDOWN100",
+	"XLEFT50",
+	"XLEFT100",
+	"XRIGHT50",
+	"XRIGHT100",
+	"CXUP",
+	"CXDOWN",
+	"CXLEFT",
+	"CXRIGHT",
+	"TRIGGERL",
+	"TRIGGERR",
+	"TRIGGERZ",
+	"A",
+	"B",
+	"X",
+	"Y",
+	"START",
+};
+
+static PADCONF pad[4];
+
+// ---------------------------------------------------------------------------
+// SDL game controllers
+//
+// The SDL objects are owned by the thread that pumps the SDL events: PADUpdateControllers()
+// opens/closes the devices and stores a plain snapshot of their state, which is what the emulation
+// thread reads in PADReadButtons(). Keeping the SDL pointers on the event thread avoids closing a
+// controller while another thread is reading it.
+
+#define PAD_AXIS_PRESS_THRESHOLD    16384   // an axis bound to a digital control is pressed at 50%
+
+struct PADGAMEPAD
+{
+	bool    present;
+	Uint8   buttons[SDL_CONTROLLER_BUTTON_MAX];
+	Sint16  axes[SDL_CONTROLLER_AXIS_MAX];
+};
+
+static PADGAMEPAD pad_gamepads[4];
+static SpinLock pad_gamepads_lock;
+
+void PADUpdateControllers()
+{
+	static bool sdl_inited = false;
+	static SDL_GameController* devices[4] = { nullptr };
+	static SDL_JoystickID device_ids[4] = { 0 };
+	static SDL_JoystickID failed_ids[4] = { 0 };      // devices that could not be opened (do not retry every frame)
+
+	if (!sdl_inited)
+	{
+		if (SDL_InitSubSystem(SDL_INIT_GAMECONTROLLER) < 0)
+		{
+			Report(Channel::SI, "SDL_InitSubSystem(SDL_INIT_GAMECONTROLLER) failed: %s\n", SDL_GetError());
+		}
+		sdl_inited = true;
+	}
+
+	// The connected game controllers, in the SDL enumeration order
+
+	int numJoysticks = SDL_NumJoysticks();
+	int connected[4];
+	int connectedCount = 0;
+
+	for (int i = 0; i < numJoysticks && connectedCount < 4; i++)
+	{
+		if (SDL_IsGameController(i))
+		{
+			connected[connectedCount++] = i;
+		}
+	}
+
+	// Open the controllers of the connected devices and close the devices that are gone.
+	// A device is reopened when its position in the list changes, so that the pad assignment follows
+	// the order of the connected game controllers.
+
+	for (int slot = 0; slot < 4; slot++)
+	{
+		SDL_JoystickID wanted = (slot < connectedCount) ? SDL_JoystickGetDeviceInstanceID(connected[slot]) : -1;
+
+		if (devices[slot] != nullptr && device_ids[slot] != wanted)
+		{
+			SDL_GameControllerClose(devices[slot]);
+			devices[slot] = nullptr;
+		}
+
+		if (devices[slot] == nullptr && wanted != -1 && failed_ids[slot] != wanted)
+		{
+			devices[slot] = SDL_GameControllerOpen(connected[slot]);
+
+			if (devices[slot] != nullptr)
+			{
+				failed_ids[slot] = 0;
+				device_ids[slot] = SDL_JoystickInstanceID(SDL_GameControllerGetJoystick(devices[slot]));
+				Report(Channel::SI, "Gamepad %i: %s\n", slot + 1, SDL_GameControllerName(devices[slot]));
+			}
+			else
+			{
+				failed_ids[slot] = wanted;
+				Report(Channel::SI, "Failed to open gamepad %i: %s\n", slot + 1, SDL_GetError());
+			}
+		}
+	}
+
+	// Snapshot the state
+
+	PADGAMEPAD snapshot[4];
+	memset(snapshot, 0, sizeof(snapshot));
+
+	for (int slot = 0; slot < 4; slot++)
+	{
+		if (devices[slot] == nullptr)
+		{
+			continue;
+		}
+
+		snapshot[slot].present = true;
+
+		for (int b = 0; b < SDL_CONTROLLER_BUTTON_MAX; b++)
+		{
+			snapshot[slot].buttons[b] = SDL_GameControllerGetButton(devices[slot], (SDL_GameControllerButton)b);
+		}
+
+		for (int a = 0; a < SDL_CONTROLLER_AXIS_MAX; a++)
+		{
+			snapshot[slot].axes[a] = SDL_GameControllerGetAxis(devices[slot], (SDL_GameControllerAxis)a);
+		}
+	}
+
+	pad_gamepads_lock.Lock();
+	memcpy(pad_gamepads, snapshot, sizeof(pad_gamepads));
+	pad_gamepads_lock.Unlock();
+}
+
+// ---------------------------------------------------------------------------
+// configuration
+
+void PADLoadConfig(int padToConfigure)
+{
+	char parm[256] = { 0 };
+
+	if (padToConfigure < 0 || padToConfigure > 3)
+	{
+		return;
+	}
+
+	// Plugged or not
+	sprintf(parm, "PluggedIn_%i", padToConfigure);
+	pad[padToConfigure].plugged = GetConfigBool(parm, USER_PADS);
+
+	// Buttons
+	for (int i = 0; i < VKEY_FOR_MAX; i++)
+	{
+		sprintf(parm, "VKEY_FOR_%s_%i", vkey_suffix[i], padToConfigure);
+		pad[padToConfigure].vkeys[i] = GetConfigInt(parm, USER_PADS);
+
+		sprintf(parm, "GCKEY_FOR_%s_%i", vkey_suffix[i], padToConfigure);
+		pad[padToConfigure].gckeys[i] = GetConfigInt(parm, USER_PADS);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// called when emulation started/stopped (pad controls)
+
+bool PADOpen()
+{
+	for (int i = 0; i < 4; i++)
+	{
+		PADLoadConfig(i);
+	}
+
+	return true;    // ok
+}
+
+void PADClose()
+{
+	pad[0].plugged =
+	pad[1].plugged =
+	pad[2].plugged =
+	pad[3].plugged = false;
+}
+
+// ---------------------------------------------------------------------------
+// process input
+
+#define THRESOLD    127
+#define STICK_INITIAL	0
+
+static void pad_reset_chan(PADState* state)
+{
+	memset(state, 0, sizeof(PADState));
+
+	// The analog control values can range from -127 to +127.
+	// The pad.a library further filters them by setting the lower cap to 15 and the upper cap to 87 for stick and 74 for cstick.
+	// But these are purely programmatic fiddles that don't concern us.
+
+	state->stickX = state->stickY = STICK_INITIAL;
+	state->substickX = state->substickY = STICK_INITIAL;
+}
+
+// A key binding is a scancode; 0 (SDL_SCANCODE_UNKNOWN) and -1 mean "not assigned".
+static bool pad_key_pressed(const Uint8* keys, int scancode)
+{
+	return scancode > 0 && scancode < SDL_NUM_SCANCODES && keys[scancode] != 0;
+}
+
+// A game controller button, or an axis deflected in the bound direction past the threshold.
+static bool pad_gc_pressed(const PADGAMEPAD* gp, int binding)
+{
+	if (!gp->present)
+	{
+		return false;
+	}
+
+	if (PAD_GCKEY_IS_BUTTON(binding))
+	{
+		int button = PAD_GCKEY_BUTTON(binding);
+		return button >= 0 && button < SDL_CONTROLLER_BUTTON_MAX && gp->buttons[button] != 0;
+	}
+
+	if (PAD_GCKEY_IS_AXIS(binding))
+	{
+		int axis = PAD_GCKEY_AXIS(binding);
+		if (axis < 0 || axis >= SDL_CONTROLLER_AXIS_MAX) return false;
+		int value = gp->axes[axis];
+		return PAD_GCKEY_AXIS_POS(binding) ? (value > PAD_AXIS_PRESS_THRESHOLD) : (value < -PAD_AXIS_PRESS_THRESHOLD);
+	}
+
+	return false;
+}
+
+// The magnitude (0...127) of the deflection of the axis bound to the control. The caller applies
+// the sign of the direction, the same way as for the keyboard bindings.
+static int pad_gc_stick(const PADGAMEPAD* gp, int binding)
+{
+	if (!gp->present || !PAD_GCKEY_IS_AXIS(binding))
+	{
+		return 0;
+	}
+
+	int axis = PAD_GCKEY_AXIS(binding);
+	if (axis < 0 || axis >= SDL_CONTROLLER_AXIS_MAX)
+	{
+		return 0;
+	}
+
+	int value = gp->axes[axis];
+	bool positive = PAD_GCKEY_AXIS_POS(binding);
+
+	if (positive && value <= 0) return 0;
+	if (!positive && value >= 0) return 0;
+
+	int scaled = (value < 0 ? -value : value) * 127 / 32767;
+	return scaled > 127 ? 127 : scaled;
+}
+
+// The value (0...255) of the game controller trigger bound to the control. The trigger axes are
+// unipolar (0...32767), so the direction of the binding is ignored.
+static int pad_gc_trigger(const PADGAMEPAD* gp, int binding)
+{
+	if (!gp->present || !PAD_GCKEY_IS_AXIS(binding))
+	{
+		return 0;
+	}
+
+	int axis = PAD_GCKEY_AXIS(binding);
+	if (axis < 0 || axis >= SDL_CONTROLLER_AXIS_MAX)
+	{
+		return 0;
+	}
+
+	int value = gp->axes[axis];
+	if (value <= 0)
+	{
+		return 0;
+	}
+
+	int scaled = value * 255 / 32767;
+	return scaled > 255 ? 255 : scaled;
+}
+
+// Both the 50% and the 100% binding of the same direction may be pressed at once,
+// so the sum is clamped instead of overflowing int8_t.
+static int8_t pad_stick_value(int value)
+{
+	if (value > 127) return 127;
+	if (value < -127) return -127;
+	return (int8_t)value;
+}
+
+// collect keyboard and gamepad buttons in PADState
+bool PADReadButtons(long padnum, PADState* state)
+{
+	uint16_t button = 0;
+	int stickX = 0, stickY = 0;
+	int substickX = 0, substickY = 0;
+	int triggerLeft = 0, triggerRight = 0;
+
+	pad_reset_chan(state);
+
+	if (padnum < 0 || padnum > 3) return false;
+
+	if (!pad[padnum].plugged) return false;
+
+	const Uint8* keys = SDL_GetKeyboardState(NULL);
+	if (keys == nullptr) return false;
+
+	PADGAMEPAD gp;
+	pad_gamepads_lock.Lock();
+	gp = pad_gamepads[padnum];
+	pad_gamepads_lock.Unlock();
+
+	PADCONF* conf = &pad[padnum];
+
+	auto key = [&](int vkey) { return pad_key_pressed(keys, conf->vkeys[vkey]); };
+	auto gc = [&](int vkey) { return pad_gc_pressed(&gp, conf->gckeys[vkey]); };
+	auto pressed = [&](int vkey) { return key(vkey) || gc(vkey); };
+
+	//
+	// ===== PAD n =====
+	//
+
+	if (pressed(VKEY_FOR_UP)) button |= PAD_BUTTON_UP;
+	if (pressed(VKEY_FOR_DOWN)) button |= PAD_BUTTON_DOWN;
+	if (pressed(VKEY_FOR_LEFT)) button |= PAD_BUTTON_LEFT;
+	if (pressed(VKEY_FOR_RIGHT)) button |= PAD_BUTTON_RIGHT;
+
+	if (pressed(VKEY_FOR_A)) button |= PAD_BUTTON_A;
+	if (pressed(VKEY_FOR_B)) button |= PAD_BUTTON_B;
+	if (pressed(VKEY_FOR_X)) button |= PAD_BUTTON_X;
+	if (pressed(VKEY_FOR_Y)) button |= PAD_BUTTON_Y;
+	if (pressed(VKEY_FOR_START)) button |= PAD_BUTTON_START;
+
+	// Note : digital L and R are only set when its analog key is pressed all the way down;
+	// this plugin is only supporting the fact, that L/R are pressed.
+
+	if (pressed(VKEY_FOR_TRIGGERL))
+	{
+		button |= PAD_TRIGGER_L;
+		triggerLeft = 255;
+	}
+	if (pressed(VKEY_FOR_TRIGGERR))
+	{
+		button |= PAD_TRIGGER_R;
+		triggerRight = 255;
+	}
+
+	if (pressed(VKEY_FOR_TRIGGERZ))
+	{
+		button |= PAD_TRIGGER_Z;
+	}
+
+	// The analog L/R triggers are the only controls with an analog value.
+
+	int analog = pad_gc_trigger(&gp, conf->gckeys[VKEY_FOR_TRIGGERL]);
+	if (analog > triggerLeft) triggerLeft = analog;
+
+	analog = pad_gc_trigger(&gp, conf->gckeys[VKEY_FOR_TRIGGERR]);
+	if (analog > triggerRight) triggerRight = analog;
+
+	// The main stick: the keyboard binds the 50%/100% keys, the gamepad binds the stick axes.
+	// The 50% and the 100% controls of a direction may share the same axis, so the largest value wins.
+
+	if (key(VKEY_FOR_XUP50))    stickY += THRESOLD / 2;
+	if (key(VKEY_FOR_XUP100))   stickY += THRESOLD;
+	if (key(VKEY_FOR_XDOWN50))  stickY += -THRESOLD / 2;
+	if (key(VKEY_FOR_XDOWN100)) stickY += -THRESOLD;
+	if (key(VKEY_FOR_XRIGHT50))  stickX += THRESOLD / 2;
+	if (key(VKEY_FOR_XRIGHT100)) stickX += THRESOLD;
+	if (key(VKEY_FOR_XLEFT50))   stickX += -THRESOLD / 2;
+	if (key(VKEY_FOR_XLEFT100))  stickX += -THRESOLD;
+
+	stickY += my_max(pad_gc_stick(&gp, conf->gckeys[VKEY_FOR_XUP50]), pad_gc_stick(&gp, conf->gckeys[VKEY_FOR_XUP100]));
+	stickY -= my_max(pad_gc_stick(&gp, conf->gckeys[VKEY_FOR_XDOWN50]), pad_gc_stick(&gp, conf->gckeys[VKEY_FOR_XDOWN100]));
+	stickX += my_max(pad_gc_stick(&gp, conf->gckeys[VKEY_FOR_XRIGHT50]), pad_gc_stick(&gp, conf->gckeys[VKEY_FOR_XRIGHT100]));
+	stickX -= my_max(pad_gc_stick(&gp, conf->gckeys[VKEY_FOR_XLEFT50]), pad_gc_stick(&gp, conf->gckeys[VKEY_FOR_XLEFT100]));
+
+	// The C stick
+
+	if (key(VKEY_FOR_CXUP))    substickY += THRESOLD;
+	if (key(VKEY_FOR_CXDOWN))  substickY += -THRESOLD;
+	if (key(VKEY_FOR_CXRIGHT)) substickX += THRESOLD;
+	if (key(VKEY_FOR_CXLEFT))  substickX += -THRESOLD;
+
+	substickY += pad_gc_stick(&gp, conf->gckeys[VKEY_FOR_CXUP]);
+	substickY -= pad_gc_stick(&gp, conf->gckeys[VKEY_FOR_CXDOWN]);
+	substickX += pad_gc_stick(&gp, conf->gckeys[VKEY_FOR_CXRIGHT]);
+	substickX -= pad_gc_stick(&gp, conf->gckeys[VKEY_FOR_CXLEFT]);
+
+	state->stickX = pad_stick_value(stickX);
+	state->stickY = pad_stick_value(stickY);
+	state->substickX = pad_stick_value(substickX);
+	state->substickY = pad_stick_value(substickY);
+	state->triggerLeft = (uint8_t)triggerLeft;
+	state->triggerRight = (uint8_t)triggerRight;
+
+	state->button = button;
+
+	return true;
+}
+
+// controller motor. 0 returned, if rumble is not supported by PAD.
+// see one of PAD_MOTOR* for allowed commands.
+bool PADSetRumble(long padnum, long cmd)
+{
+	return false;
+}

--- a/src/ui.h
+++ b/src/ui.h
@@ -8,7 +8,8 @@ The emulator settings dialog is used only for modifying the settings Json (Setti
 
 ## Controller Settings Dialog (PAD)
 
-This dialog is used to configure the PadSimpleWin32 backend.
+This dialog is used to configure the PadSimpleWin32 backend (pad.cpp). The SDL port has its own
+version of the dialog in uisdl.cpp, which configures the SDL backend (padsdl.cpp).
 
 When there is actual support for USB controllers, it will probably be redesigned.
 

--- a/src/uisdl.cpp
+++ b/src/uisdl.cpp
@@ -941,6 +941,479 @@ static void ui_selector_menu()
 
 /*
 
+# Controller settings
+
+The SDL port of the Win32 controller settings dialog (see PADConfigDialogProc and PADConfigure
+in ui.cpp): plug the pad, assign a keyboard key and/or a gamepad button or axis to every GameCube
+controller control, or clear/restore the bindings. Every control has two bindings, so the keyboard
+and the gamepad can be used at the same time.
+
+Clicking a binding button arms the capture, and the next input becomes the new binding (Esc cancels
+it, like in the Win32 dialog): a key of the main window for the keyboard column (the modifier keys
+and the F1-F12 keys are skipped, because the debugger uses them, see GetVKey in ui.cpp), or an SDL
+game controller button or a stick/trigger deflection for the gamepad column. The captured events
+are not passed to ImGui, so they cannot also move the selector cursor or navigate the UI.
+
+The dialog edits a copy of the PADCONF of the selected pad. OK writes it to the configuration
+("controllers" section) and makes the backend reread it; Cancel drops the copy.
+
+*/
+
+/* The names of the VKEY_FOR_* (keyboard) and GCKEY_FOR_* (gamepad) configuration variables, in the enum order */
+static const char* pad_binding_suffix[VKEY_FOR_MAX] =
+{
+	"UP", "DOWN", "LEFT", "RIGHT",
+	"XUP50", "XUP100", "XDOWN50", "XDOWN100",
+	"XLEFT50", "XLEFT100", "XRIGHT50", "XRIGHT100",
+	"CXUP", "CXDOWN", "CXLEFT", "CXRIGHT",
+	"TRIGGERL", "TRIGGERR", "TRIGGERZ",
+	"A", "B", "X", "Y", "START",
+};
+
+/* The rows of the dialog, in the display order */
+static const char* pad_binding_label[VKEY_FOR_MAX] =
+{
+	"Up", "Down", "Left", "Right",
+	"Up 50%", "Up 100%", "Down 50%", "Down 100%",
+	"Left 50%", "Left 100%", "Right 50%", "Right 100%",
+	"C Up", "C Down", "C Left", "C Right",
+	"L", "R", "Z", "A", "B", "X", "Y", "Start",
+};
+
+static const int pad_digital_bindings[] =
+{
+	VKEY_FOR_UP, VKEY_FOR_DOWN, VKEY_FOR_LEFT, VKEY_FOR_RIGHT,
+	VKEY_FOR_A, VKEY_FOR_B, VKEY_FOR_X, VKEY_FOR_Y,
+	VKEY_FOR_START, VKEY_FOR_TRIGGERL, VKEY_FOR_TRIGGERR, VKEY_FOR_TRIGGERZ,
+};
+
+static const int pad_stick_bindings[] =
+{
+	VKEY_FOR_XUP50, VKEY_FOR_XUP100, VKEY_FOR_XDOWN50, VKEY_FOR_XDOWN100,
+	VKEY_FOR_XLEFT50, VKEY_FOR_XLEFT100, VKEY_FOR_XRIGHT50, VKEY_FOR_XRIGHT100,
+};
+
+static const int pad_substick_bindings[] =
+{
+	VKEY_FOR_CXUP, VKEY_FOR_CXDOWN, VKEY_FOR_CXLEFT, VKEY_FOR_CXRIGHT,
+};
+
+/* The default keyboard bindings of the first pad (see PADDefaultConfig in ui.cpp), as SDL scancodes */
+static const int pad_default_vkeys[VKEY_FOR_MAX] =
+{
+	SDL_SCANCODE_HOME,      // Up
+	SDL_SCANCODE_END,       // Down
+	SDL_SCANCODE_DELETE,    // Left
+	SDL_SCANCODE_PAGEDOWN,  // Right
+	0,                      // Up 50%
+	SDL_SCANCODE_UP,        // Up 100%
+	0,                      // Down 50%
+	SDL_SCANCODE_DOWN,      // Down 100%
+	0,                      // Left 50%
+	SDL_SCANCODE_LEFT,      // Left 100%
+	0,                      // Right 50%
+	SDL_SCANCODE_RIGHT,     // Right 100%
+	SDL_SCANCODE_KP_8,      // C Up
+	SDL_SCANCODE_KP_2,      // C Down
+	SDL_SCANCODE_KP_4,      // C Left
+	SDL_SCANCODE_KP_6,      // C Right
+	SDL_SCANCODE_Q,         // L
+	SDL_SCANCODE_W,         // R
+	SDL_SCANCODE_E,         // Z
+	SDL_SCANCODE_X,         // A
+	SDL_SCANCODE_Z,         // B
+	SDL_SCANCODE_S,         // X
+	SDL_SCANCODE_A,         // Y
+	SDL_SCANCODE_RETURN,    // Start
+};
+
+/* The default gamepad bindings (the usual Xbox-style layout): the main stick is mapped to the
+   left stick, the C stick to the right stick, and the L/R triggers to the analog triggers. */
+static const int pad_default_gckeys[VKEY_FOR_MAX] =
+{
+	PAD_GCKEY_MAKE_BUTTON(SDL_CONTROLLER_BUTTON_DPAD_UP),           // Up
+	PAD_GCKEY_MAKE_BUTTON(SDL_CONTROLLER_BUTTON_DPAD_DOWN),         // Down
+	PAD_GCKEY_MAKE_BUTTON(SDL_CONTROLLER_BUTTON_DPAD_LEFT),         // Left
+	PAD_GCKEY_MAKE_BUTTON(SDL_CONTROLLER_BUTTON_DPAD_RIGHT),        // Right
+	0,                                                              // Up 50%
+	PAD_GCKEY_MAKE_AXIS(SDL_CONTROLLER_AXIS_LEFTY, false),          // Up 100%
+	0,                                                              // Down 50%
+	PAD_GCKEY_MAKE_AXIS(SDL_CONTROLLER_AXIS_LEFTY, true),           // Down 100%
+	0,                                                              // Left 50%
+	PAD_GCKEY_MAKE_AXIS(SDL_CONTROLLER_AXIS_LEFTX, false),          // Left 100%
+	0,                                                              // Right 50%
+	PAD_GCKEY_MAKE_AXIS(SDL_CONTROLLER_AXIS_LEFTX, true),           // Right 100%
+	PAD_GCKEY_MAKE_AXIS(SDL_CONTROLLER_AXIS_RIGHTY, false),         // C Up
+	PAD_GCKEY_MAKE_AXIS(SDL_CONTROLLER_AXIS_RIGHTY, true),          // C Down
+	PAD_GCKEY_MAKE_AXIS(SDL_CONTROLLER_AXIS_RIGHTX, false),         // C Left
+	PAD_GCKEY_MAKE_AXIS(SDL_CONTROLLER_AXIS_RIGHTX, true),          // C Right
+	PAD_GCKEY_MAKE_AXIS(SDL_CONTROLLER_AXIS_TRIGGERLEFT, true),     // L
+	PAD_GCKEY_MAKE_AXIS(SDL_CONTROLLER_AXIS_TRIGGERRIGHT, true),    // R
+	PAD_GCKEY_MAKE_BUTTON(SDL_CONTROLLER_BUTTON_RIGHTSHOULDER),     // Z
+	PAD_GCKEY_MAKE_BUTTON(SDL_CONTROLLER_BUTTON_A),                 // A
+	PAD_GCKEY_MAKE_BUTTON(SDL_CONTROLLER_BUTTON_B),                 // B
+	PAD_GCKEY_MAKE_BUTTON(SDL_CONTROLLER_BUTTON_X),                 // X
+	PAD_GCKEY_MAKE_BUTTON(SDL_CONTROLLER_BUTTON_Y),                 // Y
+	PAD_GCKEY_MAKE_BUTTON(SDL_CONTROLLER_BUTTON_START),             // Start
+};
+
+/* The gamepad bindings offered by the dialog, for the buttons without a friendly name */
+static const char* pad_gamepad_button_name[SDL_CONTROLLER_BUTTON_MAX] =
+{
+	"A", "B", "X", "Y", "Back", "Guide", "Start", "L Stick", "R Stick",
+	"L Shoulder", "R Shoulder", "DPad Up", "DPad Down", "DPad Left", "DPad Right",
+	"Misc", "Paddle 1", "Paddle 2", "Paddle 3", "Paddle 4", "Touchpad",
+};
+
+static const char* pad_gamepad_axis_name[SDL_CONTROLLER_AXIS_MAX] =
+{
+	"L Stick X", "L Stick Y", "R Stick X", "R Stick Y", "L Trigger", "R Trigger",
+};
+
+/* The axis capture ignores the stick noise */
+#define PAD_CAPTURE_AXIS_THRESHOLD  16384
+
+/* Dialog state */
+
+static bool     pad_dialog_open = false;
+static int      pad_dialog_num = 0;                 // the pad being configured
+static PADCONF  pad_dialog_config;                  // the edited copy of the pad configuration
+
+/* Key/gamepad capture, armed by a binding button and fed by the SDL event loop (see ui_main) */
+
+static int      pad_capture_target = -1;            // the VKEY_FOR_* that waits for an input
+static bool     pad_capture_gamepad = false;        // true: wait for a gamepad event, false: for a key
+static bool     pad_capture_active = false;
+static bool     pad_capture_done = false;
+static int      pad_captured_binding = 0;
+
+/* The keys that the Win32 dialog skips, because they cannot be bound (or the debugger needs them) */
+static bool pad_capture_ignored(SDL_Scancode scancode)
+{
+	switch (scancode)
+	{
+		case SDL_SCANCODE_LSHIFT:
+		case SDL_SCANCODE_RSHIFT:
+		case SDL_SCANCODE_LCTRL:
+		case SDL_SCANCODE_RCTRL:
+		case SDL_SCANCODE_LALT:
+		case SDL_SCANCODE_RALT:
+		case SDL_SCANCODE_LGUI:
+		case SDL_SCANCODE_RGUI:
+		case SDL_SCANCODE_MODE:
+			return true;
+		default:
+			return scancode >= SDL_SCANCODE_F1 && scancode <= SDL_SCANCODE_F12;
+	}
+}
+
+/* Load the pad configuration into the dialog (see PADLoadConfig in padsdl.cpp) */
+static void pad_dialog_load(int padnum)
+{
+	char parm[256];
+
+	pad_dialog_num = padnum;
+
+	sprintf(parm, "PluggedIn_%i", padnum);
+	pad_dialog_config.plugged = UI::Jdi->GetConfigBool(parm, USER_PADS);
+
+	for (int i = 0; i < VKEY_FOR_MAX; i++)
+	{
+		sprintf(parm, "VKEY_FOR_%s_%i", pad_binding_suffix[i], padnum);
+		pad_dialog_config.vkeys[i] = UI::Jdi->GetConfigInt(parm, USER_PADS);
+
+		sprintf(parm, "GCKEY_FOR_%s_%i", pad_binding_suffix[i], padnum);
+		pad_dialog_config.gckeys[i] = UI::Jdi->GetConfigInt(parm, USER_PADS);
+	}
+}
+
+/* Write the dialog configuration back (see PADSaveConfig in ui.cpp) and make the backend reread it */
+static void pad_dialog_save()
+{
+	char parm[256];
+
+	sprintf(parm, "PluggedIn_%i", pad_dialog_num);
+	UI::Jdi->SetConfigBool(parm, pad_dialog_config.plugged, USER_PADS);
+
+	for (int i = 0; i < VKEY_FOR_MAX; i++)
+	{
+		sprintf(parm, "VKEY_FOR_%s_%i", pad_binding_suffix[i], pad_dialog_num);
+		UI::Jdi->SetConfigInt(parm, pad_dialog_config.vkeys[i], USER_PADS);
+
+		sprintf(parm, "GCKEY_FOR_%s_%i", pad_binding_suffix[i], pad_dialog_num);
+		UI::Jdi->SetConfigInt(parm, pad_dialog_config.gckeys[i], USER_PADS);
+	}
+
+	PADLoadConfig(pad_dialog_num);
+}
+
+static void pad_dialog_abort_capture()
+{
+	pad_capture_target = -1;
+	pad_capture_gamepad = false;
+	pad_capture_active = false;
+	pad_capture_done = false;
+}
+
+static void pad_dialog_open_for(int padnum)
+{
+	pad_dialog_abort_capture();
+	pad_dialog_load(padnum);
+	pad_dialog_open = true;
+}
+
+static void pad_dialog_close()
+{
+	pad_dialog_abort_capture();
+	pad_dialog_open = false;
+}
+
+/* Unplug the pad and drop all the bindings (see PADClearConfig in ui.cpp) */
+static void pad_dialog_clear()
+{
+	pad_dialog_config.plugged = false;
+
+	for (int i = 0; i < VKEY_FOR_MAX; i++)
+	{
+		pad_dialog_config.vkeys[i] = 0;
+		pad_dialog_config.gckeys[i] = 0;
+	}
+}
+
+/* Restore the default bindings (see PADDefaultConfig in ui.cpp). The gamepad is per port, so every
+   port gets the standard gamepad mapping. The keyboard defaults are the same for every port, so
+   they are only applied to the first pad (otherwise all the pads would react to the same keys). */
+static void pad_dialog_default()
+{
+	for (int i = 0; i < VKEY_FOR_MAX; i++)
+	{
+		pad_dialog_config.gckeys[i] = pad_default_gckeys[i];
+
+		if (pad_dialog_num == 0)
+		{
+			pad_dialog_config.vkeys[i] = pad_default_vkeys[i];
+		}
+	}
+}
+
+/* The name of the key bound to the control, or "..." when the binding is not assigned */
+static std::string pad_binding_name(int scancode)
+{
+	if (scancode <= 0 || scancode >= SDL_NUM_SCANCODES)
+	{
+		return "...";
+	}
+
+	const char* name = SDL_GetScancodeName((SDL_Scancode)scancode);
+
+	return (name && *name) ? name : "?";
+}
+
+/* The name of the game controller button or axis bound to the control */
+static std::string pad_gamepad_binding_name(int binding)
+{
+	if (PAD_GCKEY_IS_BUTTON(binding))
+	{
+		int button = PAD_GCKEY_BUTTON(binding);
+
+		if (button < 0 || button >= SDL_CONTROLLER_BUTTON_MAX)
+		{
+			return "?";
+		}
+
+		return pad_gamepad_button_name[button];
+	}
+
+	if (PAD_GCKEY_IS_AXIS(binding))
+	{
+		int axis = PAD_GCKEY_AXIS(binding);
+
+		if (axis < 0 || axis >= SDL_CONTROLLER_AXIS_MAX)
+		{
+			return "?";
+		}
+
+		return std::string(pad_gamepad_axis_name[axis]) + (PAD_GCKEY_AXIS_POS(binding) ? " +" : " -");
+	}
+
+	return "...";
+}
+
+/* A binding button: the keyboard one or the gamepad one of the control */
+static void pad_dialog_binding_button(int vkey, bool gamepad)
+{
+	// The button label (and with it the button id) changes, so push a stable id
+	ImGui::PushID(vkey * 2 + (gamepad ? 1 : 0));
+
+	std::string name;
+
+	if (pad_capture_active && pad_capture_target == vkey && pad_capture_gamepad == gamepad)
+	{
+		name = "?";
+	}
+	else
+	{
+		name = gamepad
+			? pad_gamepad_binding_name(pad_dialog_config.gckeys[vkey])
+			: pad_binding_name(pad_dialog_config.vkeys[vkey]);
+	}
+
+	ImGui::BeginDisabled(!pad_dialog_config.plugged);
+	if (ImGui::Button(name.c_str(), ImVec2(110, 0)))
+	{
+		pad_capture_target = vkey;
+		pad_capture_gamepad = gamepad;
+		pad_capture_active = true;
+		pad_capture_done = false;
+	}
+	ImGui::EndDisabled();
+
+	ImGui::PopID();
+}
+
+/* A group of binding rows (Control | Keyboard | Gamepad). The table auto-fits its content, so that
+   the groups can be placed side by side. */
+static void pad_dialog_bindings(const char* id, const int* bindings, int count)
+{
+	if (!ImGui::BeginTable(id, 3, ImGuiTableFlags_SizingFixedFit | ImGuiTableFlags_NoHostExtendX))
+	{
+		return;
+	}
+
+	ImGui::TableSetupColumn("Control");
+	ImGui::TableSetupColumn("Keyboard");
+	ImGui::TableSetupColumn("Gamepad");
+	ImGui::TableHeadersRow();
+
+	for (int i = 0; i < count; i++)
+	{
+		int vkey = bindings[i];
+
+		ImGui::TableNextRow();
+
+		ImGui::TableSetColumnIndex(0);
+		ImGui::TextUnformatted(pad_binding_label[vkey]);
+
+		ImGui::TableSetColumnIndex(1);
+		pad_dialog_binding_button(vkey, false);
+
+		ImGui::TableSetColumnIndex(2);
+		pad_dialog_binding_button(vkey, true);
+	}
+
+	ImGui::EndTable();
+}
+
+static void ui_pad_settings()
+{
+	if (!pad_dialog_open)
+	{
+		return;
+	}
+
+	// Apply the binding captured by the SDL event loop
+
+	if (pad_capture_done)
+	{
+		if (pad_capture_target >= 0 && pad_capture_target < VKEY_FOR_MAX)
+		{
+			if (pad_capture_gamepad)
+			{
+				pad_dialog_config.gckeys[pad_capture_target] = pad_captured_binding;
+			}
+			else
+			{
+				pad_dialog_config.vkeys[pad_capture_target] = pad_captured_binding;
+			}
+		}
+
+		pad_capture_target = -1;
+		pad_capture_done = false;
+	}
+
+	char title[0x40];
+	sprintf(title, "Configure Controller %i", pad_dialog_num + 1);
+
+	// Buttons on the left, the Control Stick with the C Stick under it on the right. The window
+	// auto-fits its content, so there is no empty space around the controls.
+	bool open = true;
+
+	if (ImGui::Begin(title, &open, ImGuiWindowFlags_AlwaysAutoResize))
+	{
+		ImGui::Checkbox("Plugged in", &pad_dialog_config.plugged);
+
+		// The backend maps the connected game controllers to the ports in the order they are reported by SDL
+		ImGui::TextDisabled("Connected gamepads drive Port 1, Port 2, ... in order");
+
+		ImGui::Separator();
+
+		ImGui::BeginGroup();
+		ImGui::TextUnformatted("Buttons");
+		pad_dialog_bindings("pad_buttons", pad_digital_bindings, sizeof(pad_digital_bindings) / sizeof(pad_digital_bindings[0]));
+		ImGui::EndGroup();
+
+		ImGui::SameLine(0, 24);
+
+		ImGui::BeginGroup();
+		ImGui::TextUnformatted("Control Stick");
+		pad_dialog_bindings("pad_stick", pad_stick_bindings, sizeof(pad_stick_bindings) / sizeof(pad_stick_bindings[0]));
+		ImGui::Dummy(ImVec2(0, 6));
+		ImGui::TextUnformatted("C Stick");
+		pad_dialog_bindings("pad_substick", pad_substick_bindings, sizeof(pad_substick_bindings) / sizeof(pad_substick_bindings[0]));
+		ImGui::EndGroup();
+
+		ImGui::Separator();
+
+		if (pad_capture_active)
+		{
+			ImGui::TextUnformatted(pad_capture_gamepad
+				? "Press a gamepad button or move an axis (Esc to cancel)"
+				: "Press a key (Esc to cancel)");
+		}
+
+		if (ImGui::Button("Clear", ImVec2(65, 0)))
+		{
+			pad_dialog_clear();
+		}
+
+		ImGui::SameLine();
+
+		// Gamepads are per port, so every port can get the standard gamepad mapping. The keyboard
+		// part of the defaults is only applied to the first pad (see pad_dialog_default).
+		if (ImGui::Button("Default", ImVec2(65, 0)))
+		{
+			pad_dialog_default();
+		}
+
+		ImGui::SameLine();
+
+		if (ImGui::Button("OK", ImVec2(65, 0)))
+		{
+			pad_dialog_save();
+			pad_dialog_close();
+		}
+
+		ImGui::SameLine();
+
+		if (ImGui::Button("Cancel", ImVec2(65, 0)))
+		{
+			pad_dialog_close();
+		}
+	}
+
+	ImGui::End();
+
+	if (!open)
+	{
+		pad_dialog_close();
+	}
+}
+
+
+
+
+/*
+
 # Performance Counters
 
 Interesting to track :
@@ -1338,10 +1811,16 @@ static void ui_main_menu()
 			ImGui::Separator();
 			if (ImGui::BeginMenu("Controllers"))
 			{
-				ImGui::MenuItem("Port 1", NULL);
-				ImGui::MenuItem("Port 2", NULL);
-				ImGui::MenuItem("Port 3", NULL);
-				ImGui::MenuItem("Port 4", NULL);
+				for (int i = 0; i < 4; i++)
+				{
+					char label[0x20];
+					sprintf(label, "Port %i", i + 1);
+
+					if (ImGui::MenuItem(label, NULL, pad_dialog_open && pad_dialog_num == i))
+					{
+						pad_dialog_open_for(i);
+					}
+				}
 				ImGui::EndMenu();
 			}
 			if (ImGui::BeginMenu("Memcards"))
@@ -1650,7 +2129,70 @@ static int ui_main()
 				// down. If the release event (which may be delivered to another window) is skipped, the
 				// mouse stays captured by the main window and the other windows stop responding to it.
 				case SDL_MOUSEWHEEL:      forMainWindow = (event.wheel.windowID == mainWindowID); break;
+				// The game controllers are used by the pad backend (see padsdl.cpp). They are only
+				// passed to ImGui while the selector is shown, so that a gamepad can navigate the UI,
+				// but does not move the ImGui cursor while a game is running.
+				case SDL_CONTROLLERAXISMOTION:
+				case SDL_CONTROLLERBUTTONDOWN:
+				case SDL_CONTROLLERBUTTONUP:
+				case SDL_CONTROLLERDEVICEADDED:
+				case SDL_CONTROLLERDEVICEREMOVED:
+				case SDL_CONTROLLERDEVICEREMAPPED: forMainWindow = !emu_running; break;
 				default: break;
+			}
+
+			// The controller settings dialog captures the next key press or gamepad event as the
+			// new binding. The captured events must not reach ImGui, otherwise they would also
+			// move the selector cursor, trigger a menu item or navigate the UI.
+			if (pad_capture_active && !pad_capture_done)
+			{
+				if (event.type == SDL_KEYDOWN && event.key.windowID == mainWindowID)
+				{
+					SDL_Scancode scancode = event.key.keysym.scancode;
+
+					if (scancode == SDL_SCANCODE_ESCAPE)
+					{
+						pad_captured_binding = 0;       // Esc cancels the capture
+						pad_capture_done = true;
+						pad_capture_active = false;
+					}
+					else if (!pad_capture_gamepad && !pad_capture_ignored(scancode))
+					{
+						pad_captured_binding = (int)scancode;
+						pad_capture_done = true;
+						pad_capture_active = false;
+					}
+
+					forMainWindow = false;
+				}
+				else if (pad_capture_gamepad && event.type == SDL_CONTROLLERBUTTONDOWN)
+				{
+					if (event.cbutton.button >= 0 && event.cbutton.button < SDL_CONTROLLER_BUTTON_MAX)
+					{
+						pad_captured_binding = PAD_GCKEY_MAKE_BUTTON(event.cbutton.button);
+						pad_capture_done = true;
+						pad_capture_active = false;
+					}
+
+					forMainWindow = false;
+				}
+				else if (pad_capture_gamepad && event.type == SDL_CONTROLLERAXISMOTION)
+				{
+					if (event.caxis.axis >= 0 && event.caxis.axis < SDL_CONTROLLER_AXIS_MAX &&
+						(event.caxis.value >= PAD_CAPTURE_AXIS_THRESHOLD || event.caxis.value <= -PAD_CAPTURE_AXIS_THRESHOLD))
+					{
+						pad_captured_binding = PAD_GCKEY_MAKE_AXIS(event.caxis.axis, event.caxis.value > 0);
+						pad_capture_done = true;
+						pad_capture_active = false;
+					}
+
+					forMainWindow = false;
+				}
+				else if (event.type == SDL_CONTROLLERBUTTONDOWN || event.type == SDL_CONTROLLERAXISMOTION)
+				{
+					// No gamepad event may navigate the UI while a binding waits for a key
+					forMainWindow = false;
+				}
 			}
 
 			if (forMainWindow)
@@ -1663,6 +2205,10 @@ static int ui_main()
 			if (event.type == SDL_WINDOWEVENT && event.window.event == SDL_WINDOWEVENT_CLOSE && event.window.windowID == mainWindowID)
 				ui_active = false;
 		}
+
+		// Keep the SDL game controllers of the pads open, and their cached state fresh. The events
+		// pumped above have the device list up to date (see PADUpdateControllers in padsdl.cpp).
+		PADUpdateControllers();
 
 		// The release of a pressed button can be delivered to another window or to another
 		// application, so do not leave the mouse captured by the main window when it is not active.
@@ -1697,6 +2243,8 @@ static int ui_main()
 
 		// 1. Show the big demo window (Most of the sample code is in ImGui::ShowDemoWindow()! You can browse its code to learn more about Dear ImGui!).
 		ui_main_window();
+
+		ui_pad_settings();
 
 		if (Debug::debugger != nullptr) {
 			Debug::debugger->DrawInternal();


### PR DESCRIPTION
Closes #357.

The SDL build had no input backend of its own. The CMake project compiled the null pad
(`padnull.cpp`) and the Visual Studio SDL configurations compiled the Win32 backend (`pad.cpp`),
which polls `GetAsyncKeyState` and only understands the virtual-key codes of the Win32 dialog —
so in the SDL build a pad could not be configured or used at all. The SDL UI had only stubs for
`Options -> Controllers`.

This branch adds `padsdl.cpp` and ports the controller settings dialog to ImGui, keyboard and
gamepad both supported.

## Pad backend — `src/padsdl.cpp`

* A pad can be driven by the keyboard (`SDL_GetKeyboardState`) and by an SDL game controller at
  the same time.
* The key bindings are **SDL scancodes** (`VKEY_FOR_*`), the gamepad bindings are **SDL game
  controller button or axis identifiers** (`GCKEY_FOR_*`), both stored in the `controllers`
  section. The Win32 and the SDL builds keep separate settings files (`SettingsWin.json` /
  `SettingsSdl.json`, see `config.h`), so the two encodings never clash.
* Analog input is preserved: left stick → main stick, right stick → C stick, LT/RT → analog L/R
  (the digital L/R fire at 50%). The keyboard `50%`/`100%` keys keep working as before; the
  contributions of both sources are summed and clamped to `int8_t` instead of overflowing.
* The Nth connected game controller drives the Nth pad (Port 1, Port 2, ...).
* Threading: `PADUpdateControllers()` is called from the UI main loop (the thread that pumps the
  SDL events) and owns the `SDL_GameController*` objects; the emulation thread reads a
  `SpinLock`-protected snapshot of their state, so a controller is never closed while it is being
  read. Devices are opened/closed on hot-plug, and a device that fails to open is not retried
  every frame.
* `PADLoadConfig` is declared in `pad.h`, so the dialog can make the backend reread the bindings
  without restarting the emulation.

## Controller settings dialog — `src/uisdl.cpp`

`Options -> Controllers -> Port 1..4` opens "Configure Controller N":

* "Plugged in" plus a `Control | Keyboard | Gamepad` table for every control. `Buttons` is on the
  left, `Control Stick` with `C Stick` under it on the right; the window auto-fits its content
  (`ImGuiWindowFlags_AlwaysAutoResize`), so there is no dead space around the controls.
* Clicking a binding arms the capture: the next key of the main window, game controller button,
  or stick/trigger deflection (past a threshold) becomes the new binding. The captured event is
  swallowed instead of being passed to ImGui, so it cannot also move the selector cursor or
  navigate the UI.
* Esc cancels. The modifier keys and F1–F12 are skipped for the keyboard, because the debugger
  uses them. An unassigned binding shows `...`, a captured gamepad axis shows the axis with its
  direction (`L Stick X +`).
* `Clear` unplugs the pad and drops both bindings; `Default` restores the Win32 keyboard defaults
  (first pad only, otherwise all the pads would react to the same keys) and the standard gamepad
  layout (every port); `OK` saves and applies; `Cancel` drops the edited copy.
* Game controller events are only handed to ImGui while the selector is shown, so a gamepad can
  navigate the UI but does not move the ImGui cursor while a game is running (controllers are
  opened now, so this had to be handled explicitly).

## Build

`CMakeLists.txt` and the VS2022/VS2026 projects compile `padsdl.cpp` in the SDL configurations
and keep `pad.cpp` for the Win32 ones; `padnull.cpp` stays as the null backend.

## Version

`8e8533ce` bumps `EMU_VERSION` to `1.8`. It is independent of the pad port — it can be dropped or
moved to its own PR if you prefer.

## How it was checked

* MSVC v145: `Release SDL|x64` and `Release|x64` build clean, no new warnings.
* The rebuilt exes were checked byte-wise: both contain the correct UTF-16 `プレイキューブ`
  title and the `1.8` version string.
* The configuration tables were cross-checked (the enum in `pad.h`, the suffixes in `padsdl.cpp`
  and `uisdl.cpp`, the dialog labels, the default tables and the group lists): all 24 controls are
  covered exactly once and the two name tables are identical.

The interactive part (capture, analog sticks, hot-plug) needs a real gamepad, so a smoke test on
a controller is recommended:

- [ ] plug a controller, `Options -> Controllers -> Port 1`, "Plugged in", `Default`, `OK`;
- [ ] the left stick drives the main stick, the right stick the C stick, LT/RT the analog triggers;
- [ ] `Z` on RB, and A/B/X/Y/Start as labelled;
- [ ] bind a button or an axis by clicking a Gamepad cell; Esc cancels the capture;
- [ ] hot-plug a second controller: it drives Port 2.

## Commits

* `22efd7f5` — SDL: port the controller settings to the SDL UI and add the SDL pad backend
* `8e8533ce` — Version 1.8