### PR TITLE
GFX: fix the texture decoder and cache the decoded images (issue #359)

### DIFF
--- a/src/tx.cpp
+++ b/src/tx.cpp
@@ -13,6 +13,23 @@ namespace GFX
 		return p;
 	}
 
+	// FNV-1a over the raw texture bytes. GXLoadTexObj programs the map of a draw on every draw, so
+	// the draw path asks for a decode all the time; the hash is what lets it tell "the same image
+	// again" from "a title edited the texels in place" without a byte-by-byte comparison of a
+	// working copy it would have to keep.
+	static uint64_t HashTextureData(const uint8_t* data, size_t size)
+	{
+		uint64_t hash = 14695981039346656037ull;
+
+		for (size_t i = 0; i < size; i++)
+		{
+			hash ^= data[i];
+			hash *= 1099511628211ull;
+		}
+
+		return hash;
+	}
+
 	void TextureEngine::TexInit()
 	{
 		memset(texMap, 0, sizeof(texMap));
@@ -113,6 +130,11 @@ namespace GFX
 		uint8_t* ptr = (uint8_t*)Flipper::HW->mem->MIGetMemoryPointerForTX(addr);
 		memcpy(&tlut[tmem], ptr, cnt * 16 * 2);
 
+		// The decoded image of a paletted texture is a function of the palette bytes as well:
+		// remember that the palettes changed so that DecodeTexture converts those maps again even
+		// when the texture bytes themselves did not move.
+		tlutGeneration++;
+
 		InvalidatePalettedTextures();
 	}
 
@@ -127,8 +149,93 @@ namespace GFX
 		}
 	}
 
-	// Decode one texture map from main memory into rgbabuf. Returns false if the map is not usable.
-	bool TextureEngine::DecodeTexture(int id)
+	// The number of bytes the decoder reads for the image of a map. The tile geometry packs the
+	// texels of a format into 32-byte units, but the total is the nominal size of the image.
+	size_t TextureEngine::TextureDataSize(int id)
+	{
+		size_t texels = (size_t)(tx.teximg0[id].width + 1) * (tx.teximg0[id].height + 1);
+
+		switch (tx.teximg0[id].fmt)
+		{
+			case TF_I4:
+			case TF_C4:
+			case TF_CMPR:
+				return texels / 2;		// 4 bits per texel
+
+			case TF_I8:
+			case TF_IA4:
+			case TF_C8:
+				return texels;			// 8 bits per texel
+
+			case TF_IA8:
+			case TF_RGB565:
+			case TF_RGB5A3:
+			case TF_C14:
+				return texels * 2;		// 16 bits per texel
+
+			case TF_RGBA8:
+				return texels * 4;		// 32 bits per texel
+
+			default:
+				return 0;
+		}
+	}
+
+	// Decode a texture map on demand. The conversion is skipped while the GL image already holds
+	// exactly the image the map describes: the address, the format, the size, the palette binding
+	// and the texture bytes (plus the palette bytes, through the TLUT generation) all have to
+	// match. This is what keeps a title that programs the same map on every draw from redoing the
+	// conversion and the upload.
+	TextureEngine::DecodeResult TextureEngine::DecodeTexture(int id)
+	{
+		TexMap* m = &texMap[id];
+
+		int fmt = tx.teximg0[id].fmt;
+		int oldw = tx.teximg0[id].width + 1;
+		int oldh = tx.teximg0[id].height + 1;
+		uint32_t addr = tx.teximg3[id].base << 5;
+		size_t size = TextureDataSize(id);
+
+		if (oldw == 0 || oldh == 0 || size == 0)
+			return DecodeResult::Failed;
+
+		// Do not hash an image that could not be decoded in the first place
+		if ((size_t)NextPowerOfTwo(oldw) * NextPowerOfTwo(oldh) > _countof(rgbabuf))
+			return DecodeResult::Failed;
+
+		const uint8_t* rawData = (const uint8_t*)Flipper::HW->mem->MIGetMemoryPointerForTX(addr);
+		if (rawData == nullptr)
+			return DecodeResult::Failed;
+
+		uint64_t hash = HashTextureData(rawData, size);
+
+		if (m->valid &&
+			m->keyAddr == addr && m->keyFmt == fmt &&
+			m->keyWidth == oldw && m->keyHeight == oldh &&
+			m->keyTlut == tx.settlut[id].tmem && m->keyTlutGen == tlutGeneration &&
+			m->keyHash == hash)
+		{
+			return DecodeResult::Unchanged;
+		}
+
+		if (!ConvertTexture(id))
+			return DecodeResult::Failed;
+
+		// Remember what the GL image now holds
+		m->keyAddr = addr;
+		m->keyFmt = fmt;
+		m->keyWidth = oldw;
+		m->keyHeight = oldh;
+		m->keyTlut = tx.settlut[id].tmem;
+		m->keyTlutGen = tlutGeneration;
+		m->keyHash = hash;
+		m->valid = true;
+
+		return DecodeResult::Decoded;
+	}
+
+	// Convert one texture map from main memory into rgbabuf. Returns false if the map is not usable.
+	bool TextureEngine::ConvertTexture(int id)
 	{
 		TexMap* m = &texMap[id];
 
@@ -218,8 +325,13 @@ namespace GFX
 				// shapes follow the tile geometry of the format, see gfx-tc.md 5.3). The intensity is
 				// the LOW nibble of the byte and the alpha the HIGH one,
 				// and each nibble is repeated to fill 8 bits.
-				for (s = 0; s < (oldw / 8); s++)  // tile hor
-					for (t = 0; t < (oldh / 4); t++) // tile ver
+				//
+				// The tiles of a texture are stored row by row: every tile of the first tile row
+				// comes first, then the tiles of the second one, and so on. The tile rows therefore
+				// have to be the outer loop; with the tile columns outer the decoder reads the tiles
+				// of a column and an image wider than one tile comes out transposed.
+				for (t = 0; t < (oldh / 4); t++) // tile ver
+					for (s = 0; s < (oldw / 8); s++)  // tile hor
 						for (v = 0; v < 4; v++)  // texel ver
 							for (u = 0; u < 8; u++)  // texel hor
 							{
@@ -409,7 +521,8 @@ namespace GFX
 							for (u = 0; u < 4; u++)
 							{
 								unsigned ofs = width * (t + v) + s + u;
-								uint16_t idx = _BYTESWAP_UINT16(*ptr++) & 0x3ff;
+								// C14X2 carries a 14-bit index into a palette of up to 16384 entries
+								uint16_t idx = _BYTESWAP_UINT16(*ptr++) & 0x3fff;
 								GetTlutCol(&rgba, id, idx);
 								texbuf[ofs].RGBA = _BYTESWAP_UINT32(rgba.RGBA);
 							}
@@ -481,10 +594,12 @@ namespace GFX
 								rgb[2].G = (rgb[0].G + rgb[1].G) / 2;
 								rgb[2].B = (rgb[0].B + rgb[1].B) / 2;
 								rgb[2].A = 255;
-								// The fourth colour of the 3-colour mode is the transparent texel
-								rgb[3].R = 0;
-								rgb[3].G = 0;
-								rgb[3].B = 0;
+								// The fourth colour of the 3-colour mode is the transparent texel: the
+								// hardware stores the average of the endpoints there and only clears
+								// its alpha, so the RGB still takes part in a blend that uses it.
+								rgb[3].R = (rgb[0].R + rgb[1].R) / 2;
+								rgb[3].G = (rgb[0].G + rgb[1].G) / 2;
+								rgb[3].B = (rgb[0].B + rgb[1].B) / 2;
 								rgb[3].A = 0;
 							}
 
@@ -547,10 +662,12 @@ namespace GFX
 								rgb[2].G = (rgb[0].G + rgb[1].G) / 2;
 								rgb[2].B = (rgb[0].B + rgb[1].B) / 2;
 								rgb[2].A = 255;
-								// The fourth colour of the 3-colour mode is the transparent texel
-								rgb[3].R = 0;
-								rgb[3].G = 0;
-								rgb[3].B = 0;
+								// The fourth colour of the 3-colour mode is the transparent texel: the
+								// hardware stores the average of the endpoints there and only clears
+								// its alpha, so the RGB still takes part in a blend that uses it.
+								rgb[3].R = (rgb[0].R + rgb[1].R) / 2;
+								rgb[3].G = (rgb[0].G + rgb[1].G) / 2;
+								rgb[3].B = (rgb[0].B + rgb[1].B) / 2;
 								rgb[3].A = 0;
 							}
 
@@ -613,10 +730,12 @@ namespace GFX
 								rgb[2].G = (rgb[0].G + rgb[1].G) / 2;
 								rgb[2].B = (rgb[0].B + rgb[1].B) / 2;
 								rgb[2].A = 255;
-								// The fourth colour of the 3-colour mode is the transparent texel
-								rgb[3].R = 0;
-								rgb[3].G = 0;
-								rgb[3].B = 0;
+								// The fourth colour of the 3-colour mode is the transparent texel: the
+								// hardware stores the average of the endpoints there and only clears
+								// its alpha, so the RGB still takes part in a blend that uses it.
+								rgb[3].R = (rgb[0].R + rgb[1].R) / 2;
+								rgb[3].G = (rgb[0].G + rgb[1].G) / 2;
+								rgb[3].B = (rgb[0].B + rgb[1].B) / 2;
 								rgb[3].A = 0;
 							}
 
@@ -681,10 +800,12 @@ namespace GFX
 								rgb[2].G = (rgb[0].G + rgb[1].G) / 2;
 								rgb[2].B = (rgb[0].B + rgb[1].B) / 2;
 								rgb[2].A = 255;
-								// The fourth colour of the 3-colour mode is the transparent texel
-								rgb[3].R = 0;
-								rgb[3].G = 0;
-								rgb[3].B = 0;
+								// The fourth colour of the 3-colour mode is the transparent texel: the
+								// hardware stores the average of the endpoints there and only clears
+								// its alpha, so the RGB still takes part in a blend that uses it.
+								rgb[3].R = (rgb[0].R + rgb[1].R) / 2;
+								rgb[3].G = (rgb[0].G + rgb[1].G) / 2;
+								rgb[3].B = (rgb[0].B + rgb[1].B) / 2;
 								rgb[3].A = 0;
 							}
 
@@ -706,14 +827,6 @@ namespace GFX
 				return false;
 		}
 
-		// Remember what the GL image was decoded from
-		m->keyAddr = addr;
-		m->keyFmt = fmt;
-		m->keyWidth = m->width;
-		m->keyHeight = m->height;
-		m->keyTlut = tx.settlut[id].tmem;
-		m->valid = true;
-
 		return true;
 	}
 
@@ -724,7 +837,19 @@ namespace GFX
 		glBindTexture(GL_TEXTURE_2D, m->glTexture);
 
 		glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, m->dw, m->dh, 0, GL_RGBA, GL_UNSIGNED_BYTE, rgbabuf);
+
+		// A texture object that already has the same size only needs its texels replaced;
+		// glTexImage2D would throw the storage away and allocate it again.
+		if (m->glWidth == m->dw && m->glHeight == m->dh)
+		{
+			glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, m->dw, m->dh, GL_RGBA, GL_UNSIGNED_BYTE, rgbabuf);
+		}
+		else
+		{
+			glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, m->dw, m->dh, 0, GL_RGBA, GL_UNSIGNED_BYTE, rgbabuf);
+			m->glWidth = m->dw;
+			m->glHeight = m->dh;
+		}
 
 		m->paramsDirty = true;
 	}
@@ -806,13 +931,19 @@ namespace GFX
 			{
 				m->dirty = false;
 
-				if (DecodeTexture(i))
+				switch (DecodeTexture(i))
 				{
-					UploadTexture(i);
-				}
-				else
-				{
-					m->valid = false;
+					case DecodeResult::Decoded:
+						UploadTexture(i);
+						break;
+
+					case DecodeResult::Unchanged:
+						// The GL texture already holds this image
+						break;
+
+					default:
+						m->valid = false;
+						break;
 				}
 			}
 
@@ -920,7 +1051,15 @@ namespace GFX
 
 			switch (kind)
 			{
-				case 0: tx.texmode0[id].bits = value; m->paramsDirty = true; break;
+				case 0:
+					// GXLoadTexObj programs the mode on every draw, and the sampler parameters
+					// (which may rebuild the mip chain) only change with the value.
+					if (tx.texmode0[id].bits != value)
+					{
+						tx.texmode0[id].bits = value;
+						m->paramsDirty = true;
+					}
+					break;
 				case 1: tx.texmode1[id].bits = value; break;
 				case 2:
 					tx.teximg0[id].bits = value;
@@ -934,7 +1073,10 @@ namespace GFX
 				case 4: tx.teximg2[id].bits = value; break;
 				case 5:
 					tx.teximg3[id].bits = value;
-					// The texture base may point at new data even if the address is unchanged
+					// The texture base may point at new data even if the address is unchanged, and
+					// a title may edit the texels in place, so the map has to be looked at again.
+					// DecodeTexture compares the description and the texture bytes and keeps the
+					// decoded image when neither changed.
 					m->dirty = true;
 					break;
 				case 6:
@@ -964,6 +1106,11 @@ namespace GFX
 
 			case TX_INVTAGS_ID:
 				tx.invtags = value;
+				// The hardware's "the texture bytes changed" command (GXInvalidateTexAll). The
+				// backend decodes from main memory on demand and otherwise keeps the decoded image,
+				// so every map has to be decoded again.
+				for (int i = 0; i < GFX_MAX_TEXTURES; i++)
+					texMap[i].dirty = true;
 				return;
 
 			case TX_PERFMODE_ID:
@@ -1001,7 +1148,9 @@ namespace GFX
 	{
 		id &= (GFX_MAX_TEXTURES - 1);
 
-		if (!DecodeTexture(id))
+		// The dump wants the pixels, not the cache: rgbabuf is shared by all maps and may hold the
+		// image of another one, so the map has to be converted into it unconditionally.
+		if (!ConvertTexture(id))
 		{
 			return false;
 		}
@@ -1017,11 +1166,16 @@ namespace GFX
 		{
 			for (int x = 0; x < m->width; x++)
 			{
-				const Color& c = rgbabuf[(size_t)y * m->dw + x];
+				// The decoder serialises every texel into the R,G,B,A byte order the GL upload
+				// wants, which is the reverse of the Color field order (Color is A,B,G,R). Read
+				// the bytes, not the fields: after the serialisation the `R` field holds the
+				// alpha, the `G` field the blue one and so on, which is why reading the fields
+				// dumped every non-grey format with the channels rotated.
+				const uint8_t* c = (const uint8_t*)&rgbabuf[(size_t)y * m->dw + x];
 				uint8_t* p = &rgb[((size_t)y * m->width + x) * 3];
-				p[0] = c.R;
-				p[1] = c.G;
-				p[2] = c.B;
+				p[0] = c[0];
+				p[1] = c[1];
+				p[2] = c[2];
 			}
 		}
 
@@ -1030,6 +1184,7 @@ namespace GFX
 
 	void TextureEngine::Reset()
 	{		tx = TXState{};
+		tlutGeneration = 0;
 
 		for (int i = 0; i < GFX_MAX_TEXTURES; i++)
 		{
@@ -1045,6 +1200,8 @@ namespace GFX
 			m->keyFmt = -1;
 			m->keyWidth = m->keyHeight = 0;
 			m->keyTlut = 0xFFFFFFFF;
+			m->keyTlutGen = 0;
+			m->keyHash = 0;
 			m->appliedMode0 = 0xFFFFFFFF;
 			m->appliedMode1 = 0xFFFFFFFF;
 		}

--- a/src/tx.h
+++ b/src/tx.h
@@ -274,10 +274,16 @@ namespace GFX
 		int dw = 0, dh = 0;				//!< Size of the GL image (power of two)
 		float ds = 1.0f, dt = 1.0f;		//!< Texture coordinate scale (real / stored)
 
+		// Size the GL image was last allocated with, so that a re-decode can upload into the
+		// existing storage (glTexSubImage2D) instead of reallocating it (glTexImage2D)
+		int glWidth = 0, glHeight = 0;
+
 		// What the current GL image was decoded from
 		uint32_t keyAddr = 0;
 		int keyFmt = -1, keyWidth = 0, keyHeight = 0;
 		uint32_t keyTlut = 0xFFFFFFFF;
+		uint32_t keyTlutGen = 0;		//!< TLUT generation the image was decoded with
+		uint64_t keyHash = 0;			//!< Content hash of the texture bytes the image was decoded from
 
 		uint32_t appliedMode0 = 0xFFFFFFFF;	//!< TexMode0 value the sampler parameters were set from
 		uint32_t appliedMode1 = 0xFFFFFFFF;	//!< TexMode1 value the LOD limits were set from
@@ -297,12 +303,28 @@ namespace GFX
 		Color rgbabuf[1024 * 1024];
 		uint8_t tlut[1024 * 1024];  // TLUT buffer
 
+		//! Bumped by every palette load. A paletted texture is a function of the palette bytes as
+		//! well as of its own, so a decoded image is only current while this counter is unchanged.
+		uint32_t tlutGeneration = 0;
+
 		bool active = false;
+
+		//! What DecodeTexture did with a map.
+		enum class DecodeResult
+		{
+			Failed,			//!< The map is not usable (bad address or unknown format)
+			Decoded,		//!< rgbabuf holds a new image that has to be uploaded
+			Unchanged,		//!< The GL texture already holds exactly this image
+		};
 
 		void TexInit();
 		void TexFree();
 		void GetTlutCol(Color* c, unsigned id, unsigned entry);
-		bool DecodeTexture(int id);
+		DecodeResult DecodeTexture(int id);
+		//! Decode unconditionally into rgbabuf (the debugger dump and the caching decode above).
+		bool ConvertTexture(int id);
+		//! The byte size of the raw image of a map, as the decoder reads it.
+		size_t TextureDataSize(int id);
 		void UploadTexture(int id);
 		void ApplyTextureParams(int id);
 		void LoadTlut(uint32_t addr, uint32_t tmem, uint32_t cnt);

--- a/testing/gfx_report_texture_test.cpp
+++ b/testing/gfx_report_texture_test.cpp
@@ -331,9 +331,11 @@ namespace pureikyubutest
 					break;
 
 				case GFX::TF_IA4:
-					// The IA4 decoder walks the tiles column first (tx.cpp), so the encoder does too
-					for (int s = 0; s < w; s += 8)
-						for (int t = 0; t < h; t += 4)
+					// Tile rows first, like the decoder: the tiles of a texture are stored row by
+					// row, so the encoder must not mirror a column-first walk here (doing that hid
+					// the transposed decode the gallery was supposed to show).
+					for (int t = 0; t < h; t += 4)
+						for (int s = 0; s < w; s += 8)
 							for (int v = 0; v < 4; v++)
 								for (int u = 0; u < 8; u++)
 								{

--- a/testing/gfx_texture_test.cpp
+++ b/testing/gfx_texture_test.cpp
@@ -208,6 +208,73 @@ namespace pureikyubutest
 			Assert::AreEqual<int>(0x00, rgb[0], L"alpha 0x55 must be discarded");
 		}
 
+		// The 8x4 tiles of an IA4 image are stored row by row: every tile of the first tile row
+		// comes first, then the tiles of the second one. With the tile columns as the outer loop
+		// the decoder reads a column of tiles and any image wider than one tile comes out
+		// transposed. Tag the first texel of each of the four tiles of a 16x8 image (the low
+		// nibble is the intensity, the high one keeps the texel opaque) and read them back.
+		TEST_METHOD(Tex_IA4ReadsTheTileGridInRowOrder)
+		{
+			RequireGL();
+			GfxTestMachine& m = M();
+			SetupPassThrough(m);
+			SetupStage0(m);
+
+			uint8_t raw[128] = { 0 };
+			raw[0 * 32] = 0xF1;				// tile (0, 0)
+			raw[1 * 32] = 0xF2;				// tile (1, 0), the other tile of the first tile row
+			raw[2 * 32] = 0xF3;				// tile (0, 1), the first tile of the second tile row
+			raw[3 * 32] = 0xF4;				// tile (1, 1)
+
+			SetupTexture(m, 16, 8, GFX::TF_IA4, raw, sizeof(raw));
+
+			uint8_t rgb[3];
+
+			DrawTexel(m, 16, 8, 0, 0, rgb);
+			Assert::AreEqual<int>(0x11, rgb[0], L"tile (0, 0)");
+
+			DrawTexel(m, 16, 8, 8, 0, rgb);
+			Assert::AreEqual<int>(0x22, rgb[0], L"tile (1, 0) follows it in memory");
+
+			DrawTexel(m, 16, 8, 0, 4, rgb);
+			Assert::AreEqual<int>(0x33, rgb[0], L"tile (0, 1) starts the second tile row");
+
+			DrawTexel(m, 16, 8, 8, 4, rgb);
+			Assert::AreEqual<int>(0x44, rgb[0], L"tile (1, 1)");
+		}
+
+		// The texels of the 8x8 tiles of a 4-bit image are laid out the same way. I4 has two
+		// texels per byte (the high nibble first), so the tag goes into the high nibble.
+		TEST_METHOD(Tex_I4ReadsTheTileGridInRowOrder)
+		{
+			RequireGL();
+			GfxTestMachine& m = M();
+			SetupPassThrough(m);
+			SetupStage0(m);
+
+			uint8_t raw[128] = { 0 };
+			raw[0 * 32] = 0x10;				// tile (0, 0)
+			raw[1 * 32] = 0x20;				// tile (1, 0)
+			raw[2 * 32] = 0x30;				// tile (0, 1)
+			raw[3 * 32] = 0x40;				// tile (1, 1)
+
+			SetupTexture(m, 16, 16, GFX::TF_I4, raw, sizeof(raw));
+
+			uint8_t rgb[3];
+
+			DrawTexel(m, 16, 16, 0, 0, rgb);
+			Assert::AreEqual<int>(0x11, rgb[0], L"tile (0, 0)");
+
+			DrawTexel(m, 16, 16, 8, 0, rgb);
+			Assert::AreEqual<int>(0x22, rgb[0], L"tile (1, 0)");
+
+			DrawTexel(m, 16, 16, 0, 8, rgb);
+			Assert::AreEqual<int>(0x33, rgb[0], L"tile (0, 1)");
+
+			DrawTexel(m, 16, 16, 8, 8, rgb);
+			Assert::AreEqual<int>(0x44, rgb[0], L"tile (1, 1)");
+		}
+
 		// IA8: 8 bits of intensity and 8 bits of alpha, intensity in the high byte.
 		TEST_METHOD(Tex_IA8SplitsIntensityAndAlpha)
 		{
@@ -590,6 +657,100 @@ namespace pureikyubutest
 			Assert::AreEqual<int>(0x00, rgb[0], L"red");
 			Assert::AreEqual<int>(0xFF, rgb[1], L"green from palette entry 2");
 			Assert::AreEqual<int>(0x00, rgb[2], L"blue");
+		}
+
+		// =========================================================================================
+		// Decoding on demand: what invalidates a decoded image, and what the debugger gets back
+		// =========================================================================================
+
+		// The debugger's texture dump (the `gxtexdump` command) must hand the colour channels back
+		// in R,G,B order. The decoder serialises every texel into the byte order the GL upload
+		// wants (R,G,B,A), which is the reverse of the Color field order, so a dump that read the
+		// union fields used to rotate the channels of every non-grey format.
+		TEST_METHOD(Tex_DumpReturnsTheColourChannelsInOrder)
+		{
+			RequireGL();
+			GfxTestMachine& m = M();
+			SetupPassThrough(m);
+			SetupStage0(m);
+
+			uint8_t raw[64] = { 0 };
+			raw[0] = 0xAA;					// alpha
+			raw[1] = 0x11;					// red
+			raw[32] = 0x22;					// green
+			raw[33] = 0x33;					// blue
+
+			SetupTexture(m, 4, 4, GFX::TF_RGBA8, raw, sizeof(raw));
+
+			std::vector<uint8_t> rgb;
+			int width = 0, height = 0;
+			Assert::IsTrue(m.gfx->tx->DumpTexture(0, rgb, &width, &height));
+
+			Assert::AreEqual<int>(4, width, L"width");
+			Assert::AreEqual<int>(4, height, L"height");
+			Assert::AreEqual<int>(0x11, rgb[0], L"red");
+			Assert::AreEqual<int>(0x22, rgb[1], L"green");
+			Assert::AreEqual<int>(0x33, rgb[2], L"blue");
+		}
+
+		// GXLoadTexObj programs the whole map on every draw, so the draw path asks for a decode all
+		// the time; the decoder keeps the image it already has when the description *and* the
+		// texture bytes are the same, but a title that edits the texels in place (and programs the
+		// same map again) must still get the new bytes. Rewriting the same registers with other
+		// data at the same address is exactly that case.
+		TEST_METHOD(Tex_AnInPlaceEditOfTheTexelsIsPickedUp)
+		{
+			RequireGL();
+			GfxTestMachine& m = M();
+			SetupPassThrough(m);
+			SetupStage0(m);
+
+			uint8_t raw[32] = { 0 };
+			raw[0] = 0x20;
+
+			SetupTexture(m, 4, 4, GFX::TF_I8, raw, sizeof(raw));
+
+			uint8_t rgb[3];
+			DrawTexel(m, 4, 4, 0, 0, rgb);
+			Assert::AreEqual<int>(0x20, rgb[0], L"the first image");
+
+			// The same map (same address, format and size) with other texels behind it
+			raw[0] = 0x80;
+			SetupTexture(m, 4, 4, GFX::TF_I8, raw, sizeof(raw));
+
+			DrawTexel(m, 4, 4, 0, 0, rgb);
+			Assert::AreEqual<int>(0x80, rgb[0], L"the edited texel");
+		}
+
+		// The same holds for a palette: rebinding the same TLUT after its entries changed has to
+		// re-expand the indices, even though the texture bytes did not move.
+		TEST_METHOD(Tex_AReloadedPaletteIsPickedUp)
+		{
+			RequireGL();
+			GfxTestMachine& m = M();
+			SetupPassThrough(m);
+			SetupStage0(m);
+
+			const uint16_t red[4] = { 0xF800, 0xF800, 0xF800, 0xF800 };
+			SetupRgb565Tlut(m, red, 4);
+
+			uint8_t raw[32] = { 0 };
+			raw[0] = 0;						// texel (0, 0) uses the first entry
+
+			SetupTexture(m, 4, 4, GFX::TF_C8, raw, sizeof(raw));
+
+			uint8_t rgb[3];
+			DrawTexel(m, 4, 4, 0, 0, rgb);
+			Assert::AreEqual<int>(0xFF, rgb[0], L"red from the first palette");
+			Assert::AreEqual<int>(0x00, rgb[2], L"...");
+
+			// Load another palette into the same TMEM slot and bind it again
+			const uint16_t blue[4] = { 0x001F, 0x001F, 0x001F, 0x001F };
+			SetupRgb565Tlut(m, blue, 4);
+
+			DrawTexel(m, 4, 4, 0, 0, rgb);
+			Assert::AreEqual<int>(0x00, rgb[0], L"the texture bytes did not change");
+			Assert::AreEqual<int>(0xFF, rgb[2], L"the new palette entries appear");
 		}
 	};
 }

--- a/wiki/gfx.md
+++ b/wiki/gfx.md
@@ -194,6 +194,37 @@ The tile shapes come from the texture unit (gfx-tc.md 5.3): 4-bit formats are
 AR unit first, then the GB one). CMPR sub-blocks sit in the 8x8 tile in the order TL, TR, BL, BR at
 byte offsets 0/8/16/24.
 
+The tiles of an image are stored **row by row**: every tile of the first tile row comes first, then
+the tiles of the second one, and so on. An image that is wider than one tile therefore needs the
+tile row as the outer walk of the decoder; with the tile columns outer the map is read column by
+column and everything but the first tile column is transposed. This is what happened to the IA4
+decoder (8-wide tiles) and it is why a 32x32 IA4 map came out as noise while the same map was
+correct in the gallery - the gallery encoder mirrored the decoder's walk. Both walks are row-first
+now, and `gfx_texture_test.cpp` samples the first texel of every tile of a 2x2 tile grid for the
+8x8 (I4), 8x4 (IA4) and 16-bit/RGBA8 formats so the order is pinned.
+
+The C14X2 palette index is 14 bits wide (the register field passes all of them through), and the
+transparent fourth colour of the CMPR three-colour mode keeps the average of its two endpoints with
+a cleared alpha, which is what the hardware puts there (the RGB takes part in a blend that uses it,
+only the alpha makes the texel invisible).
+
+### Decoding on demand
+
+A draw programs the whole texture map (`GXLoadTexObj`) every time it uses it, so the backend is
+asked for a decode constantly. `DecodeTexture` only converts and uploads when the map really
+changed: it compares the description (base address, format, size, palette binding) and an FNV-1a
+hash of the raw texture bytes it would read against what the GL texture was decoded from
+(`TexMap::key*`). A palette lives outside the texture bytes, so every TLUT load bumps a generation
+counter that is part of the check as well (`gfx-tc.md` palettes are shared by the maps that bind
+them). Titles that edit a texture in place are still picked up, because the hash covers the bytes,
+not just the registers; `Tex_AnInPlaceEditOfTheTexelsIsPickedUp` and
+`Tex_AReloadedPaletteIsPickedUp` pin that down.
+
+`TX_INVTAGS` (`GXInvalidateTexAll`) marks every map for a decode again. The upload reuses the GL
+image storage (`glTexSubImage2D`) while the image size is unchanged, and the sampler parameters
+(including the mip chain of a mipmapped map) are only re-applied when `TX_SETMODE0/1` really
+changes, not on every write of the same value.
+
 **Open item (CMPR).** The format definition available to the project describes the two interpolated
 endpoints as thirds (`(2*A + B) / 3`), which is what the decoder implements, while a second
 description of the same decoder gives `A*(frac+1) + B*(8-frac-1)` shifted right by three, i.e. 3/8


### PR DESCRIPTION
The tex-fmt-cube demo decoded some formats as garbage. Comparing the decoder against the real demo data and the format definition found:

- IA4 walked the tiles column first (tile columns outer), while the tiles of an image are stored row by row. A map wider than one tile (the demo's 32x32 IA4) came out transposed. The report encoder mirrored the same walk, which is why the gallery never showed it; both are row-first now.
- The debugger's texture dump (gxtexdump) read the Color fields after the decoder had serialised the texels into the R,G,B,A byte order GL wants, which rotated the channels of every non-grey format.
- C14X2 masked its palette index with 0x3ff instead of the 14-bit 0x3fff.
- The transparent fourth colour of the CMPR three-colour mode lost the RGB of the endpoint average the hardware keeps there.

The map of a draw is programmed on every draw (GXLoadTexObj), so the decoder is asked for a decode all the time. DecodeTexture now compares the description and an FNV-1a hash of the raw texture bytes (plus a TLUT generation for the palette) and keeps the GL image when nothing changed, and that still picks up in-place texel and palette edits. The upload reuses the image storage (glTexSubImage2D), the sampler parameters and the mip chain are only re-applied when TX_SETMODE0/1 really change, and TX_INVTAGS (GXInvalidateTexAll) marks every map for a decode again.

Tests: multi-tile sampling for IA4/I4, the dump channel order, an in-place texel edit and a reloaded palette (348 green). See wiki/gfx.md.