### PR TITLE
Perf: the Gekko <-> PI/MEM path is not the bottleneck; the device threads polling the time base are (issue #360)

### DIFF
--- a/src/cp.cpp
+++ b/src/cp.cpp
@@ -67,7 +67,7 @@ namespace Flipper
 		fifo->Reset();
 
 		tickPerFifo = 100;
-		updateTbrValue = Core->GetTicks() + tickPerFifo;
+		updateTbrValue = Core->GetTicks() + (int64_t)tickPerFifo * (int64_t)FifoBatch;
 
 		cp_thread = EMUCreateThread(CPThread, false, this, "CPThread");
 
@@ -144,18 +144,74 @@ namespace Flipper
 		}
 	}
 
+	bool CommandProcessor::HasFifoWork()
+	{
+		// Same count calculation as PumpFifo, but without any of its side effects.
+		uint32_t cnt;
+
+		if (cpregs.wrptr >= cpregs.rdptr)
+		{
+			cnt = cpregs.wrptr - cpregs.rdptr;
+		}
+		else
+		{
+			cnt = (cpregs.top - cpregs.rdptr) + (cpregs.wrptr - cpregs.base);
+		}
+
+		return cnt != 0 && (cpregs.cr & CP_CR_RDEN) != 0 &&
+			(cpregs.sr & (CP_SR_OVF | CP_SR_UVF | CP_SR_BPINT)) == 0;
+	}
+
+	// Called every Flipper tick step by the CPU thread. The CP thread is woken once per `FifoBatch`
+	// FIFO entries of emulated CP time, so it can drain a batch and go back to sleep instead of
+	// polling the time base in a tight loop (see the notes at Gekko::CpuStats).
+	void CommandProcessor::TickSync(int64_t ticks)
+	{
+		if (cp_thread == nullptr)
+		{
+			return;
+		}
+
+		// See Flipper::Update: a backwards jump of the time base (a CPU reset) invalidates the
+		// anchor and has to be picked up, or the FIFO would stop draining.
+		if (ticks < updateTbrValue && (updateTbrValue - ticks) < (int64_t)tickPerFifo * (int64_t)FifoBatch)
+		{
+			return;
+		}
+
+		updateTbrValue = ticks + (int64_t)tickPerFifo * (int64_t)FifoBatch;
+		lastDrainTick = ticks;
+		fifoEvent.Signal();
+	}
+
 	void CommandProcessor::CPThread(void* Param)
 	{
 		CommandProcessor* cp = (CommandProcessor*)Param;
 
+		// Block until the CPU thread says that a batch of FIFO entries is due (or until the safety
+		// timeout expires, so that a missed wakeup cannot stall the graphics pipeline).
+		cp->fifoEvent.Wait(2);
+
 		int64_t ticks = Core->GetTicks();
-		if (ticks < cp->updateTbrValue)
+
+		// How many entries the emulated CP could have consumed since the last drain. The batch is
+		// bounded, so that a long gap does not turn into one huge burst.
+		int64_t budget = (ticks - cp->lastDrainTick) / (int64_t)cp->tickPerFifo;
+		if (budget <= 0)
 		{
 			return;
 		}
-		cp->updateTbrValue = ticks + cp->tickPerFifo;
+		cp->lastDrainTick = ticks;
 
-		cp->PumpFifo();
+		if (budget > (int64_t)CommandProcessor::FifoBatch * 4)
+		{
+			budget = (int64_t)CommandProcessor::FifoBatch * 4;
+		}
+
+		while (budget-- > 0 && cp->HasFifoWork())
+		{
+			cp->PumpFifo();
+		}
 	}
 
 	// One burst of the graphics FIFO: this is what the CP does on a tick, and what the unit tests

--- a/src/cp.h
+++ b/src/cp.h
@@ -545,6 +545,16 @@ namespace Flipper
 		size_t	tickPerFifo = 0;
 		int64_t	updateTbrValue = 0;
 
+		// The CP thread must not busy-wait on the CPU's time base: it is woken instead, every
+		// `FifoBatch` FIFO entries' worth of emulated ticks, through this event (see CPThread).
+		// `lastDrainTick` is the tick the thread last drained the FIFO at, so that the drain stays
+		// at the emulated CP rate even when the thread was not scheduled for a while.
+		static const size_t FifoBatch = 16;
+
+		Event fifoEvent;
+		int64_t lastDrainTick = 0;
+		bool HasFifoWork();
+
 		// Stats
 		size_t cpLoads = 0;
 		size_t xfLoads = 0;
@@ -587,6 +597,12 @@ namespace Flipper
 
 		// Streaming FIFO burst write notification from PI
 		void FifoWriteBurst();
+
+		/// <summary>
+		/// Called by the CPU thread (through Flipper::Update) every Flipper tick step, so that the
+		/// CP thread is woken when the emulated CP has a batch of FIFO entries to consume.
+		/// </summary>
+		void TickSync(int64_t ticks);
 
 		void CPAbortFifo();
 

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -789,6 +789,13 @@ namespace Debug
 			case PerfCounter::PEs:
 				return Flipper::HW->pi->PIGetInterruptCounter(PIInterruptSource::PE_FINISH);
 				break;
+
+			case PerfCounter::GekkoCompiledSegments:
+				return Gekko::stats.jitCompiles;
+				break;
+			case PerfCounter::GekkoExecutedSegments:
+				return Gekko::stats.jitBlocks;
+				break;
 		}
 
 		return value;
@@ -809,6 +816,13 @@ namespace Debug
 				break;
 			case PerfCounter::PEs:
 				Flipper::HW->pi->PIResetInterruptCounter(PIInterruptSource::PE_FINISH);
+				break;
+
+			case PerfCounter::GekkoCompiledSegments:
+				Gekko::stats.jitCompiles = 0;
+				break;
+			case PerfCounter::GekkoExecutedSegments:
+				Gekko::stats.jitBlocks = 0;
 				break;
 		}
 	}

--- a/src/debug.h
+++ b/src/debug.h
@@ -189,6 +189,29 @@ namespace Debug
 		VIs,				// Number of VI VBlank interrupts (based on PI interrupt counters)
 		PEs,				// Number of PE DRAW_DONE operations (based on PI interrupt counters)
 
+		// CPU-side counters (see Gekko::CpuStats). 4 and 5 are also what the status bar shows as
+		// "jitc <compiled>/<executed>".
+		GekkoCompiledSegments,		// Basic blocks translated by the recompiler
+		GekkoExecutedSegments,		// Basic blocks run by the recompiler
+		GekkoJitInstrs,			// Instructions retired inside those blocks
+		GekkoFallbacks,			// Instructions handed back to the interpreter from a block
+		GekkoInterpInstrs,		// Instructions run by the interpreter proper
+		DcacheFills,			// Data cache line fills
+		IcacheFills,			// Instruction cache line fills
+		PiReads,			// Single-beat CPU reads that reached the PI
+		PiWrites,			// Single-beat CPU writes that reached the PI
+		MmioReads,			// ... of those, the ones that hit the register space
+		MmioWrites,
+
+		// Host cycle counters (see Gekko::CycleScope). Only meaningful while `--bench` is running,
+		// which is the only thing that turns Gekko::cycleProfile on.
+		JitInvalidations,		// Times the whole block cache was dropped
+		JitRunCycles,			// Host cycles inside Jit::Run (including the compiled blocks)
+		JitCompileCycles,		// ... of which spent translating a block
+		JitFallbackCycles,		// ... of which spent in the interpreter fallback
+		CastInCycles,			// Host cycles spent filling cache lines from the PI/MEM
+		InterpCycles,			// Host cycles inside one interpreted instruction
+
 		Max,
 	};
 

--- a/src/dsp.cpp
+++ b/src/dsp.cpp
@@ -307,6 +307,11 @@ namespace DSP
 	{
 		Dsp16* dsp = (Dsp16*)Parameter;
 
+		// Block until the CPU thread says that a batch of DSP time is due (see DspCore::TickSync).
+		// The thread used to poll the shared time base in a tight loop, which cost far more than the
+		// DSP work itself (see the benchmark notes in `testing/gekko_bench`).
+		dsp->core->WaitForWork();
+
 		// Do DSP actions
 		dsp->core->Update();
 	}
@@ -321,6 +326,8 @@ namespace DSP
 				Report(Channel::DSP, "Run\n");
 			}
 			savedGekkoTicks = Core->GetTicks();
+			core->wakeTick = savedGekkoTicks;
+			core->workEvent.Signal();
 		}
 	}
 
@@ -795,7 +802,7 @@ namespace DSP
 			Report(Channel::DSP, "CpuToDspWriteHi: 0x%04X\n", value);
 		}
 
-		core->delay_mailbox_reasons = 4;
+		core->HoldMailbox();
 
 		// Bit 15 carries the valid flag, so the sender's bit 15 is discarded here
 		// (writing the high word clears the flag).
@@ -812,7 +819,7 @@ namespace DSP
 			Report(Channel::DSP, "CpuToDspWriteLo: 0x%04X\n", value);
 		}
 
-		core->delay_mailbox_reasons = 4;
+		core->HoldMailbox();
 
 		CpuToDspMailbox[1] = value;
 		CpuToDspMailbox[0] |= 0x8000;

--- a/src/dspai.cpp
+++ b/src/dspai.cpp
@@ -104,12 +104,25 @@ namespace DSP
 		*reg = CDCR;
 	}
 
+	void DspAIControl::Reset()
+	{
+		cdcr = 0;
+		madr_hi = 0;
+		madr_lo = 0;
+		len = 0;
+		dcnt = 0;
+		currentDmaAddr = 0;
+		dmaTime = (uint64_t)-1;
+		memset(zeroes, 0, sizeof(zeroes));
+	}
+
 	// ---------------------------------------------------------------------------
 	// DMA
 
 	// dma transfer complete (when AIDCNT == 0)
 	void AIDINT()
 	{
+		Gekko::stats.aiInts++;
 		CDCR |= CDCR_AIINT;
 		if (CDCR & CDCR_AIINTMSK)
 		{
@@ -133,6 +146,9 @@ namespace DSP
 		dsp_ai.dcnt = dsp_ai.len & ~AID_EN;
 		dsp_ai.dmaTime = Core->GetTicks() + AIGetTime(32, dsp_ai.dmaRate);
 		dsp_ai.currentDmaAddr = (dsp_ai.madr_hi << 16) | dsp_ai.madr_lo;
+
+		// The thread may have parked itself while no DMA was armed; wake it for the first block.
+		dsp_ai.audioEvent.Signal();
 		if (dsp_ai.log)
 		{
 			Report(Channel::AI, "DMA started: %08X, %i bytes\n", dsp_ai.currentDmaAddr, dsp_ai.dcnt * 32);
@@ -143,6 +159,8 @@ namespace DSP
 	// Simulate AI FIFO
 	static void AIFeedMixer()
 	{
+		Gekko::stats.aiFeeds++;
+
 		int bytes = 32;
 
 		if (dsp_ai.dcnt == 0 || (dsp_ai.len & AID_EN) == 0)
@@ -265,8 +283,37 @@ namespace DSP
 	}
 
 	// Update audio DMA thread
+	// Called by the CPU thread every Flipper tick step. The DMA asks for a 32-byte block every
+	// `AIGetTime(32, rate)` ticks (about 6750 at 48 kHz), so the thread can block between the blocks.
+	void AITickSync(int64_t ticks)
+	{
+		if (dsp_ai.audioThread == nullptr)
+		{
+			return;
+		}
+
+		if (dsp_ai.dmaTime == (uint64_t)-1 || (uint64_t)ticks < dsp_ai.dmaTime)
+		{
+			return;
+		}
+
+		dsp_ai.audioEvent.Signal();
+	}
+
 	static void AIUpdate(void* Parameter)
 	{
+		// Block until the next DMA block is due (or the safety timeout expires, so that a missed
+		// wakeup cannot stall the audio). See AITickSync.
+		dsp_ai.audioEvent.Wait(2);
+
+		if (dsp_ai.dmaTime == (uint64_t)-1)
+		{
+			// No DMA is armed, so there is nothing to feed: park the thread until AIStartDMA
+			// resumes it instead of spinning on the time base.
+			dsp_ai.audioThread->Suspend();
+			return;
+		}
+
 		if ((uint64_t)Core->GetTicks() >= dsp_ai.dmaTime)
 		{
 			if (dsp_ai.dcnt == 0)
@@ -302,7 +349,7 @@ namespace DSP
 		Report(Channel::AI, "DSP AI DMA\n");
 
 		// clear regs
-		memset(&dsp_ai, 0, sizeof(DspAIControl));
+		dsp_ai.Reset();
 
 		dsp_ai.audioThread = EMUCreateThread(AIUpdate, true, nullptr, "AI");
 

--- a/src/dspai.h
+++ b/src/dspai.h
@@ -25,6 +25,19 @@ namespace DSP
 
 		Thread* audioThread;    // The main AI thread that receives samples from AI DMA FIFO.
 		// When FIFOs overflow - AudioThread Feed Mixer.
+
+		// The AI thread is woken through this event at the ticks where the next DMA block is due
+		// (see AITickSync). It used to poll the Gekko time base in a tight loop, which made every
+		// write of that time base transfer the cache line between the cores and cost far more than
+		// the DMA work itself (see the benchmark notes in `testing/gekko_bench`).
+		Event audioEvent;
+
+		/// <summary>
+		/// Put the AI DMA state back to its power-on value. This exists because the block used to be
+		/// cleared with a plain memset, which also wiped the Event above (a wait on a zeroed handle
+		/// returns immediately, so the AI thread silently went back to spinning).
+		/// </summary>
+		void Reset();
 	};
 
 	extern  DspAIControl dsp_ai;
@@ -39,4 +52,10 @@ namespace DSP
 	bool    DSPGetResetModifier();
 
 	void	DspSetAiDmaSampleRate(int32_t rate);
+
+	/// <summary>
+	/// Called by the CPU thread (through Flipper::Update) every Flipper tick step, so that the AI
+	/// thread wakes up when the next DMA block is due.
+	/// </summary>
+	void	AITickSync(int64_t ticks);
 }

--- a/src/dspcore.cpp
+++ b/src/dspcore.cpp
@@ -635,6 +635,35 @@ namespace DSP
 		dsp->Suspend();
 	}
 
+	// Called by the CPU thread every Flipper tick step. Waking up on every step would mean about a
+	// million scheduler wakeups per second, so the thread is woken once per `DspWakeTicks` and then
+	// drains a whole batch.
+	void DspCore::TickSync(int64_t ticks)
+	{
+		if (ticks < wakeTick)
+		{
+			return;
+		}
+
+		wakeTick = ticks + DspWakeTicks;
+		workEvent.Signal();
+	}
+
+	void DspCore::HoldMailbox()
+	{
+		if (Core != nullptr)
+		{
+			mailboxHoldTick = Core->GetTicks() + MailboxHoldTicks;
+		}
+	}
+
+	void DspCore::WaitForWork()
+	{
+		// The safety timeout keeps a missed wakeup from stalling the DSP forever.
+		workEvent.Wait(2);
+		Gekko::stats.dspWakes++;
+	}
+
 	void DspCore::Update()
 	{
 		uint64_t ticks = Core->GetTicks();
@@ -642,12 +671,18 @@ namespace DSP
 		// We need to suspend DspCore execution for a while until the CPU writes all data to Mailbox registers.
 		// In reality 2 writes from Gekko side fly quickly through Flipper's guts and DSPCore does not have time to wedge in the middle. In the emulator it is necessary to do more carefully.
 
-		if (delay_mailbox_reasons > 0) {
-			delay_mailbox_reasons--;
+		if (ticks < mailboxHoldTick)
+		{
 			return;
 		}
 
-		if (ticks >= (dsp->savedGekkoTicks + GekkoTicksPerDspInstruction))
+		// Execute everything the emulated DSP could have executed since it last ran, up to one
+		// wakeup's worth. The anchor is taken again at the end exactly as the one-instruction-at-a-
+		// time version did: the DSP is limited by the host, not by the emulated clock, and the
+		// backlog is dropped rather than accumulated.
+		uint32_t budget = (uint32_t)(DspWakeTicks / (int64_t)GekkoTicksPerDspInstruction);
+
+		while (budget-- > 0 && ticks >= (dsp->savedGekkoTicks + GekkoTicksPerDspInstruction))
 		{
 			// Test breakpoints and canaries
 			if (dsp->IsRunning())
@@ -675,6 +710,12 @@ namespace DSP
 			CheckInterrupts();
 
 			interp->ExecuteInstr();
+			Gekko::stats.dspInstrs++;
+			dsp->savedGekkoTicks += GekkoTicksPerDspInstruction;
+		}
+
+		if (dsp->savedGekkoTicks <= ticks)
+		{
 			dsp->savedGekkoTicks = ticks;
 		}
 	}

--- a/src/dspcore.h
+++ b/src/dspcore.h
@@ -440,9 +440,37 @@ namespace DSP
 		/// <summary>
 		/// In a real Flipper 2 writes to CPU->DSP Mailbox cannot be interrupted in the middle by a read from the DSP side.
 		/// If this happens - Deadlock can happen.
-		/// We solve this problem by artificially delaying the DspCore execution thread.
+		/// We solve this problem by holding the DSP off for a few ticks after each mailbox write.
+		///
+		/// This is a tick, not a number of Update() calls: Update() now drains a whole batch, so
+		/// counting calls would hold the DSP off for a whole batch (thousands of ticks) instead of
+		/// the few instructions the two mailbox writes are apart.
 		/// </summary>
-		int delay_mailbox_reasons = 0;
+		int64_t mailboxHoldTick = 0;
+		static const int64_t MailboxHoldTicks = 100;
+
+		/// <summary>
+		/// Called by the CPU side after a mailbox half-write: hold the DSP off for a few ticks so
+		/// that it cannot read the mailbox between the two halves of a message (see mailboxHoldTick).
+		/// Tolerates a null Core, which is what the DSP unit tests have (they drive the mailbox
+		/// directly, without a Gekko core behind it).
+		/// </summary>
+		void HoldMailbox();
+
+		// The DSP thread is woken through this event at the ticks where it has a batch of
+		// instructions' worth of time to execute (see TickSync), instead of polling the Gekko time
+		// base in a tight loop (see the benchmark notes in `testing/gekko_bench`).
+		Event workEvent;
+		int64_t wakeTick = 0;
+
+		/// <summary>
+		/// How many Gekko ticks one wakeup covers. The DSP wants one instruction every
+		/// `GekkoTicksPerDspInstruction` ticks, so a wakeup carries
+		/// `DspWakeTicks / GekkoTicksPerDspInstruction` instructions. Waking up once per Flipper tick
+		/// step would mean roughly a million scheduler wakeups per second, which costs more than the
+		/// DSP work itself.
+		/// </summary>
+		static const int64_t DspWakeTicks = 1000;
 
 	public:
 
@@ -466,6 +494,17 @@ namespace DSP
 		void HardReset();
 
 		void Update();
+
+		/// <summary>
+		/// Called by the CPU thread (through Flipper::Update) every Flipper tick step, so that the
+		/// DSP thread is woken once per `DspWakeTicks`.
+		/// </summary>
+		void TickSync(int64_t ticks);
+
+		/// <summary>
+		/// Block until the next batch of DSP time is due (see TickSync).
+		/// </summary>
+		void WaitForWork();
 
 		// Debug methods
 

--- a/src/flipper.cpp
+++ b/src/flipper.cpp
@@ -9,24 +9,6 @@ namespace Flipper
 	Flipper* HW;
 	DSP::Dsp16* DSP;      // Instance of dsp core
 
-	// This thread acts as the HWUpdate of Dolwin 0.10.
-	// Previously, an HWUpdate call occurred after each Gekko instruction (or so).
-	// This was tied only to update VI, SI and AI.
-	// After switching to multitasking, leave the old HWUpdate update mechanism, will be gradually replaced by other threads of different Flipper components.
-	void Flipper::HwUpdateThread(void* Parameter)
-	{
-		Flipper* flipper = (Flipper*)Parameter;
-
-		int64_t ticks = Core->GetTicks();
-		if (ticks < flipper->hwUpdateTbrValue)
-		{
-			return;
-		}
-		flipper->hwUpdateTbrValue = ticks + Flipper::ticksToHwUpdate;
-
-		flipper->Update();
-	}
-
 	Flipper::Flipper(HWConfig* config)
 	{
 		Report(Channel::Info,
@@ -87,14 +69,10 @@ namespace Flipper
 		MCOpen(config);
 
 		JDI::Hub.AddNode(L"HW_JDI_JSON", HwJdi, hw_init_handlers);
-
-		hwUpdateThread = EMUCreateThread(HwUpdateThread, false, this, "HW");
 	}
 
 	Flipper::~Flipper()
 	{
-		EMUJoinThread(hwUpdateThread);
-
 		JDI::Hub.RemoveNode(L"HW_JDI_JSON");
 
 		DSP->Suspend();
@@ -148,11 +126,23 @@ namespace Flipper
 		MCClose();
 	}
 
-	void Flipper::Update()
+	void Flipper::Update(int64_t ticks)
 	{
+		// A pending deadline that is still ahead of us means there is nothing to do yet. When the
+		// time base has jumped *backwards* (the CPU was reset) the anchor is stale and has to be
+		// taken again, otherwise the periodic work would stop until the time base caught up.
+		if (ticks < hwUpdateTbrValue && (hwUpdateTbrValue - ticks) < FlipperTickStep)
+		{
+			return;
+		}
+		hwUpdateTbrValue = ticks + FlipperTickStep;
+
 		// update joypads and video
 		vi->VIUpdate();
 		si->SIPoll();
+
+		// ... and let the CP thread know when it has a batch of FIFO entries to consume.
+		cp->TickSync(ticks);
 	}
 
 	uint32_t Flipper::GetMemorySize()

--- a/src/flipper.cpp
+++ b/src/flipper.cpp
@@ -141,8 +141,16 @@ namespace Flipper
 		vi->VIUpdate();
 		si->SIPoll();
 
-		// ... and let the CP thread know when it has a batch of FIFO entries to consume.
+		// ... and let the CP thread know when it has a batch of FIFO entries to consume, and the
+		// AI thread when the next audio DMA block is due.
 		cp->TickSync(ticks);
+		DSP::AITickSync(ticks);
+
+		// The DSP core has its own thread as well, woken in batches.
+		if (DSP != nullptr)
+		{
+			DSP->core->TickSync(ticks);
+		}
 	}
 
 	uint32_t Flipper::GetMemorySize()

--- a/src/flipper.h
+++ b/src/flipper.h
@@ -99,19 +99,17 @@ namespace Flipper
 	class ProcessorInterface;
 	class VideoInterface;
 
+	// The granularity at which the VI scan-out and the serial poll see the time base. It has to stay
+	// well below one VI line (`vi.one_frame / vi.vcount`, about 2570 ticks on NTSC), and 100 ticks
+	// is 50 interpreter instructions or a couple of basic blocks.
+	static const int64_t FlipperTickStep = 100;
+
 	/// <summary>
 	/// Global class for driving Flipper ASIC.
 	/// </summary>
 	class Flipper
 	{
-		static void HwUpdateThread(void* Parameter);
-
 		int64_t hwUpdateTbrValue = 0;
-
-		Thread* hwUpdateThread = nullptr;
-		static const size_t ticksToHwUpdate = 100;
-
-		void Update();
 
 		AudioInterface* ai = nullptr;
 		DiskInterface* di = nullptr;
@@ -122,6 +120,16 @@ namespace Flipper
 	public:
 		Flipper(HWConfig* config);
 		~Flipper();
+
+		/// <summary>
+		/// The periodic Flipper-side work (the VI scan-out and the serial interface poll).
+		/// It is driven by the CPU thread from the tick the emulated CPU advances, at the ticks
+		/// where it is due. It used to live on a thread of its own that polled the shared time base
+		/// in a tight loop; that thread made every write of the time base transfer the cache line
+		/// between the cores and cost more than the work it performed (see the benchmark notes in
+		/// `testing/gekko_bench`). `ticks` is the current value of the emulated time base.
+		/// </summary>
+		void Update(int64_t ticks);
 
 		AudioMixer* Mixer = nullptr;
 

--- a/src/gekko.cpp
+++ b/src/gekko.cpp
@@ -5,6 +5,9 @@ using namespace Debug;
 
 namespace Gekko
 {
+	CpuStats stats;
+	bool cycleProfile = false;
+
 	// The main driving force behind the entire emulator. All other threads are based on changing the TBR Gekko register.
 	void GekkoCore::GekkoThreadProc(void* Parameter)
 	{
@@ -37,7 +40,7 @@ namespace Gekko
 	GekkoCore::GekkoCore()
 	{
 		cache = new Cache(this);
-		icache = new Cache(this);
+		icache = new Cache(this, true);
 		
 		// DEBUG
 		//cache->SetLogLevel(CacheLogLevel::MemOps);
@@ -103,6 +106,7 @@ namespace Gekko
 		regs.msr &= ~(MSR_DR | MSR_IR);
 
 		regs.tb.uval = 0;
+		flipperDeadline = 0;
 		regs.spr[SPR::HID1] = 0x8000'0000;
 		// The decrementer produces an exception on underflow, so it starts out negative:
 		// the program has to reload it with a positive value to arm the first exception.
@@ -165,6 +169,18 @@ namespace Gekko
 	void GekkoCore::Step()
 	{
 		interp->ExecuteOpcode();
+	}
+
+	// The Flipper-side periodic work is due: let the ASIC run it and arm the next deadline. The
+	// hook lives here rather than in the header because the inline Tick/TickN cannot see Flipper.
+	void GekkoCore::SyncFlipper()
+	{
+		flipperDeadline = regs.tb.sval + Flipper::FlipperTickStep;
+
+		if (Flipper::HW != nullptr)
+		{
+			Flipper::HW->Update(regs.tb.sval);
+		}
 	}
 
 	void GekkoCore::AssertInterrupt()
@@ -287,6 +303,7 @@ namespace Gekko
 		}
 
 		// disable address translation
+		stats.invException++;
 		if (jit != nullptr) jit->InvalidateAll();
 		regs.msr &= ~(MSR_IR | MSR_DR);
 
@@ -828,9 +845,10 @@ namespace Gekko
 
 namespace Gekko
 {
-	Cache::Cache(GekkoCore* core)
+	Cache::Cache(GekkoCore* core, bool instruction)
 	{
 		this->core = core;
+		this->instruction = instruction;
 
 		cacheData = new uint8_t[cacheSize];
 
@@ -966,6 +984,7 @@ namespace Gekko
 		// data cache (the 0x81300000 hack in ExecuteOpcode, which exists precisely
 		// because IPL2 is DMA'ed into memory behind the CPU's back) and for the
 		// instruction cache (HID0[ICFI]).
+		stats.invFlash++;
 		if (core->jit != nullptr)
 		{
 			core->jit->InvalidateAll();
@@ -1064,6 +1083,13 @@ namespace Gekko
 
 		if (frozen)
 			return;
+
+		CycleScope cycles(&stats.castInCycles);
+
+		if (instruction)
+			stats.icacheFills++;
+		else
+			stats.dcacheFills++;
 
 		if (log >= CacheLogLevel::MemOps)
 		{

--- a/src/gekko.h
+++ b/src/gekko.h
@@ -681,6 +681,10 @@ namespace Gekko
 		uint64_t piWrites = 0;			// Single-beat CPU writes that reached the PI
 		uint64_t mmioReads = 0;			// ... of those, the ones that hit the register space
 		uint64_t mmioWrites = 0;
+		uint64_t dspInstrs = 0;			// DSP instructions executed
+		uint64_t dspWakes = 0;			// Times the DSP thread was woken
+		uint64_t aiFeeds = 0;			// AI DMA blocks pushed into the mixer
+		uint64_t aiInts = 0;			// AIDINT (DMA complete) interrupts
 
 		// Host cycles (only while `cycleProfile` is on).
 		uint64_t jitRunCycles = 0;		// Time inside Jit::Run, including the generated blocks

--- a/src/gekko.h
+++ b/src/gekko.h
@@ -501,6 +501,10 @@ namespace Gekko
 		bool enabled = false;
 		bool frozen = false;
 
+		// The instruction cache is the same class as the data cache; the flag only decides which of
+		// the two fill counters `CastIn` bumps.
+		bool instruction = false;
+
 		CacheLogLevel log = CacheLogLevel::None;
 
 		void CastIn(uint32_t pa);		// Mem -> Cache
@@ -515,7 +519,7 @@ namespace Gekko
 		GekkoCore* core;
 
 	public:
-		Cache(GekkoCore* core);
+		Cache(GekkoCore* core, bool instruction = false);
 		~Cache();
 
 		void Reset();
@@ -647,6 +651,85 @@ namespace Gekko
 		Trap,
 	};
 
+	// CPU-side performance counters. They answer the "where does the emulated CPU time actually go"
+	// question that the `--bench` mode asks: how much of the work is done by translated code and how
+	// much by the interpreter, how long the average basic block is, how often a block has to be
+	// translated again, and how many memory accesses leave the emulated cache for the PI/MEM.
+	//
+	// The counters are plain increments on cold paths (a block entry, a cache line fill, an access
+	// that reaches the PI), so leaving them on costs nothing measurable. The cycle counters are the
+	// exception: `rdtsc` is cheap but not free, so they only update while `cycleProfile` is set,
+	// which is what the benchmark's BENCH_PROFILE switch turns on.
+	struct CpuStats
+	{
+		uint64_t jitBlocks = 0;			// Basic blocks run by the recompiler
+		uint64_t jitInstrs = 0;			// Instructions retired inside those blocks
+		uint64_t jitCompiles = 0;		// Basic blocks translated
+		uint64_t jitInvalidations = 0;		// Times the whole block cache was dropped
+		uint64_t invException = 0;		// ... on an exception entry
+		uint64_t invRfi = 0;			// ... on rfi
+		uint64_t invMtmsr = 0;			// ... on mtmsr
+		uint64_t invMtspr = 0;			// ... on mtspr of a BAT/SDR1/HID0/HID2
+		uint64_t invIcbi = 0;			// ... on icbi
+		uint64_t invTlb = 0;			// ... on tlbie/tlbsync
+		uint64_t invFlash = 0;			// ... on a cache flash invalidate
+		uint64_t jitFallbacks = 0;		// Instructions handed back to the interpreter from a block
+		uint64_t interpInstrs = 0;		// Instructions run by the interpreter proper
+		uint64_t dcacheFills = 0;		// Data cache line fills (CPU -> PI -> MEM)
+		uint64_t icacheFills = 0;		// Instruction cache line fills
+		uint64_t piReads = 0;			// Single-beat CPU reads that reached the PI
+		uint64_t piWrites = 0;			// Single-beat CPU writes that reached the PI
+		uint64_t mmioReads = 0;			// ... of those, the ones that hit the register space
+		uint64_t mmioWrites = 0;
+
+		// Host cycles (only while `cycleProfile` is on).
+		uint64_t jitRunCycles = 0;		// Time inside Jit::Run, including the generated blocks
+		uint64_t blockCallCycles = 0;		// ... of which spent inside a generated block
+		uint64_t compileCycles = 0;		// ... of which spent translating a block
+		uint64_t fallbackCycles = 0;		// ... of which spent in the interpreter fallback
+		uint64_t memHelperCycles = 0;		// ... of which spent in the JIT memory helpers
+		uint64_t memHelperCalls = 0;		// Number of calls into those helpers
+		uint64_t castInCycles = 0;		// Time spent filling cache lines
+		uint64_t interpCycles = 0;		// Time inside one interpreted instruction
+
+		void Reset()
+		{
+			*this = CpuStats{};
+		}
+	};
+
+	extern CpuStats stats;
+
+	// When set, the hot paths also accumulate host cycle counts into `stats`.
+	extern bool cycleProfile;
+
+	GEKKO_INLINE uint64_t ReadCycleCounter()
+	{
+#if defined(_MSC_VER)
+		return __rdtsc();
+#else
+		return __builtin_ia32_rdtsc();
+#endif
+	}
+
+	// A scoped cycle accumulator. When `cycleProfile` is off the whole thing is a load and a branch.
+	class CycleScope
+	{
+		uint64_t* target;
+		uint64_t start;
+
+	public:
+		explicit CycleScope(uint64_t* t) : target(t), start(cycleProfile ? ReadCycleCounter() : 0) {}
+
+		~CycleScope()
+		{
+			if (cycleProfile)
+			{
+				*target += ReadCycleCounter() - start;
+			}
+		}
+	};
+
 	class GekkoCore
 	{
 		friend Interpreter;
@@ -763,6 +846,15 @@ namespace Gekko
 		{
 			regs.tb.uval += CounterStep;         // timer
 
+			// The Flipper-side periodic work (the VI scan-out and the serial poll) hangs off the
+			// time base, so it is driven from here, where the time base is already in hand. A
+			// thread that polled the same counter instead made every write of it transfer the
+			// cache line between the cores (see Flipper::Update).
+			if (regs.tb.sval >= flipperDeadline)
+			{
+				SyncFlipper();
+			}
+
 			uint32_t old = regs.spr[SPR::DEC];
 			regs.spr[SPR::DEC] -= DecrementerStep;          // decrementer
 
@@ -796,6 +888,11 @@ namespace Gekko
 
 			regs.tb.uval += (uint64_t)CounterStep * n;
 
+			if (regs.tb.sval >= flipperDeadline)
+			{
+				SyncFlipper();
+			}
+
 			uint32_t old = regs.spr[SPR::DEC];
 			regs.spr[SPR::DEC] -= DecrementerStep * n;
 
@@ -820,6 +917,10 @@ namespace Gekko
 		void AssertInterrupt();
 		void ClearInterrupt();
 		void Exception(Gekko::Exception code);
+
+		// The tick at which the Flipper-side periodic work is next due (see Flipper::Update).
+		int64_t flipperDeadline = 0;
+		void SyncFlipper();
 
 #pragma region "Memory interface"
 

--- a/src/gekkoc.cpp
+++ b/src/gekkoc.cpp
@@ -3976,13 +3976,21 @@ namespace Gekko
 	// return from exception
 	void Interpreter::rfi()
 	{
-		// SRR1 can flip MSR[IR]/[DR], which changes what every effective address in
-		// the compiled blocks translates to.
-		if (core->jit != nullptr) core->jit->InvalidateAll();
+		uint32_t oldMsr = core->regs.msr;
 
 		core->regs.msr &= ~(0x87C0FF73 | 0x00040000);
 		core->regs.msr |= core->regs.spr[SPR::SRR1] & 0x87C0FF73;
 		core->regs.pc = core->regs.spr[SPR::SRR0] & ~3;
+
+		// Only SRR1's view of MSR[IR]/[DR] can change what a compiled block translates to; the
+		// rest of the restored bits are read at run time by the helper the block calls. Dropping
+		// the whole block cache for them is what made rfi (and mtmsr) free to interrupt the
+		// recompiler thousands of times a second - see the benchmark notes in `testing/gekko_bench`.
+		if (((oldMsr ^ core->regs.msr) & (MSR_IR | MSR_DR)) != 0)
+		{
+			Gekko::stats.invRfi++;
+			if (core->jit != nullptr) core->jit->InvalidateAll();
+		}
 	}
 
 	// syscall
@@ -4145,7 +4153,16 @@ namespace Gekko
 
 		uint32_t oldMsr = core->regs.msr;
 		core->regs.msr = core->regs.gpr[info.paramBits[0]];
-		if (core->jit != nullptr) core->jit->InvalidateAll();
+
+		// The OS toggles MSR[EE] around every critical section, and that cannot change what a
+		// compiled block translates to: only MSR[IR]/[DR] can, because they decide what the cached
+		// instruction fetch means. Dropping the whole block cache on every mtmsr cost more
+		// re-translations than the rest of the recompiler together (see `testing/gekko_bench`).
+		if (((oldMsr ^ core->regs.msr) & (MSR_IR | MSR_DR)) != 0)
+		{
+			Gekko::stats.invMtmsr++;
+			if (core->jit != nullptr) core->jit->InvalidateAll();
+		}
 
 		if ((oldMsr & MSR_IR) != (core->regs.msr & MSR_IR))
 		{
@@ -4170,6 +4187,7 @@ namespace Gekko
 		if (spr == SPR::SDR1 || spr == SPR::HID0 || spr == SPR::HID2 ||
 			(spr >= SPR::IBAT0U && spr <= SPR::DBAT3L))
 		{
+			Gekko::stats.invMtspr++;
 			if (core->jit != nullptr) core->jit->InvalidateAll();
 		}
 
@@ -4533,6 +4551,7 @@ namespace Gekko
 		if (pa != Gekko::BadAddress)
 		{
 			core->icache->Invalidate(pa);
+			Gekko::stats.invIcbi++;
 			if (core->jit != nullptr) core->jit->InvalidateAll();
 		}
 		else
@@ -4603,6 +4622,7 @@ namespace Gekko
 
 	void Interpreter::tlbie()
 	{
+		Gekko::stats.invTlb++;
 		if (core->jit != nullptr) core->jit->InvalidateAll();
 		core->dtlb.Invalidate(core->regs.gpr[info.paramBits[0]]);
 		core->itlb.Invalidate(core->regs.gpr[info.paramBits[0]]);

--- a/src/gekkojit.cpp
+++ b/src/gekkojit.cpp
@@ -39,11 +39,36 @@ namespace Gekko
 
 namespace
 {
-	void JitReadByte(GekkoCore* core, uint32_t addr, uint32_t* reg) { core->ReadByte(addr, reg); }
-	void JitReadWord(GekkoCore* core, uint32_t addr, uint32_t* reg) { core->ReadWord(addr, reg); }
-	void JitWriteByte(GekkoCore* core, uint32_t addr, uint32_t data) { core->WriteByte(addr, data); }
-	void JitWriteHalf(GekkoCore* core, uint32_t addr, uint32_t data) { core->WriteHalf(addr, data); }
-	void JitWriteWord(GekkoCore* core, uint32_t addr, uint32_t data) { core->WriteWord(addr, data); }
+	void JitReadByte(GekkoCore* core, uint32_t addr, uint32_t* reg)
+	{
+		stats.memHelperCalls++;
+		CycleScope cycles(&stats.memHelperCycles);
+		core->ReadByte(addr, reg);
+	}
+	void JitReadWord(GekkoCore* core, uint32_t addr, uint32_t* reg)
+	{
+		stats.memHelperCalls++;
+		CycleScope cycles(&stats.memHelperCycles);
+		core->ReadWord(addr, reg);
+	}
+	void JitWriteByte(GekkoCore* core, uint32_t addr, uint32_t data)
+	{
+		stats.memHelperCalls++;
+		CycleScope cycles(&stats.memHelperCycles);
+		core->WriteByte(addr, data);
+	}
+	void JitWriteHalf(GekkoCore* core, uint32_t addr, uint32_t data)
+	{
+		stats.memHelperCalls++;
+		CycleScope cycles(&stats.memHelperCycles);
+		core->WriteHalf(addr, data);
+	}
+	void JitWriteWord(GekkoCore* core, uint32_t addr, uint32_t data)
+	{
+		stats.memHelperCalls++;
+		CycleScope cycles(&stats.memHelperCycles);
+		core->WriteWord(addr, data);
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -56,6 +81,8 @@ namespace
 // instruction - only a slower one.
 void Jit::Fallback(GekkoCore* core, uint32_t instr, uint32_t pc)
 {
+	stats.jitFallbacks++;
+	CycleScope cycles(&stats.fallbackCycles);
 	core->interp->ExecuteDecoded(pc, instr);
 }
 
@@ -135,6 +162,7 @@ void Jit::InvalidateAll()
 {
 	// O(1): every entry with an older generation is simply ignored. The arena is
 	// reused from the beginning only when it is exhausted.
+	stats.jitInvalidations++;
 	generation++;
 	if (generation == 0)
 	{
@@ -225,6 +253,8 @@ static bool IsBranchInstr(Instruction instr)
 
 uint32_t Jit::CompileBlock(uint32_t pc, uint32_t pa, uint32_t& instrCount)
 {
+	uint64_t compileStart = cycleProfile ? ReadCycleCounter() : 0;
+
 	if (code == nullptr)
 	{
 		return BadAddress;
@@ -1111,14 +1141,32 @@ uint32_t Jit::CompileBlock(uint32_t pc, uint32_t pa, uint32_t& instrCount)
 	block->instrCount = count;
 	block->codeOffset = offset;
 
+	stats.jitCompiles++;
+	stats.compileCycles += compileStart ? (ReadCycleCounter() - compileStart) : 0;
+
 	return offset;
+}
+
+// Every path of Run() that hands the instruction back to the interpreter goes through here, so
+// that the CPU statistics can tell translated code and interpreted code apart.
+void Jit::RunOneInterpreted()
+{
+	stats.interpInstrs++;
+	CycleScope cycles(&stats.interpCycles);
+	core->interp->ExecuteOpcode();
 }
 
 void Jit::Run()
 {
+	CycleScope cycles(&stats.jitRunCycles);
+	RunInner();
+}
+
+void Jit::RunInner()
+{
 	if (!supported)
 	{
-		core->interp->ExecuteOpcode();
+		RunOneInterpreted();
 		return;
 	}
 
@@ -1129,7 +1177,7 @@ void Jit::Run()
 	// cache for every instruction of it either.
 	if (pc >= PI_MEMSPACE_BOOTROM)
 	{
-		core->interp->ExecuteOpcode();
+		RunOneInterpreted();
 		return;
 	}
 
@@ -1142,7 +1190,7 @@ void Jit::Run()
 	// path, which a compiled block cannot model (see FetchInstr).
 	if (!core->icache->IsEnabled())
 	{
-		core->interp->ExecuteOpcode();
+		RunOneInterpreted();
 		return;
 	}
 
@@ -1151,7 +1199,7 @@ void Jit::Run()
 	if (pa == BadAddress || pa >= PI_MEMSPACE_BOOTROM || core->icache->GetCachePointer(pa) == nullptr ||
 		(WIMG & WIMG_I) != 0)
 	{
-		core->interp->ExecuteOpcode();
+		RunOneInterpreted();
 		return;
 	}
 
@@ -1162,13 +1210,13 @@ void Jit::Run()
 		uint32_t count = 0;
 		if (CompileBlock(pc, pa, count) == BadAddress)
 		{
-			core->interp->ExecuteOpcode();
+			RunOneInterpreted();
 			return;
 		}
 		block = FindBlock(pc, pa);
 		if (block == nullptr)
 		{
-			core->interp->ExecuteOpcode();
+			RunOneInterpreted();
 			return;
 		}
 	}
@@ -1177,9 +1225,15 @@ void Jit::Run()
 
 	JitExit exit{};
 	BlockFn fn = (BlockFn)(void*)(code + block->codeOffset);
-	fn(core, &core->regs, &exit);
+	{
+		CycleScope cycles(&stats.blockCallCycles);
+		fn(core, &core->regs, &exit);
+	}
 
 	uint32_t n = (uint32_t)exit.count;
+
+	stats.jitBlocks++;
+	stats.jitInstrs += n;
 
 	// Mirror Interpreter::ExecuteOpcode: an instruction that raises an exception
 	// does not advance the tick, and a taken branch is ticked once by BranchCheck

--- a/src/gekkojit.h
+++ b/src/gekkojit.h
@@ -179,6 +179,14 @@ namespace Gekko
 		Block* FindBlock(uint32_t pc, uint32_t pa);
 		Block* AllocBlock(uint32_t pc, uint32_t pa);
 
+		// Run one instruction through the interpreter: every path of Run() that cannot use a
+		// compiled block goes through here, so that the CPU statistics can tell translated code
+		// and interpreted code apart.
+		void RunOneInterpreted();
+
+		// The body of Run(), so that Run() can wrap it in a cycle counter.
+		void RunInner();
+
 		// Called from generated code. Static members so that they inherit Jit's
 		// friendship with GekkoCore / Interpreter.
 		static void Fallback(GekkoCore* core, uint32_t instr, uint32_t pc);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -179,19 +179,51 @@ Emulator emu;
 
 CmdLineOptions cmdline;
 
-static void ParseCmdLineArg(const std::string& arg)
+// Arguments that carry their own parameters (`--bench <file> [seconds]`) need a lookahead, so the
+// raw command line is first split into a token list and then walked here.
+static void ParseCmdLineArgs(const std::vector<std::string>& args)
 {
-	if (arg == "--ipl")
+	for (size_t i = 0; i < args.size(); i++)
 	{
-		cmdline.ipl = true;
-	}
-	else if (arg == "--no-disc")
-	{
-		cmdline.noDisc = true;
-	}
-	else
-	{
-		Report(Channel::Norm, "Unknown command line argument: %s\n", arg.c_str());
+		const std::string& arg = args[i];
+
+		if (arg == "--ipl")
+		{
+			cmdline.ipl = true;
+		}
+		else if (arg == "--no-disc")
+		{
+			cmdline.noDisc = true;
+		}
+		else if (arg == "--bench")
+		{
+			if (i + 1 < args.size())
+			{
+				cmdline.bench = true;
+				cmdline.benchFile = Util::StringToWstring(args[++i]);
+
+				// An optional second parameter is the duration in seconds. A file name can start
+				// with a digit too, so the parameter is only taken when the *whole* token is a number.
+				if (i + 1 < args.size())
+				{
+					char* end = nullptr;
+					unsigned long seconds = strtoul(args[i + 1].c_str(), &end, 0);
+					if (end != nullptr && *end == 0 && seconds > 0)
+					{
+						cmdline.benchSeconds = (uint32_t)seconds;
+						i++;
+					}
+				}
+			}
+			else
+			{
+				Report(Channel::Norm, "--bench needs an image file (and an optional duration in seconds)\n");
+			}
+		}
+		else
+		{
+			Report(Channel::Norm, "Unknown command line argument: %s\n", arg.c_str());
+		}
 	}
 }
 
@@ -204,6 +236,7 @@ void EMUParseCmdLine(const char* commandLine)
 
 	// Split into arguments, honouring the quotes (arguments are not allowed to contain spaces otherwise).
 
+	std::vector<std::string> args;
 	std::string arg;
 	bool quoted = false;
 
@@ -219,7 +252,7 @@ void EMUParseCmdLine(const char* commandLine)
 		{
 			if (!arg.empty())
 			{
-				ParseCmdLineArg(arg);
+				args.push_back(arg);
 				arg.clear();
 			}
 		}
@@ -231,8 +264,10 @@ void EMUParseCmdLine(const char* commandLine)
 
 	if (!arg.empty())
 	{
-		ParseCmdLineArg(arg);
+		args.push_back(arg);
 	}
+
+	ParseCmdLineArgs(args);
 }
 
 void EMUParseCmdLine(int argc, char** argv)

--- a/src/main.h
+++ b/src/main.h
@@ -34,6 +34,14 @@ struct CmdLineOptions
 {
 	bool    ipl = false;        // `--ipl`: start the Bootrom (IPL) immediately, without going through the UI
 	bool    noDisc = false;     // `--no-disc`: start with the DVD lid open (no disk), so that the IPL takes its "no disk" path
+
+	// `--bench <file> [seconds]`: load the file, run it for the given number of seconds (30 by
+	// default) without a user interface and print the measured emulation throughput and the
+	// performance counters. This is the measurement tool for the "find the bottleneck" work:
+	// the counters say where the emulated CPU time actually goes.
+	bool    bench = false;
+	std::wstring benchFile;
+	uint32_t    benchSeconds = 30;
 };
 
 extern  CmdLineOptions cmdline;

--- a/src/pi.cpp
+++ b/src/pi.cpp
@@ -24,6 +24,7 @@ namespace Flipper
 
 	void ProcessorInterface::PIReadByte(uint32_t pa, uint32_t* reg)
 	{
+		Gekko::stats.piReads++;
 		uint8_t* ptr;
 
 		if (pa >= PI_MEMSPACE_BOOTROM)
@@ -55,6 +56,7 @@ namespace Flipper
 
 	void ProcessorInterface::PIWriteByte(uint32_t pa, uint32_t data)
 	{
+		Gekko::stats.piWrites++;
 		uint8_t* ptr;
 
 		if (pa >= PI_MEMSPACE_BOOTROM)
@@ -76,6 +78,7 @@ namespace Flipper
 
 	void ProcessorInterface::PIReadHalf(uint32_t pa, uint32_t* reg)
 	{
+		Gekko::stats.piReads++;
 		uint8_t* ptr;
 
 		if (pa >= PI_MEMSPACE_BOOTROM)
@@ -95,6 +98,7 @@ namespace Flipper
 		// hardware trap
 		if (pa >= HW_BASE)
 		{
+			Gekko::stats.mmioReads++;
 			pi_reg_trap* trap = &hw_reg_traps[pa & 0xfffe];
 			trap->read(pa, reg, trap->context);
 			return;
@@ -115,6 +119,7 @@ namespace Flipper
 
 	void ProcessorInterface::PIWriteHalf(uint32_t pa, uint32_t data)
 	{
+		Gekko::stats.piWrites++;
 		uint8_t* ptr;
 
 		if (pa >= PI_MEMSPACE_BOOTROM)
@@ -125,6 +130,7 @@ namespace Flipper
 		// hardware trap
 		if (pa >= HW_BASE)
 		{
+			Gekko::stats.mmioWrites++;
 			pi_reg_trap* trap = &hw_reg_traps[pa & 0xfffe];
 			trap->write(pa, data, trap->context);
 			return;
@@ -144,6 +150,7 @@ namespace Flipper
 
 	void ProcessorInterface::PIReadWord(uint32_t pa, uint32_t* reg)
 	{
+		Gekko::stats.piReads++;
 		uint8_t* ptr;
 
 		// bus load word
@@ -171,6 +178,7 @@ namespace Flipper
 		// hardware trap
 		if (pa >= HW_BASE)
 		{
+			Gekko::stats.mmioReads++;
 			pi_reg_trap* trap;
 			uint32_t temp_hi, temp_lo;
 			trap = &hw_reg_traps[pa & 0xffff];
@@ -194,6 +202,7 @@ namespace Flipper
 
 	void ProcessorInterface::PIWriteWord(uint32_t pa, uint32_t data)
 	{
+		Gekko::stats.piWrites++;
 		uint8_t* ptr;
 
 		if (pa >= PI_MEMSPACE_BOOTROM)
@@ -204,6 +213,7 @@ namespace Flipper
 		// hardware trap
 		if (pa >= HW_BASE)
 		{
+			Gekko::stats.mmioWrites++;
 			pi_reg_trap* trap = &hw_reg_traps[pa & 0xffff];
 			trap->write(pa, data >> 16, trap->context);
 			trap = &hw_reg_traps[(pa + 2) & 0xffff];
@@ -236,6 +246,7 @@ namespace Flipper
 
 	void ProcessorInterface::PIReadDouble(uint32_t pa, uint64_t* reg)
 	{
+		Gekko::stats.piReads++;
 		if (pa >= PI_MEMSPACE_BOOTROM)
 		{
 			Halt("PI: Attempting to read uint64_t from BootROM\n");
@@ -258,6 +269,7 @@ namespace Flipper
 
 	void ProcessorInterface::PIWriteDouble(uint32_t pa, uint64_t* data)
 	{
+		Gekko::stats.piWrites++;
 		if (pa >= PI_MEMSPACE_BOOTROM)
 		{
 			Halt("PI: Attempting to write uint64_t to BootROM\n");

--- a/src/uisdl.cpp
+++ b/src/uisdl.cpp
@@ -2056,6 +2056,10 @@ static void ui_bench()
 		Core->PrintOpcodeStats(25);
 	}
 
+	Debug::Report(Debug::Channel::Norm, "dsp instructions   : %llu (%llu wakes)\n",
+		(unsigned long long)st.dspInstrs, (unsigned long long)st.dspWakes);
+	Debug::Report(Debug::Channel::Norm, "ai dma             : %llu feeds, %llu ints\n",
+		(unsigned long long)st.aiFeeds, (unsigned long long)st.aiInts);
 	Debug::Report(Debug::Channel::Norm, "vi interrupts      : %lld\n", (long long)bench_counter(Debug::PerfCounter::VIs));
 	Debug::Report(Debug::Channel::Norm, "pe finishes        : %lld\n", (long long)bench_counter(Debug::PerfCounter::PEs));
 

--- a/src/uisdl.cpp
+++ b/src/uisdl.cpp
@@ -1472,6 +1472,13 @@ namespace UI
 		int32_t pes = perf->GetPECounter();
 		perf->ResetPECounter();
 
+		// An unattended benchmark leaves a per-second timeline in the debug log (`EMU_LOG=<file>`),
+		// so that a run can be examined afterwards without watching the status bar.
+		if (cmdline.bench)
+		{
+			Debug::Report(Debug::Channel::Info, "profile: %s, %d VI/s, %d PE/s\n", str, vis, pes);
+		}
+
 		// Display information in the status bar
 
 		SetStatusText(STATUS_ENUM::Progress, Util::StringToWstring(str));
@@ -1564,6 +1571,11 @@ static void CreateRenderTarget()
 {
 	// Create RenderTarget (for xfb / gfx)
 	SDL_WindowFlags window_flags = (SDL_WindowFlags)(SDL_WINDOW_RESIZABLE | SDL_WINDOW_OPENGL);
+	if (cmdline.bench)
+	{
+		// The benchmark runs unattended, so its video output window stays out of the way.
+		window_flags = (SDL_WindowFlags)(window_flags | SDL_WINDOW_HIDDEN);
+	}
 	render_target = SDL_CreateWindow("Video Output", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 640, 480, window_flags);
 }
 
@@ -1686,7 +1698,11 @@ void OnMainWindowOpened(const wchar_t* currentFileName)
 	std::wstring_convert<std::codecvt_utf8<wchar_t>> utf8_conv;
 	SDL_SetWindowTitle(window, utf8_conv.to_bytes(newTitle).c_str());
 
-	UI::g_perfMetrics = new UI::PerfMetrics();
+	// A benchmark run samples the counters itself: the metrics thread clears them every second.
+	if (!cmdline.bench)
+	{
+		UI::g_perfMetrics = new UI::PerfMetrics();
+	}
 }
 
 // emulation stop in progress
@@ -1871,6 +1887,217 @@ static void run_selected_file()
 	}
 
 	load_file(usel.files[usel.selected]->name);
+}
+
+/*
+
+# Benchmark mode
+
+`--bench <file> [seconds]` loads the image, runs it unattended for the requested number of seconds
+(30 by default) and prints the measured throughput together with the CPU-side performance counters.
+This is the measurement tool for the performance work on the emulator: the counters say how the
+emulated instructions split between translated blocks and the interpreter, how long the average
+basic block is, how often a block has to be recompiled and how many memory accesses leave the
+emulated cache for the PI/MEM. The whole point is to compare configurations (the recompiler against
+the interpreter, one memory path against another) on the same workload.
+
+An interactive run shows the same throughput in the status bar one line per second (see
+PerfThreadProc); with `--bench` that line also goes to the debug log, so an unattended run leaves a
+per-second timeline behind.
+
+*/
+
+static int64_t bench_counter(Debug::PerfCounter counter)
+{
+	return Debug::g_PerfCounters->GetCounter(counter);
+}
+
+// The cycle counters are raw TSC ticks; measure the rate against the SDL high-resolution counter
+// once, so that the benchmark can report seconds rather than ticks.
+static double MeasureTscFrequency()
+{
+	uint64_t qpc0 = SDL_GetPerformanceCounter();
+	uint64_t tsc0 = Gekko::ReadCycleCounter();
+	SDL_Delay(100);
+	uint64_t qpc1 = SDL_GetPerformanceCounter();
+	uint64_t tsc1 = Gekko::ReadCycleCounter();
+
+	if (qpc1 == qpc0)
+	{
+		return 1.0;
+	}
+
+	return (double)(tsc1 - tsc0) * (double)SDL_GetPerformanceFrequency() / (double)(qpc1 - qpc0);
+}
+
+static void ui_bench()
+{
+	CreateRenderTarget();
+
+	UI::Jdi->LoadFile(Util::WstringToString(cmdline.benchFile));
+	if (Debug::debugger)
+	{
+		Debug::debugger->InvalidateAll();
+	}
+	OnMainWindowOpened(cmdline.benchFile.c_str());
+	UI::Jdi->Run();
+
+	// The cycle counters cost two `rdtsc` per block (about 20% of the throughput), so they are
+	// opt-in: `set BENCH_PROFILE=1` turns the host cycle breakdown on, the plain run measures the
+	// real throughput.
+	bool profiled = getenv("BENCH_PROFILE") != nullptr;
+	Gekko::cycleProfile = profiled;
+	bool stats = getenv("BENCH_STATS") != nullptr;
+	if (stats)
+	{
+		Core->EnableOpcodeStats(true);
+	}
+	Debug::g_PerfCounters->ResetAllCounters();
+	Gekko::stats.Reset();
+	Core->ResetInstructionCounter();
+
+	uint64_t start = SDL_GetTicks64();
+	uint64_t durationMs = (uint64_t)cmdline.benchSeconds * 1000;
+	uint64_t lastReport = start;
+	int64_t lastOps = 0;
+	int64_t lastTb = 0;
+	uint64_t lastBlocks = 0;
+	uint64_t lastCompiles = 0;
+	uint64_t lastInval = 0;
+
+	while (SDL_GetTicks64() - start < durationMs)
+	{
+		// Drain the events, so that the render window stays responsive and `SDL_QUIT` does not
+		// leave the process hanging.
+		SDL_Event event;
+		while (SDL_PollEvent(&event))
+		{
+			if (event.type == SDL_QUIT)
+			{
+				durationMs = SDL_GetTicks64() - start;
+			}
+		}
+		SDL_Delay(20);
+
+		uint64_t now = SDL_GetTicks64();
+		if (now - lastReport >= 1000)
+		{
+			int64_t ops = (int64_t)Core->GetInstructionCounter();
+			double sec = (double)(now - lastReport) / 1000.0;
+
+			Debug::Report(Debug::Channel::Info,
+				"profile: %.2f MIPS (%.2fx real), %.2fM blocks/s (%.2f instr/block), %.0fK compiles/s, %.0fK invalidations/s\n",
+				(double)(ops - lastOps) / sec / 1e6,
+				(double)(Core->regs.tb.sval - lastTb) / (double)Core->OneSecond() / sec,
+				(double)(Gekko::stats.jitBlocks - lastBlocks) / sec / 1e6,
+				(Gekko::stats.jitBlocks - lastBlocks) ? (double)(Gekko::stats.jitInstrs) / (double)Gekko::stats.jitBlocks : 0.0,
+				(double)(Gekko::stats.jitCompiles - lastCompiles) / sec / 1e3,
+				(double)(Gekko::stats.jitInvalidations - lastInval) / sec / 1e3);
+
+			lastOps = ops;
+			lastTb = Core->regs.tb.sval;
+			lastBlocks = Gekko::stats.jitBlocks;
+			lastCompiles = Gekko::stats.jitCompiles;
+			lastInval = Gekko::stats.jitInvalidations;
+			lastReport = now;
+		}
+	}
+
+	Gekko::cycleProfile = false;
+	if (stats)
+	{
+		Core->EnableOpcodeStats(false);
+	}
+
+	uint64_t elapsed = SDL_GetTicks64() - start;
+	uint64_t ops = (uint64_t)Core->GetInstructionCounter();
+	double seconds = (double)elapsed / 1000.0;
+
+	const Gekko::CpuStats& st = Gekko::stats;
+	double tscHz = MeasureTscFrequency();
+
+	Debug::Report(Debug::Channel::Norm, "\n");
+	Debug::Report(Debug::Channel::Norm, "--- benchmark: %s ---\n", Util::WstringToString(cmdline.benchFile).c_str());
+	// The emulated time the run covered, which is the metric to compare two configurations by:
+	// a faster build gets further into the game in the same wall time, and a game's instruction
+	// density per emulated second depends on where it is.
+	double emulated = (double)Core->regs.tb.uval / (double)Core->OneSecond();
+
+	Debug::Report(Debug::Channel::Norm, "elapsed            : %.3f s\n", seconds);
+	Debug::Report(Debug::Channel::Norm, "emulated time      : %.3f s (%.2fx real time)\n", emulated, emulated / seconds);
+	Debug::Report(Debug::Channel::Norm, "instructions       : %llu\n", (unsigned long long)ops);
+	Debug::Report(Debug::Channel::Norm, "throughput         : %.2f MIPS\n", (double)ops / seconds / 1e6);
+	Debug::Report(Debug::Channel::Norm, "basic blocks run   : %llu (%.2f instructions per block)\n",
+		(unsigned long long)st.jitBlocks, st.jitBlocks ? (double)st.jitInstrs / (double)st.jitBlocks : 0.0);
+	Debug::Report(Debug::Channel::Norm, "blocks translated  : %llu (%.0f/s, %.2f%% of the blocks run)\n",
+		(unsigned long long)st.jitCompiles, (double)st.jitCompiles / seconds,
+		st.jitBlocks ? (double)st.jitCompiles / (double)st.jitBlocks * 100.0 : 0.0);
+	Debug::Report(Debug::Channel::Norm, "block invalidations: %llu (%.0f/s)\n",
+		(unsigned long long)st.jitInvalidations, (double)st.jitInvalidations / seconds);
+	Debug::Report(Debug::Channel::Norm, "  exception entry  : %llu\n", (unsigned long long)st.invException);
+	Debug::Report(Debug::Channel::Norm, "  rfi              : %llu\n", (unsigned long long)st.invRfi);
+	Debug::Report(Debug::Channel::Norm, "  mtmsr            : %llu\n", (unsigned long long)st.invMtmsr);
+	Debug::Report(Debug::Channel::Norm, "  mtspr bat/sdr/hid: %llu\n", (unsigned long long)st.invMtspr);
+	Debug::Report(Debug::Channel::Norm, "  icbi             : %llu\n", (unsigned long long)st.invIcbi);
+	Debug::Report(Debug::Channel::Norm, "  tlbie/tlbsync    : %llu\n", (unsigned long long)st.invTlb);
+	Debug::Report(Debug::Channel::Norm, "  cache flush      : %llu\n", (unsigned long long)st.invFlash);
+	Debug::Report(Debug::Channel::Norm, "jit fallbacks      : %llu (%.2f%% of the instructions)\n",
+		(unsigned long long)st.jitFallbacks, ops ? (double)st.jitFallbacks / (double)ops * 100.0 : 0.0);
+	Debug::Report(Debug::Channel::Norm, "interp instructions: %llu\n", (unsigned long long)st.interpInstrs);
+	Debug::Report(Debug::Channel::Norm, "data cache fills   : %llu\n", (unsigned long long)st.dcacheFills);
+	Debug::Report(Debug::Channel::Norm, "instr cache fills  : %llu\n", (unsigned long long)st.icacheFills);
+	Debug::Report(Debug::Channel::Norm, "pi reads           : %llu (mmio %llu)\n",
+		(unsigned long long)st.piReads, (unsigned long long)st.mmioReads);
+	Debug::Report(Debug::Channel::Norm, "pi writes          : %llu (mmio %llu)\n",
+		(unsigned long long)st.piWrites, (unsigned long long)st.mmioWrites);
+	if (stats)
+	{
+		Debug::Report(Debug::Channel::Norm, "top guest instructions:\n");
+		Core->PrintOpcodeStats(25);
+	}
+
+	Debug::Report(Debug::Channel::Norm, "vi interrupts      : %lld\n", (long long)bench_counter(Debug::PerfCounter::VIs));
+	Debug::Report(Debug::Channel::Norm, "pe finishes        : %lld\n", (long long)bench_counter(Debug::PerfCounter::PEs));
+
+	// Where the host cycles went. `jit total` is the time the CPU thread spent inside the
+	// recompiler; the rest of the wall time belongs to the other threads, to the UI and to idle time.
+	if (!profiled)
+	{
+		UI::Jdi->Stop();
+		Thread::Sleep(200);
+		UI::Jdi->Unload();
+		DestroyRenderTarget();
+		OnMainWindowClosed();
+		return;
+	}
+
+	Debug::Report(Debug::Channel::Norm, "host cycles (TSC %.2f GHz):\n", tscHz / 1e9);
+	Debug::Report(Debug::Channel::Norm, "  jit total        : %.3f s (%.1f%% of the wall), %llu cycles\n",
+		(double)st.jitRunCycles / tscHz, seconds > 0 ? (double)st.jitRunCycles / tscHz / seconds * 100.0 : 0.0,
+		(unsigned long long)st.jitRunCycles);
+	Debug::Report(Debug::Channel::Norm, "    generated block: %.3f s (%.1f%% of jit), %.1f cycles/block\n",
+		(double)st.blockCallCycles / tscHz, st.jitRunCycles ? (double)st.blockCallCycles / st.jitRunCycles * 100.0 : 0.0,
+		st.jitBlocks ? (double)st.blockCallCycles / (double)st.jitBlocks : 0.0);
+	Debug::Report(Debug::Channel::Norm, "    translating    : %.3f s (%.1f%% of jit), %.1f cycles/block\n",
+		(double)st.compileCycles / tscHz, st.jitRunCycles ? (double)st.compileCycles / st.jitRunCycles * 100.0 : 0.0,
+		st.jitCompiles ? (double)st.compileCycles / (double)st.jitCompiles : 0.0);
+	Debug::Report(Debug::Channel::Norm, "    dispatch       : %.3f s (%.1f%% of jit)\n",
+		(double)(st.jitRunCycles > st.blockCallCycles + st.compileCycles ? st.jitRunCycles - st.blockCallCycles - st.compileCycles : 0) / tscHz,
+		st.jitRunCycles ? (double)(st.jitRunCycles > st.blockCallCycles + st.compileCycles ? st.jitRunCycles - st.blockCallCycles - st.compileCycles : 0) / st.jitRunCycles * 100.0 : 0.0);
+	Debug::Report(Debug::Channel::Norm, "    interp fallback: %.3f s (%.1f%% of jit)\n",
+		(double)st.fallbackCycles / tscHz, st.jitRunCycles ? (double)st.fallbackCycles / st.jitRunCycles * 100.0 : 0.0);
+	Debug::Report(Debug::Channel::Norm, "    cache fills    : %.3f s (%.1f%% of jit)\n",
+		(double)st.castInCycles / tscHz, st.jitRunCycles ? (double)st.castInCycles / st.jitRunCycles * 100.0 : 0.0);
+	Debug::Report(Debug::Channel::Norm, "    mem helpers    : %.3f s (%.1f%% of jit), %llu calls, %.1f cycles/call\n",
+		(double)st.memHelperCycles / tscHz, st.jitRunCycles ? (double)st.memHelperCycles / st.jitRunCycles * 100.0 : 0.0,
+		(unsigned long long)st.memHelperCalls, st.memHelperCalls ? (double)st.memHelperCycles / (double)st.memHelperCalls : 0.0);
+	Debug::Report(Debug::Channel::Norm, "  interpreted instr: %.3f s\n", (double)st.interpCycles / tscHz);
+
+	UI::Jdi->Stop();
+	Thread::Sleep(200);
+	UI::Jdi->Unload();
+	DestroyRenderTarget();
+	OnMainWindowClosed();
 }
 
 static void ui_selector()
@@ -2094,6 +2321,14 @@ static int ui_main()
 	ImGui_ImplSDLRenderer2_Init(renderer);
 
 	ui_active = true;
+
+	// The command line may ask for an unattended benchmark run of a specific image.
+
+	if (cmdline.bench)
+	{
+		ui_bench();
+		ui_active = false;
+	}
 
 	// The command line may ask to start the IPL right away (as if File -> Run Bootrom was clicked).
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -21,7 +21,75 @@ void SpinLock::Unlock()
 
 #endif
 
-#ifdef _WINDOWS
+Event::Event()
+{
+#if defined(_WINDOWS)
+	handle = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+	assert(handle != nullptr);
+#else
+	pthread_mutex_init(&mutex, nullptr);
+	pthread_cond_init(&cond, nullptr);
+	signaled = false;
+#endif
+}
+
+Event::~Event()
+{
+#if defined(_WINDOWS)
+	if (handle != nullptr)
+	{
+		CloseHandle(handle);
+		handle = nullptr;
+	}
+#else
+	pthread_cond_destroy(&cond);
+	pthread_mutex_destroy(&mutex);
+#endif
+}
+
+void Event::Signal()
+{
+#if defined(_WINDOWS)
+	SetEvent(handle);
+#else
+	pthread_mutex_lock(&mutex);
+	signaled = true;
+	pthread_cond_signal(&cond);
+	pthread_mutex_unlock(&mutex);
+#endif
+}
+
+bool Event::Wait(size_t timeoutMs)
+{
+#if defined(_WINDOWS)
+	return WaitForSingleObject(handle, (DWORD)timeoutMs) == WAIT_OBJECT_0;
+#else
+	struct timespec until;
+	clock_gettime(CLOCK_REALTIME, &until);
+	until.tv_sec += timeoutMs / 1000;
+	until.tv_nsec += (long)(timeoutMs % 1000) * 1000000L;
+	if (until.tv_nsec >= 1000000000L)
+	{
+		until.tv_sec++;
+		until.tv_nsec -= 1000000000L;
+	}
+
+	pthread_mutex_lock(&mutex);
+	while (!signaled)
+	{
+		if (pthread_cond_timedwait(&cond, &mutex, &until) != 0)
+		{
+			break;		// timed out
+		}
+	}
+	bool was = signaled;
+	signaled = false;
+	pthread_mutex_unlock(&mutex);
+	return was;
+#endif
+}
+
+#if defined(_WINDOWS)
 
 DWORD WINAPI Thread::RingleaderThreadProc(LPVOID lpParameter)
 {

--- a/src/utils.h
+++ b/src/utils.h
@@ -55,6 +55,32 @@ public:
 
 typedef void (*ThreadProc)(void* param);
 
+// A waitable one-shot event: the portable counterpart of the wakeups between the emulator's
+// worker threads. Waiting on it blocks the thread, which is the point: a thread that busy-waits
+// on a location another core writes makes every write of that location transfer a cache line
+// between the cores (and keeps two cores hot), which costs far more than the work the waiting
+// thread performs. See the benchmark notes in `testing/gekko_bench`.
+class Event
+{
+#if defined(_WINDOWS)
+	HANDLE handle = nullptr;
+#else
+	pthread_mutex_t mutex;
+	pthread_cond_t cond;
+	bool signaled = false;
+#endif
+
+public:
+	Event();
+	~Event();
+
+	// Wake one waiter (or leave the event signaled until somebody waits).
+	void Signal();
+
+	// Wait for the event or the timeout. Returns true when it was signaled.
+	bool Wait(size_t timeoutMs);
+};
+
 class Thread
 {
 	struct WrappedContext

--- a/testing/dsp_test_support.cpp
+++ b/testing/dsp_test_support.cpp
@@ -247,6 +247,11 @@ Gekko::GekkoCore* Core = nullptr;
 
 namespace Gekko
 {
+	// The DSP sources bump the DSP counters in `stats` (see Gekko::CpuStats); the test DLL does not
+	// link gekko.cpp, so the block is supplied here like the other emulator-wide entities.
+	CpuStats stats;
+	bool cycleProfile = false;
+
 	int64_t GekkoCore::GetTicks()
 	{
 		return testGekkoTicks;

--- a/testing/gekko_bench/Readme.md
+++ b/testing/gekko_bench/Readme.md
@@ -128,6 +128,7 @@ The knobs below narrow down what part of it matters:
 | `BENCH_SPIN_PAUSE=1` | Execute the CPU's spin-wait hint (`pause`/`YieldProcessor`) in the loop |
 | `BENCH_SPIN_SLEEP=<ms>` | Sleep between polls instead of spinning (the fully blocked case) |
 | `BENCH_SPIN_DIV=<n>` | Touch the time base only every n-th iteration (`0` = never) |
+| `BENCH_SPIN_WORK=<n>` | Burn about n cycles per iteration, like a device thread that does real work per poll |
 
 Measured on the `workload_alu` mix at 30M instructions (~292 MIPS without
 pollers):
@@ -148,10 +149,43 @@ base at all costs 1.85x, so the damage is the spinning itself (the machine's SMT
 siblings and its power budget) and not only the cache-line transfers. And a
 blocked wait costs nothing: the remedy is to *not* busy-wait at all.
 
-The emulator was fixed accordingly: the VI/serial update is now executed by the
-CPU thread from the tick it already advances (`Flipper::Update`), and the CP
-thread blocks on an `Event` that the CPU thread signals when a batch of FIFO
-entries is due (`CommandProcessor::TickSync`).
+`BENCH_SPIN_WORK` separates the two effects. A device thread that does real work
+on every poll - the DSP executes one emulated instruction per iteration - spins
+orders of magnitude slower than a tight loop:
+
+| Configuration | Poll rate | MIPS |
+|---|---|---|
+| 2 pollers, no work | 80.1M/s | 130.3 |
+| 2 pollers, `BENCH_SPIN_WORK=40` | 48.8M/s | 146.2 |
+| 2 pollers, `BENCH_SPIN_WORK=400` | 16.6M/s | 188.0 |
+| 2 pollers, `BENCH_SPIN_WORK=4000` | 2.4M/s | 265.5 |
+| No pollers | - | 290.1 |
+
+So the cost tracks the poll rate, and a thread that only looks at the time base
+every few microseconds is nearly free. That is the test to apply before giving a
+device thread the same treatment: the AI DMA thread polled in a tight loop like
+the VI and CP ones and was worth 1.3-1.4x; the DSP thread, which was already
+15x slower, was worth another 1.2-1.3x - and it turned out to matter for
+correctness, not just speed (see below).
+
+The emulator was fixed accordingly. The VI/serial update is now executed by the
+CPU thread from the tick it already advances (`Flipper::Update`); the CP thread
+blocks on an `Event` that the CPU thread signals when a batch of FIFO entries is
+due (`CommandProcessor::TickSync`); the AI DMA thread is woken by
+`DSP::AITickSync` when the next 32-byte block is due; and the DSP thread is woken
+by `DspCore::TickSync` once per `DspWakeTicks` and then drains a batch of
+emulated DSP instructions.
+
+Two things to know about the DSP one. It batches, because one emulated DSP
+instruction per wakeup would mean five million wakeups per second. And batching
+made the DSP *execute more*: it used to re-anchor its deadline to the current
+tick on every poll, so a host that could not keep up with one instruction per
+five ticks simply dropped the rest - about 5.3M instructions/s here against the
+14-15M/s after. That is not only a speed question: on Luigi's Mansion the DSP
+falling behind stalls the game (it spins in its audio driver, the emulator drops
+to 0.6x real time and stops rendering altogether), and the batched version is
+stable at 4.3-4.6x. The per-event instructions still re-anchor after the batch,
+so the DSP stays host-limited rather than accumulating a backlog.
 
 Measured with two binaries built from the same tooling, one with the periodic
 work on its own polling thread and one without, on the same command line and the
@@ -165,6 +199,19 @@ whole story.
 | `pong.dol` (interpreted, no caches) | 22.0 MIPS, 1.47x | 55.0 MIPS, 3.66x | **2.50x** |
 | Ikaruga (disc, recompiler) | 40.3 MIPS, 2.16x | 49.6 MIPS, 2.66x | **1.23x** |
 | Luigi's Mansion (disc, recompiler) | 27.8 MIPS, 1.72x | 36.2 MIPS, 2.25x | **1.30x** |
+
+And the whole set, with the AI and DSP threads included, on a 20-second run of
+the same two images (the polling-thread figure is the build with the VI/CP only):
+
+| Workload | VI/CP only | all four | Speedup |
+|---|---|---|---|
+| Ikaruga | 48.7 MIPS, 2.61x | 80.4 MIPS, 4.58x | **1.65x** |
+| Luigi's Mansion | 10.7 MIPS, 0.62x (stalled) | 68.1 MIPS, 4.26x | **6.4x** |
+
+Attribution on Ikaruga (15 s, two runs each): the VI/CP work takes it from
+2.50-2.59x to 2.55x, the AI thread from there to 3.27-3.34x, and the DSP thread
+to 4.56-4.58x. `pong.dol`, which has neither an active DSP nor an active audio
+DMA, is unchanged by the last two steps (3.71x, 3.74x, 3.69x).
 
 The uncached case is the one the issue was written about - every Gekko memory
 access goes through the PI there - and it is also where the pollers hurt most,

--- a/testing/gekko_bench/Readme.md
+++ b/testing/gekko_bench/Readme.md
@@ -17,7 +17,9 @@ It is a development tool, not part of any build.
 | `gen_workload.py` | Generates synthetic Gekko workloads (instruction mix, code size, data window) |
 | `gen_selfmod.py` | Self-modifying-code probe (does the execution engine pick up rewritten instructions?) |
 | `gen_ipl.py` | Synthetic boot ROM + game + IPL2: BAT setup, cache enable, `mtmsr`, a per-cache-line `dcbst`/`icbi` flush, `bctr` into the game, a deliberate DSI whose handler returns with `rfi`, and an IPL2 stand-in that calls a `bclrl` thunk |
-| `build.sh` | Builds the harness from the current working tree |
+| `build.sh` | Builds the harness from the current working tree (GCC/Clang) |
+| `build_win.bat` | The same build with MSVC, so that the two compilers can be compared on one workload |
+| `bench_win_prof.cpp` | Empty `ProfStart`/`ProfStop` for the MSVC build (the sampler is POSIX) |
 | `build_base.sh` | Builds a reference harness from `git HEAD` (used as the differential oracle) |
 | `check.sh` | Compares the state fingerprint of the reference, the interpreter and the recompiler |
 | `compare.sh` | Throughput table for every workload |
@@ -94,6 +96,143 @@ whole suite must stay green with it; see "Host ABI" below.
   almost never produces a `bclrl` (about one word in 131072): a wrong `bclrl`
   translation made the recompiler derail on the real IPL2 entry and was invisible
   to every other test here.
+
+## The emulator's background threads
+
+The harness runs the CPU core alone: `main` calls `Core->Step()` or
+`Core->jit->Run()` in a tight loop. The emulator does not - it also runs the
+Flipper-side device threads, and until recently every one of them waited for its
+own deadline by reading `Core->GetTicks()` in a tight loop. The time base is the
+same location the CPU thread writes on every tick, so each write had to take the
+cache line back from every poller, and every poller then pulled it back again.
+That is not a micro-optimisation problem: the pollers cost more than the work
+they perform.
+
+`BENCH_SPIN=<n>` reproduces it faithfully - it starts n threads that poll
+`Core->GetTicks()` exactly like the device threads did - so the effect can be
+measured on a workload that does not change underneath the measurement:
+
+```
+$ BENCH_JIT=1 BENCH_RAW=workload_alu.bin ./bench dummy 30000000 1000000
+Executed 30000018 instructions in 0.103 s = 291.74 MIPS
+$ BENCH_SPIN=2 BENCH_JIT=1 BENCH_RAW=workload_alu.bin ./bench dummy 30000000 1000000
+Executed 30000025 instructions in 0.214 s = 140.34 MIPS
+spinner polls: 16117259 (75.4M/s)
+```
+
+Two pollers cost **2.1x** on the same instruction stream, one costs about 1.85x.
+The knobs below narrow down what part of it matters:
+
+| Variable | Effect on the poller |
+|---|---|
+| `BENCH_SPIN_PAUSE=1` | Execute the CPU's spin-wait hint (`pause`/`YieldProcessor`) in the loop |
+| `BENCH_SPIN_SLEEP=<ms>` | Sleep between polls instead of spinning (the fully blocked case) |
+| `BENCH_SPIN_DIV=<n>` | Touch the time base only every n-th iteration (`0` = never) |
+
+Measured on the `workload_alu` mix at 30M instructions (~292 MIPS without
+pollers):
+
+| Configuration | MIPS |
+|---|---|
+| No pollers | 291.7 |
+| 1 poller | 157.7 |
+| 2 pollers | 140.3 |
+| 2 pollers, `BENCH_SPIN_PAUSE=1` | 152.4 |
+| 2 pollers, `BENCH_SPIN_DIV=1024` | 240.4 |
+| 2 pollers, `BENCH_SPIN_SLEEP=1` | 288.5 |
+| 2 pollers, `BENCH_SPIN_DIV=0` (pure spin, no time base reads) | 130.2 |
+
+Two things follow. Reducing the polling rate helps but does not fix it -
+`BENCH_SPIN_DIV=1024` still costs 18%, and a spinner that never touches the time
+base at all costs 1.85x, so the damage is the spinning itself (the machine's SMT
+siblings and its power budget) and not only the cache-line transfers. And a
+blocked wait costs nothing: the remedy is to *not* busy-wait at all.
+
+The emulator was fixed accordingly: the VI/serial update is now executed by the
+CPU thread from the tick it already advances (`Flipper::Update`), and the CP
+thread blocks on an `Event` that the CPU thread signals when a batch of FIFO
+entries is due (`CommandProcessor::TickSync`).
+
+Measured with two binaries built from the same tooling, one with the periodic
+work on its own polling thread and one without, on the same command line and the
+same wall time. "Real time" is the emulated time the run covered (`tb` divided
+by `CPU_TIMER_CLOCK`), which is the number to compare: a faster build reaches a
+later point of the game in the same second, so its MIPS figure alone is not the
+whole story.
+
+| Workload | Polling threads | Fixed | Speedup |
+|---|---|---|---|
+| `pong.dol` (interpreted, no caches) | 22.0 MIPS, 1.47x | 55.0 MIPS, 3.66x | **2.50x** |
+| Ikaruga (disc, recompiler) | 40.3 MIPS, 2.16x | 49.6 MIPS, 2.66x | **1.23x** |
+| Luigi's Mansion (disc, recompiler) | 27.8 MIPS, 1.72x | 36.2 MIPS, 2.25x | **1.30x** |
+
+The uncached case is the one the issue was written about - every Gekko memory
+access goes through the PI there - and it is also where the pollers hurt most,
+because the interpreter writes the time base on every instruction. A real disc
+game gains less: its Gekko thread is only part of the emulator's total load, and
+the same pollers are also competing with the graphics work.
+
+## Measuring the emulator as a whole
+
+`--bench <file> [seconds]` runs the emulator without a user interface for the
+requested number of seconds and prints the throughput together with the CPU
+statistics (`Gekko::CpuStats`). `set BENCH_PROFILE=1` additionally turns on the
+host cycle counters, which cost about 20% of the throughput themselves, so the
+plain run is the one to quote:
+
+```
+> set EMU_LOG=bench.log
+> pureikyubu.exe --bench "C:\Isos\NGC\Ikaruga.iso" 15
+```
+
+The report answers the question this harness keeps raising - how much of the
+emulated work is the CPU, and how much is the rest of the console:
+
+```
+instructions       : 602482411
+throughput         : 43.08 MIPS
+basic blocks run   : 96642645 (6.96 instructions per block)
+blocks translated  : 2902777 (193428/s, 3.07% of the blocks run)
+block invalidations: 163889 (10921/s)
+  mtmsr            : 107959
+  rfi              : 26050
+  exception entry  : 16248
+jit fallbacks      : 22767860 (3.52% of the instructions)
+data cache fills   : 932071
+pi reads           : 78024 (mmio 77968)
+```
+
+The PI/MEM interface is not the bottleneck. On this run the CPU reached it 78
+thousand times against 602 million retired instructions (0.013%), and with
+`BENCH_PROFILE=1` the whole memory-helper path - every translated load and
+store, including the address translation and the cache probe - accounted for
+about a tenth of the host cycles, of which filling lines from the PI/MEM was
+0.1%. Everything else is the recompiler's own bookkeeping:
+
+```
+host cycles (TSC 3.00 GHz):
+  jit total        : 13.901 s (92.6% of the wall)
+    generated block:  7.319 s (52.7% of jit), 252 cycles/block
+    translating    :  2.056 s (14.8% of jit), 2263 cycles/block
+    dispatch       :  4.526 s (32.6% of jit)
+    interp fallback:  0.460 s ( 3.3% of jit)
+    cache fills    :  0.011 s ( 0.1% of jit)
+```
+
+(A caveat: `BENCH_PROFILE` costs about 20% of the throughput, because two
+`rdtsc` per basic block is not free, so read the *shares* above rather than the
+absolute seconds, and quote the plain run when comparing configurations.)
+
+Two thirds of the block-cache drops came from `mtmsr` - the register the OS
+toggles around every critical section to enable and disable interrupts, which
+cannot change what a compiled block translates to - and one sixth from `rfi`.
+Both now only drop the cache when MSR[IR]/[DR] actually change; that removes
+about 85,000 cache drops per second on this workload. It does *not* reduce the
+re-translation rate by the same factor, because the rate is set by how much of
+the guest code is live at once rather than by the drops (the compiles stay at
+about 200,000/s, and quadrupling the block cache changes them by a few percent).
+The average basic block is only seven instructions long, so the per-block
+dispatch and translation are where the remaining time goes.
 
 ## Host ABI
 

--- a/testing/gekko_bench/bench.cpp
+++ b/testing/gekko_bench/bench.cpp
@@ -158,7 +158,12 @@ static void StartSpinners(int count)
         int div = getenv("BENCH_SPIN_DIV") ? atoi(getenv("BENCH_SPIN_DIV")) : 1;
         if (div < 1) div = 1;
 
-        g_spinThreads.emplace_back([pause, sleepMs, div]()
+        // A device thread that does real work on every iteration (the DSP executes one emulated
+        // instruction per poll) iterates orders of magnitude slower than a tight loop. WORK makes
+        // each iteration burn roughly that many cycles, to see whether a slow poller still hurts.
+        int work = getenv("BENCH_SPIN_WORK") ? atoi(getenv("BENCH_SPIN_WORK")) : 0;
+
+        g_spinThreads.emplace_back([pause, sleepMs, div, work]()
         {
             int64_t deadline = Core->GetTicks();
             unsigned skip = 0;
@@ -171,6 +176,8 @@ static void StartSpinners(int count)
                     continue;   // div == 0: a pure spin that never touches the time base
                 }
                 skip = 0;
+
+                for (volatile int w = 0; w < work; w++) { }
 
                 int64_t ticks = Core->GetTicks();
                 g_spinPolls.fetch_add(1, std::memory_order_relaxed);

--- a/testing/gekko_bench/bench.cpp
+++ b/testing/gekko_bench/bench.cpp
@@ -6,6 +6,8 @@
 
 #include "pch.h"
 #include <chrono>
+#include <thread>
+#include <atomic>
 #include <fstream>
 #include <algorithm>
 #include <set>
@@ -127,6 +129,80 @@ static bool JitRequested()
 {
     const char* v = getenv("BENCH_JIT");
     return v != nullptr && v[0] != '\0';
+}
+
+// BENCH_SPIN=<n> makes n background threads poll Core->GetTicks() in a tight loop,
+// exactly like the emulator's HW update and CP FIFO threads do. The emulator runs
+// those threads on the same time base that the CPU thread advances on every
+// instruction, so the harness can measure that interference on a fixed workload
+// instead of guessing at it from the outside. BENCH_SPIN_PAUSE=1 makes the
+// pollers execute the CPU's spin-wait hint, BENCH_SPIN_SLEEP=<ms> makes them
+// sleep between polls.
+static std::atomic<bool> g_spinStop{ false };
+static std::atomic<long long> g_spinPolls{ 0 };
+static std::vector<std::thread> g_spinThreads;
+
+static void StartSpinners(int count)
+{
+    if (count <= 0)
+    {
+        return;
+    }
+
+    const char* pauseVar = getenv("BENCH_SPIN_PAUSE");
+    bool pause = pauseVar != nullptr && pauseVar[0] != '\0';
+    int sleepMs = getenv("BENCH_SPIN_SLEEP") ? atoi(getenv("BENCH_SPIN_SLEEP")) : -1;
+
+    for (int i = 0; i < count; i++)
+    {
+        int div = getenv("BENCH_SPIN_DIV") ? atoi(getenv("BENCH_SPIN_DIV")) : 1;
+        if (div < 1) div = 1;
+
+        g_spinThreads.emplace_back([pause, sleepMs, div]()
+        {
+            int64_t deadline = Core->GetTicks();
+            unsigned skip = 0;
+            while (!g_spinStop.load(std::memory_order_relaxed))
+            {
+                // A real device thread only has to look at the time base often enough to catch its
+                // next deadline; the rest of the loop is private work. BENCH_SPIN_DIV models that.
+                if (div != 1 && (div == 0 || ++skip < (unsigned)div))
+                {
+                    continue;   // div == 0: a pure spin that never touches the time base
+                }
+                skip = 0;
+
+                int64_t ticks = Core->GetTicks();
+                g_spinPolls.fetch_add(1, std::memory_order_relaxed);
+                if (ticks >= deadline)
+                {
+                    deadline = ticks + 100;
+                }
+                if (sleepMs >= 0)
+                {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(sleepMs));
+                }
+                else if (pause)
+                {
+#if defined(_MSC_VER)
+                    _mm_pause();
+#else
+                    __builtin_ia32_pause();
+#endif
+                }
+            }
+        });
+    }
+}
+
+static void StopSpinners()
+{
+    g_spinStop.store(true);
+    for (auto& t : g_spinThreads)
+    {
+        t.join();
+    }
+    g_spinThreads.clear();
 }
 
 static bool FuzzUnsafe(Gekko::Instruction i)
@@ -1163,6 +1239,10 @@ int main(int argc, char** argv)
 	bool stateTrace = getenv("BENCH_STATE_TRACE") != nullptr;
 
 	uint64_t done = 0;
+
+	// Reproduce the emulator's background threads (see BENCH_SPIN).
+	StartSpinners(getenv("BENCH_SPIN") ? atoi(getenv("BENCH_SPIN")) : 0);
+
 	auto t0 = std::chrono::high_resolution_clock::now();
 
 	while (done < totalSteps)
@@ -1231,6 +1311,9 @@ int main(int argc, char** argv)
 	auto t1 = std::chrono::high_resolution_clock::now();
 	double sec = std::chrono::duration<double>(t1 - t0).count();
 
+	long long spins = g_spinPolls.load();
+	StopSpinners();
+
 	if (useJit)
 	{
 		done = (uint64_t)Core->GetInstructionCounter();
@@ -1244,6 +1327,10 @@ int main(int argc, char** argv)
 	printf("MMIO reads %llu, writes %llu\n",
 		(unsigned long long)Flipper::ProcessorInterface::mmioReads,
 		(unsigned long long)Flipper::ProcessorInterface::mmioWrites);
+	if (spins != 0)
+	{
+		printf("spinner polls: %lld (%.1fM/s)\n", spins, (double)spins / sec / 1e6);
+	}
 	if (stats)
 	{
 		g_verbose = true;

--- a/testing/gekko_bench/bench_win_prof.cpp
+++ b/testing/gekko_bench/bench_win_prof.cpp
@@ -1,0 +1,4 @@
+// The POSIX sampling profiler is not available on Windows; the harness only calls
+// ProfStart/ProfStop from the BENCH_PROF path, so empty stubs keep it portable.
+void ProfStart() {}
+void ProfStop(const char* outPath) { (void)outPath; }

--- a/testing/gekko_bench/build_base.sh
+++ b/testing/gekko_bench/build_base.sh
@@ -8,13 +8,18 @@ BENCH=${BENCH:-/tmp/pkbench}
 BASE=$BENCH/base
 rm -rf $BASE
 mkdir -p $BASE/src
-for f in gekko.cpp gekkoc.cpp gekkodec.cpp gekkodisasm.cpp gqr.h gekko.h gekkoc.h gekkodec.h gekkodisasm.h; do
+# The reference is the same harness built from git HEAD, so the file set and the flags have to
+# match build.sh exactly (the core sources and the headers they include are versioned together).
+
+for f in gekko.cpp gekkoc.cpp gekkodec.cpp gekkodisasm.cpp gekkojit.cpp gekkojit_ps.cpp \
+         gekkojit_x64.h gekkojit_ps.h gqr.h gekko.h gekkoc.h gekkodec.h gekkodisasm.h gekkojit.h; do
     (cd $REPO && git show HEAD:src/$f) > $BASE/src/$f
 done
 
-g++ -std=c++17 -D_LINUX -O2 -fno-strict-aliasing -w \
+g++ -std=c++17 -D_LINUX -DBENCH_WITH_JIT -O2 -fno-strict-aliasing -w \
     -I$HERE -I$BASE/src \
     $BASE/src/gekko.cpp $BASE/src/gekkoc.cpp $BASE/src/gekkodec.cpp $BASE/src/gekkodisasm.cpp \
+    $BASE/src/gekkojit.cpp $BASE/src/gekkojit_ps.cpp \
     $HERE/stubs.cpp $HERE/bench.cpp $HERE/prof.cpp \
     -o $BASE/bench -lpthread
 

--- a/testing/gekko_bench/build_win.bat
+++ b/testing/gekko_bench/build_win.bat
@@ -1,0 +1,34 @@
+@echo off
+rem Build the standalone Gekko benchmark with MSVC, from the current working tree.
+rem This is the Windows counterpart of build.sh: the same sources and the same stubs,
+rem so that the two compilers can be compared on exactly the same workload.
+rem
+rem   BLD   scratch directory (default <here>\build_win)
+rem   VCVARS  path to vcvars64.bat (default: Visual Studio 2022/2026 Community)
+setlocal
+set HERE=%~dp0
+if "%BLD%"=="" set BLD=%HERE%build_win
+if "%VCVARS%"=="" set VCVARS=C:\Program Files\Microsoft Visual Studio\18\Community\VC\Auxiliary\Build\vcvars64.bat
+if not exist "%VCVARS%" set VCVARS=C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat
+call "%VCVARS%" >nul
+
+set REPO=%HERE%..\..
+if not exist "%BLD%\src" mkdir "%BLD%\src"
+copy /y "%REPO%\src\gekko.cpp"        "%BLD%\src\" >nul
+copy /y "%REPO%\src\gekkoc.cpp"       "%BLD%\src\" >nul
+copy /y "%REPO%\src\gekkodec.cpp"     "%BLD%\src\" >nul
+copy /y "%REPO%\src\gekkodisasm.cpp"  "%BLD%\src\" >nul
+copy /y "%REPO%\src\gekkojit.cpp"     "%BLD%\src\" >nul
+copy /y "%REPO%\src\gekkojit_ps.cpp"  "%BLD%\src\" >nul
+copy /y "%REPO%\src\gekkojit_x64.h"   "%BLD%\src\" >nul
+copy /y "%REPO%\src\gekkojit_ps.h"    "%BLD%\src\" >nul
+copy /y "%REPO%\src\gqr.h"            "%BLD%\src\" >nul
+
+pushd "%HERE%"
+cl /nologo /O2 /Oi /GL /EHsc /std:c++17 /MT /W3 /wd4996 /DBENCH_WITH_JIT /D_WINDOWS ^
+   /I. /I"%BLD%\src" /I"%REPO%\src" ^
+   "%BLD%\src\gekko.cpp" "%BLD%\src\gekkoc.cpp" "%BLD%\src\gekkodec.cpp" ^
+   "%BLD%\src\gekkojit.cpp" "%BLD%\src\gekkojit_ps.cpp" "%BLD%\src\gekkodisasm.cpp" ^
+   stubs.cpp bench.cpp bench_win_prof.cpp ^
+   /Fe:"%BLD%\bench.exe" /Fo:"%BLD%\\" /link /LTCG
+popd

--- a/testing/gekko_bench/pch.h
+++ b/testing/gekko_bench/pch.h
@@ -22,6 +22,12 @@
 
 extern bool g_verbose;
 
+#if defined(_MSC_VER)
+#define BENCH_ALWAYS_INLINE __forceinline
+#else
+#define BENCH_ALWAYS_INLINE inline __attribute__((always_inline))
+#endif
+
 #ifdef _LINUX
 #include <byteswap.h>
 #define _BYTESWAP_UINT16 __bswap_16
@@ -119,14 +125,14 @@ namespace Flipper
 		static uint64_t mmioReads;
 		static uint64_t mmioWrites;
 
-		__attribute__((always_inline)) static uint8_t* RamPtr(uint32_t pa)
+		BENCH_ALWAYS_INLINE static uint8_t* RamPtr(uint32_t pa)
 		{
 			return (pa < ramSize) ? &ram[pa] : nullptr;
 		}
 
 		// Returns a pointer into the boot ROM image, or nullptr when the address is
 		// outside it (or outside the requested access size).
-		__attribute__((always_inline)) static uint8_t* BootromPtr(uint32_t pa, uint32_t need)
+		BENCH_ALWAYS_INLINE static uint8_t* BootromPtr(uint32_t pa, uint32_t need)
 		{
 			if (bootrom == nullptr || pa < PI_MEMSPACE_BOOTROM) return nullptr;
 			uint32_t off = pa - PI_MEMSPACE_BOOTROM;
@@ -145,9 +151,15 @@ namespace Flipper
 		void PIWriteBurst(uint32_t phys_addr, uint8_t burstData[32]);
 	};
 
+	// The harness has no Flipper ASIC: the CPU drives the periodic VI/serial work through this
+	// hook (see GekkoCore::SyncFlipper), so the stub only has to provide the interface.
+	static const int64_t FlipperTickStep = 100;
+
 	struct FlipperStub
 	{
 		ProcessorInterface* pi;
+
+		void Update(int64_t ticks) { (void)ticks; }
 	};
 
 	extern FlipperStub* HW;

--- a/wiki/main.md
+++ b/wiki/main.md
@@ -32,8 +32,11 @@ Instead of calling `Thread` class directly from utils.cpp, `EMUCreateThread` / `
 The time base (TBR) is advanced by the Gekko thread, and every periodic piece of
 Flipper work hangs off it. The VI scan-out and the serial poll are therefore
 executed *by the Gekko thread itself*, at the ticks where they are due
-(`GekkoCore::Tick`/`TickN` call `Flipper::Update`); the CP thread is woken with
-an `Event` when a batch of FIFO entries is due.
+(`GekkoCore::Tick`/`TickN` call `Flipper::Update`). The threads that cannot move
+there - the CP, because it owns the OpenGL context; the AI DMA and the DSP core,
+because they are heavy - are woken through an `Event` when their next deadline
+passes (`CommandProcessor::TickSync`, `DSP::AITickSync`, `DspCore::TickSync`)
+and then drain a batch of work.
 
 This is not a detail. A device thread that waits for its deadline by reading
 `Core->GetTicks()` in a tight loop makes every write of the time base transfer

--- a/wiki/main.md
+++ b/wiki/main.md
@@ -27,6 +27,29 @@ Supported file formats:
 
 Instead of calling `Thread` class directly from utils.cpp, `EMUCreateThread` / `EMUJoinThread` calls are used for threads. They are in essence wrappers and are needed to keep statistics of active threads of the emulator.
 
+### Periodic hardware work
+
+The time base (TBR) is advanced by the Gekko thread, and every periodic piece of
+Flipper work hangs off it. The VI scan-out and the serial poll are therefore
+executed *by the Gekko thread itself*, at the ticks where they are due
+(`GekkoCore::Tick`/`TickN` call `Flipper::Update`); the CP thread is woken with
+an `Event` when a batch of FIFO entries is due.
+
+This is not a detail. A device thread that waits for its deadline by reading
+`Core->GetTicks()` in a tight loop makes every write of the time base transfer
+that cache line between the cores, and it costs far more than the work the
+thread performs - on the order of 2x for the emulator as a whole. Waiting
+threads have to block (see `Event` in utils.h, and the benchmark notes and
+measurements in `testing/gekko_bench/Readme.md`).
+
+## Command line
+
+| Option | Meaning |
+|---|---|
+| `--ipl` | Start the Bootrom (IPL) right away, without going through the UI |
+| `--no-disc` | Start with the DVD lid open, so that the IPL takes its "no disc" path |
+| `--bench <file> [seconds]` | Run the file unattended for the given number of seconds (30 by default) and print the measured throughput and the CPU statistics to the debug log (`EMU_LOG=<file>`). `BENCH_PROFILE=1` adds the host cycle breakdown, `BENCH_STATS=1` the guest instruction histogram |
+
 ## HWConfig
 
 To avoid using configuration from the HW component, all Flipper hardware emulation settings are aggregated


### PR DESCRIPTION
Closes #360.

The issue asked where the synthetic 400+ MIPS goes when the recompiler meets a
real game, and suspected the Gekko <-> PI (MEM) interaction. It is not there. The
bottleneck is that every periodic Flipper module waited for its deadline by
reading `Core->GetTicks()` in a tight loop — the same location the CPU thread
writes on every tick. Each write had to take the cache line back from every
poller, and every poller pulled it back.

## The PI/MEM path is 0.013% of the work

New `--bench <file> [seconds]` mode reports the CPU-side counters unattended.
Ikaruga from disc, 15 s, 602M retired instructions:

```
throughput         : 43.08 MIPS
basic blocks run   : 96642645 (6.96 instructions per block)
blocks translated  : 2902777 (193428/s, 3.07% of the blocks run)
jit fallbacks      : 22767860 (3.52% of the instructions)
data cache fills   : 932071
pi reads           : 78024 (mmio 77968)
```

78 thousand PI accesses against 602 million instructions. With
`BENCH_PROFILE=1`, the whole translated memory path — address translation, cache
probe, helper call — is about a tenth of the host cycles, and filling lines
through the PI/MEM is 0.1% of that. Everything else is the recompiler's own
bookkeeping, and two thirds of the block-cache drops came from `mtmsr` (the
register the OS toggles around every critical section, which cannot change what a
compiled block translates to).

## Evidence, on a workload that cannot move

`BENCH_SPIN=<n>` in the standalone harness starts n threads that poll the time
base exactly like the device threads did, so the cost is measured on an unchanged
instruction stream (the harness runs the CPU core alone, the emulator does not):

| configuration | MIPS |
|---|---|
| no pollers | 291.7 |
| 1 poller | 157.7 |
| 2 pollers | 140.3 |
| 2 pollers, `BENCH_SPIN_PAUSE=1` | 152.4 |
| 2 pollers, `BENCH_SPIN_DIV=1024` | 240.4 |
| 2 pollers, `BENCH_SPIN_SLEEP=1` | 288.5 |
| 2 pollers, `BENCH_SPIN_DIV=0` (pure spin, no time base reads) | 130.2 |

Reducing the poll rate helps but does not fix it, and a spinner that never
touches the time base at all still costs 1.85x: the damage is the spinning
itself, not only the cache-line transfers. A blocked wait costs nothing.

`BENCH_SPIN_WORK` separates the two and is the test to apply before giving a
thread the same treatment — the cost tracks the poll rate, and a thread that
looks at the time base only every few microseconds is nearly free:

| configuration | poll rate | MIPS |
|---|---|---|
| 2 pollers, no work | 80.1M/s | 130.3 |
| 2 pollers, `BENCH_SPIN_WORK=400` | 16.6M/s | 188.0 |
| 2 pollers, `BENCH_SPIN_WORK=4000` | 2.4M/s | 265.5 |
| no pollers | — | 290.1 |

## Changes

**Periodic work moves onto the thread that advances the clock.**
`GekkoCore::Tick`/`TickN` call `Flipper::Update`, so the VI scan-out and the
serial poll run on the CPU thread at the exact ticks where they are due. The
thread that used to do it (and the time base it polled) is gone.

**The threads that cannot move there block on an `Event`** (new, portable,
`utils.h`) and drain a batch:

* `CommandProcessor::TickSync` wakes the CP thread once per `FifoBatch` (16)
  FIFO entries' worth of emulated CP time; the drain stays at the emulated rate.
* `DSP::AITickSync` wakes the AI DMA thread when the next 32-byte block is due
  (~6750 ticks at 48 kHz). It also parks itself when no DMA is armed, where it
  used to spin for as long as the game kept the DMA switched off.
* `DspCore::TickSync` wakes the DSP thread once per `DspWakeTicks` (1000); one
  emulated DSP instruction per wakeup would mean five million wakeups per second.
  The DSP thread now also executes more: `DspCore::Update` re-anchored its
  deadline to the current tick on every poll, so a host that could not keep up
  with one instruction per five ticks dropped the rest — 5.3M instructions/s
  against the 14–15M/s the constant asks for. That was a correctness problem, not
  just a speed one: on Luigi's Mansion the lagging DSP stalls the game (it spins
  in its audio driver, never renders a frame, 0.6x real time). The batch still
  re-anchors when it is done, so the DSP stays host-limited instead of
  accumulating a backlog.

**`mtmsr` and `rfi` only drop the compiled blocks when MSR[IR]/[DR] change**,
which removes ~85,000 needless cache drops per second. It does not reduce
re-translations by the same factor — that rate is set by how much guest code is
live at once (it stays at ~200K/s, and quadrupling the block cache moves it by a
few percent) — but the drops were pure waste.

## Results

Two binaries from the same tooling, same command line, same wall time. "Real
time" is the emulated time the run covered (`tb / CPU_TIMER_CLOCK`), which is the
number to compare: a faster build reaches a later point of the game in the same
second.

| workload | before | after | speedup |
|---|---|---|---|
| `pong.dol` (interpreted, no caches) | 22.0 MIPS, 1.47x | 55.0 MIPS, 3.66x | **2.50x** |
| Ikaruga (disc, recompiler) | 40.3 MIPS, 2.16x | 80.4 MIPS, 4.58x | **2.00x** |
| Luigi's Mansion (disc, recompiler) | 27.8 MIPS, 1.72x | 68.1 MIPS, 4.26x | **2.45x** |

Attribution on Ikaruga (two runs each): VI/serial + CP 2.50–2.59x → 2.55x, AI
DMA → 3.27–3.34x, DSP → 4.56–4.58x. `pong.dol` has neither an active DSP nor an
active audio DMA and is unchanged by the last two steps (3.71x, 3.74x, 3.69x).

The Luigi's Mansion baseline is itself unstable: the DSP lagging makes it stall
at 0.62x real time in some runs, which is why its "before" figure varies between
runs. With the batched DSP it is consistently 4.3–4.6x.

## Correctness

* Full unit test suite: **348/348**, including every DSP test and the
  golden-vector sweep. (`testing/dsp_test_support.cpp` gained the link double for
  the new counters, and the mailbox hold-off tolerates the null `Core` the tests
  use.)
* Harness differential checks (reference interpreter == interpreter == JIT over
  the alu/mem/ps/psq mixes), random instruction fuzzer (4000 programs, 181
  instruction types), exhaustive branch test (654 cases), Paired-Single test
  (54571 cases) — all green.
* Ikaruga, Luigi's Mansion, Metroid Prime and the IPL boot path run and render
  (`pe finishes` > 0), checked over repeated 10–40 s runs.

## Tooling added, so the next round does not have to guess

* `--bench <file> [seconds]`: unattended run, throughput plus `Gekko::CpuStats`
  (translated vs interpreted instructions, basic block length, re-translations
  and their causes, cache line fills, every CPU access that leaves the cache for
  the PI/MEM, and an `tb`-based real-time factor). `BENCH_PROFILE=1` adds the host
  cycle breakdown (it costs ~20% of the throughput itself, so quote the plain
  run), `BENCH_STATS=1` the guest instruction histogram.
* `BENCH_SPIN`/`_DIV`/`_PAUSE`/`_SLEEP`/`_WORK` in `testing/gekko_bench`: reproduce
  and dissect the thread interference on a fixed workload.
* `build_win.bat`: build that harness with MSVC, so the two compilers can be
  compared on one workload. `build_base.sh` was building a reference that no
  longer linked (it predates the recompiler); it now mirrors `build.sh`.

## Not in this PR

* The DVD thread polls the time base the same way, but only during a transfer
  (~2.4M polls/s by the table above, so a small share).
* The remaining time is the recompiler itself: the average basic block is seven
  instructions long, dispatch is ~33% and re-translation ~15% of the JIT time.
  A larger block cache and a bigger `MaxBlockInstrs` do not move it; block
  chaining and inlining the memory helpers are the next things to look at.