### PR TITLE
Fix the black screen in The Wind Waker / Animal Crossing (issue #361)

### DIFF
--- a/scripts/VS2026/pureikyubu_test.vcxproj
+++ b/scripts/VS2026/pureikyubu_test.vcxproj
@@ -37,6 +37,7 @@
     <ClCompile Include="..\..\testing\gfx_cp_test.cpp" />
     <ClCompile Include="..\..\testing\gfx_cp_array_test.cpp" />
     <ClCompile Include="..\..\testing\gfx_cp_spec_test.cpp" />
+    <ClCompile Include="..\..\testing\gfx_si_spec_test.cpp" />
     <ClCompile Include="..\..\testing\gfx_su_features_test.cpp" />
     <ClCompile Include="..\..\testing\gfx_bump_test.cpp" />
     <ClCompile Include="..\..\testing\gfx_texture_test.cpp" />
@@ -68,6 +69,9 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="..\..\src\dspdma.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="..\..\src\si.cpp">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="..\..\src\dsparam.cpp">

--- a/scripts/VS2026/pureikyubu_test.vcxproj
+++ b/scripts/VS2026/pureikyubu_test.vcxproj
@@ -36,6 +36,7 @@
     <ClCompile Include="..\..\testing\gfx_xf_test.cpp" />
     <ClCompile Include="..\..\testing\gfx_cp_test.cpp" />
     <ClCompile Include="..\..\testing\gfx_cp_array_test.cpp" />
+    <ClCompile Include="..\..\testing\gfx_cp_spec_test.cpp" />
     <ClCompile Include="..\..\testing\gfx_su_features_test.cpp" />
     <ClCompile Include="..\..\testing\gfx_bump_test.cpp" />
     <ClCompile Include="..\..\testing\gfx_texture_test.cpp" />

--- a/src/cp.cpp
+++ b/src/cp.cpp
@@ -104,11 +104,27 @@ namespace Flipper
 		cp->CpWriteReg(addr & 0xFF, data);
 	}
 
+	// The read pointer has reached the break point. The break point itself stops the reader; the
+	// status flag is raised whenever the break point is enabled (CP_ENABLE[FIFOBRK]) and cleared
+	// when it is disabled (command-processor.md 4.3: "the FIFO read pointer reached the break
+	// point (cleared by disabling the break point)"). CP_ENABLE[FIFOBRKINT] only decides whether
+	// the CP interrupt is raised on top of that.
 	void CommandProcessor::CP_BREAK()
 	{
-		if (cpregs.cr & CP_CR_BPINTEN && (cpregs.sr & CP_SR_BPINT) == 0)
+		if ((cpregs.cr & CP_CR_BPEN) == 0)
 		{
-			cpregs.sr |= CP_SR_BPINT;
+			return;
+		}
+
+		if ((cpregs.sr & CP_SR_BPINT) != 0)
+		{
+			return;
+		}
+
+		cpregs.sr |= CP_SR_BPINT;
+
+		if (cpregs.cr & CP_CR_BPINTEN)
+		{
 			HW->pi->PIAssertInt(PI_INTERRUPT_CP);
 			Report(Channel::CP, "BREAK\n");
 		}
@@ -263,6 +279,25 @@ namespace Flipper
 		}
 	}
 
+	// The distance between the write and the read pointer, over the ring. Both pointers live in
+	// 32-byte units, so the result is in the same units (command-processor.md 4.5).
+	void CommandProcessor::FifoCount(uint32_t* count) const
+	{
+		if (cpregs.wrptr >= cpregs.rdptr)
+		{
+			*count = cpregs.wrptr - cpregs.rdptr;
+		}
+		else
+		{
+			*count = (cpregs.top - cpregs.rdptr) + (cpregs.wrptr - cpregs.base);
+		}
+	}
+
+	void CommandProcessor::ResetFifoProcessor()
+	{
+		fifo->Reset();
+	}
+
 	void CommandProcessor::CPAbortFifo()
 	{
 		Report(Channel::GP, "CP Abort FIFO\n");
@@ -299,10 +334,22 @@ namespace Flipper
 				return cpregs.lomarkl & 0xffe0;
 			case CP_FIFO_LOCNTH:
 				return cpregs.lomarkh;
+			// The count is what the hardware reports, not a value the CPU wrote: it is the distance
+			// between the write and the read pointer, in the same 32-byte units and over the same
+			// ring (command-processor.md 4.5). The CP keeps it live so that a program which polls
+			// CP_FIFO_COUNT sees the FIFO drain as the CP walks it.
 			case CP_FIFO_COUNTL:
-				return cpregs.cntl & 0xffe0;
+			{
+				uint32_t count = 0;
+				FifoCount(&count);
+				return (uint16_t)(count & 0xffe0);
+			}
 			case CP_FIFO_COUNTH:
-				return cpregs.cnth;
+			{
+				uint32_t count = 0;
+				FifoCount(&count);
+				return (uint16_t)(count >> 16);
+			}
 			case CP_FIFO_WPTRL:
 				return cpregs.wrptrl & 0xffe0;
 			case CP_FIFO_WPTRH:

--- a/src/cp.h
+++ b/src/cp.h
@@ -591,6 +591,10 @@ namespace Flipper
 		uint16_t CpReadReg(uint32_t addr);
 		void CpWriteReg(uint32_t addr, uint16_t value);
 
+		//! The live FIFO occupancy (write pointer minus read pointer, over the ring), in 32-byte
+		//! units. This is what CP_FIFO_COUNT reports and what the water marks are compared against.
+		void FifoCount(uint32_t* count) const;
+
 	public:
 		CommandProcessor(Flipper* flipper, HWConfig* config);
 		~CommandProcessor();
@@ -610,6 +614,11 @@ namespace Flipper
 
 		//! The frame counters, for the debug interface (`gxframes`, `gxregs cp`).
 		void GetStats(CommandProcessorStats* stats) const;
+
+		//! Drop the decoded command stream the CP has buffered (the CP-side FIFO), so that a new
+		//! command stream starts from an empty buffer. The unit tests use it to isolate one test
+		//! stream from the next; CPAbortFifo (CP_ABORT) is the guest-visible equivalent.
+		void ResetFifoProcessor();
 
 		//! Drain the graphics FIFO once: exactly the work the CP thread does on one tick. The unit
 		//! tests use it to run the command stream deterministically, without the emulator threads.

--- a/src/di.cpp
+++ b/src/di.cpp
@@ -22,19 +22,15 @@ namespace Flipper
 	// disk driver.
 	void DiskInterface::DIUpdateInt()
 	{
-		uint16_t pending = di.sr & (DI_SR_BRKINT | DI_SR_TCINT | DI_SR_DEINT);
-		uint16_t unmasked = di.sr & (DI_SR_BRKINTMSK | DI_SR_TCINTMSK | DI_SR_DEINTMSK);
+		// Each cause has its own mask bit (DI_SR_BRKINT/DI_SR_BRKINTMSK and so on), so the line is
+		// the OR of the four (cause && its own mask) pairs. The cause bits and their masks are not
+		// adjacent, so the two groups cannot be ANDed with each other.
+		bool brk = (di.sr & DI_SR_BRKINT) != 0 && (di.sr & DI_SR_BRKINTMSK) != 0;
+		bool tc = (di.sr & DI_SR_TCINT) != 0 && (di.sr & DI_SR_TCINTMSK) != 0;
+		bool de = (di.sr & DI_SR_DEINT) != 0 && (di.sr & DI_SR_DEINTMSK) != 0;
+		bool cvr = (di.cvr & DI_CVR_CVRINT) != 0 && (di.cvr & DI_CVR_CVRINTMSK) != 0;
 
-		if (di.cvr & DI_CVR_CVRINT)
-		{
-			pending |= DI_CVR_CVRINT;
-			if (di.cvr & DI_CVR_CVRINTMSK)
-			{
-				unmasked |= DI_CVR_CVRINT;
-			}
-		}
-
-		if ((pending & unmasked) != 0)
+		if (brk || tc || de || cvr)
 		{
 			HW->pi->PIAssertInt(PI_INTERRUPT_DI);
 		}

--- a/src/di.cpp
+++ b/src/di.cpp
@@ -7,6 +7,44 @@ namespace Flipper
 {
 
 	// ---------------------------------------------------------------------------
+	// The aggregate disk interrupt
+	//
+	// The disk interface reports several internal causes to the CPU through ONE Processor
+	// Interface line (PI_INTERRUPT_DI): the transfer-complete, the break and the device-error
+	// causes in DISR, plus the cover cause in DICVR. Each cause has its own mask, and the line
+	// follows the OR of the ones that are currently latched and unmasked.
+	//
+	// The line therefore cannot be "asserted by" a single cause: every place that changes a cause
+	// or a mask has to re-evaluate it. Dropping it only inside one status-register write, and only
+	// when that single write left every cause clear, leaves the line asserted forever as soon as
+	// two causes are latched and the guest acknowledges them in separate writes - the CPU then
+	// re-enters the external-interrupt handler on every rfi and the guest never returns to its
+	// disk driver.
+	void DiskInterface::DIUpdateInt()
+	{
+		uint16_t pending = di.sr & (DI_SR_BRKINT | DI_SR_TCINT | DI_SR_DEINT);
+		uint16_t unmasked = di.sr & (DI_SR_BRKINTMSK | DI_SR_TCINTMSK | DI_SR_DEINTMSK);
+
+		if (di.cvr & DI_CVR_CVRINT)
+		{
+			pending |= DI_CVR_CVRINT;
+			if (di.cvr & DI_CVR_CVRINTMSK)
+			{
+				unmasked |= DI_CVR_CVRINT;
+			}
+		}
+
+		if ((pending & unmasked) != 0)
+		{
+			HW->pi->PIAssertInt(PI_INTERRUPT_DI);
+		}
+		else
+		{
+			HW->pi->PIClearInt(PI_INTERRUPT_DI);
+		}
+	}
+
+	// ---------------------------------------------------------------------------
 	// cover control. Callbacks are issued from DDU 
 
 	void DiskInterface::DIOpenCover(void *ctx)
@@ -14,10 +52,7 @@ namespace Flipper
 		DiskInterface* di = (DiskInterface*)ctx;
 		// cover interrupt
 		di->DICVR |= DI_CVR_CVRINT;
-		if (di->DICVR & DI_CVR_CVRINTMSK)
-		{
-			HW->pi->PIAssertInt(PI_INTERRUPT_DI);
-		}
+		di->DIUpdateInt();
 	}
 
 	void DiskInterface::DICloseCover(void* ctx)
@@ -25,10 +60,7 @@ namespace Flipper
 		DiskInterface* di = (DiskInterface*)ctx;
 		// cover interrupt
 		di->DICVR |= DI_CVR_CVRINT;
-		if (di->DICVR & DI_CVR_CVRINTMSK)
-		{
-			HW->pi->PIAssertInt(PI_INTERRUPT_DI);
-		}
+		di->DIUpdateInt();
 	}
 
 	// ---------------------------------------------------------------------------
@@ -40,10 +72,7 @@ namespace Flipper
 		di->DICR &= ~DI_CR_TSTART;
 
 		di->DISR |= DI_SR_DEINT;
-		if (di->DISR & DI_SR_DEINTMSK)
-		{
-			HW->pi->PIAssertInt(PI_INTERRUPT_DI);
-		}
+		di->DIUpdateInt();
 
 		DVD::DDU->SetTransferCallbacks(DIHostToDduCallbackCommand, DIDduToHostCallback, di);
 	}
@@ -58,10 +87,7 @@ namespace Flipper
 		DISR &= ~DI_SR_BRK;
 
 		DISR |= DI_SR_BRKINT;
-		if (DISR & DI_SR_BRKINTMSK)
-		{
-			HW->pi->PIAssertInt(PI_INTERRUPT_DI);
-		}
+		DIUpdateInt();
 
 		DVD::DDU->SetTransferCallbacks(DIHostToDduCallbackCommand, DIDduToHostCallback, this);
 	}
@@ -72,10 +98,7 @@ namespace Flipper
 		DICR &= ~DI_CR_TSTART;
 
 		DISR |= DI_SR_TCINT;
-		if (DISR & DI_SR_TCINTMSK)
-		{
-			HW->pi->PIAssertInt(PI_INTERRUPT_DI);
-		}
+		DIUpdateInt();
 
 		if (di.log) {
 			Report(Channel::DI, "TransferComplete\n");
@@ -256,10 +279,9 @@ namespace Flipper
 		{
 			DISR &= ~DI_SR_DEINT;
 		}
-		if ((DISR & DI_SR_BRKINT) == 0 && (DISR & DI_SR_TCINT) == 0 && (DISR & DI_SR_DEINT) == 0)
-		{
-			HW->pi->PIClearInt(PI_INTERRUPT_DI);
-		}
+		// The guest acknowledged some of the internal causes; the aggregate line has to be
+		// re-evaluated, not cleared from this one write.
+		DIUpdateInt();
 
 		// Issue break
 		if (data & DI_SR_BRK)
@@ -303,12 +325,13 @@ namespace Flipper
 		if (data & DI_CVR_CVRINT)
 		{
 			DICVR &= ~DI_CVR_CVRINT;
-			HW->pi->PIClearInt(PI_INTERRUPT_DI);
 		}
 
 		// set mask
 		if (data & DI_CVR_CVRINTMSK) DICVR |= DI_CVR_CVRINTMSK;
 		else DICVR &= ~DI_CVR_CVRINTMSK;
+
+		DIUpdateInt();
 	}
 
 	void DiskInterface::read_cvr(uint32_t* reg)

--- a/src/di.h
+++ b/src/di.h
@@ -76,6 +76,12 @@ namespace Flipper
 		static uint8_t DIHostToDduCallbackCommand(void* ctx);
 		static uint8_t DIHostToDduCallbackData(void* ctx);
 		static void DIDduToHostCallback(uint8_t data, void* ctx);
+		/// <summary>
+		/// Re-evaluate the aggregate Processor Interface line (PI_INTERRUPT_DI) from the three
+		/// internal DISR causes and their masks. Called wherever a cause or a mask changes.
+		/// </summary>
+		void DIUpdateInt();
+
 		void write_sr(uint16_t data);
 		void write_cr(uint16_t data);
 		void write_cvr(uint16_t data);

--- a/src/dspai.cpp
+++ b/src/dspai.cpp
@@ -69,10 +69,11 @@ namespace DSP
 			CDCR &= ~CDCR_AIINT;
 		}
 
-		if ((CDCR & CDCR_DSPINT) == 0 && (CDCR & CDCR_ARINT) == 0 && (CDCR & CDCR_AIINT) == 0)
-		{
-			Flipper::HW->pi->PIClearInt(PI_INTERRUPT_DSP);
-		}
+		// The guest acknowledged some of the internal causes. The Processor Interface carries one
+		// aggregate line for all three of them, so it has to be re-evaluated here - otherwise a
+		// cause that the guest clears is still held high by whichever other cause is still latched,
+		// and the CPU re-enters the handler forever.
+		DSPUpdateInt();
 
 		// DSP DMA always ready
 		CDCR &= ~CDCR_DSPDMA;
@@ -124,14 +125,11 @@ namespace DSP
 	{
 		Gekko::stats.aiInts++;
 		CDCR |= CDCR_AIINT;
-		if (CDCR & CDCR_AIINTMSK)
+		if ((CDCR & CDCR_AIINTMSK) && dsp_ai.log)
 		{
-			Flipper::HW->pi->PIAssertInt(PI_INTERRUPT_DSP);
-			if (dsp_ai.log)
-			{
-				Report(Channel::AI, "AIDINT\n");
-			}
+			Report(Channel::AI, "AIDINT\n");
 		}
+		DSPUpdateInt();
 	}
 
 	// how much time AI DMA need to playback "n" bytes in Gekko ticks
@@ -266,10 +264,7 @@ namespace DSP
 		}
 
 		CDCR |= CDCR_DSPINT;
-		if (CDCR & CDCR_DSPINTMSK)
-		{
-			Flipper::HW->pi->PIAssertInt(PI_INTERRUPT_DSP);
-		}
+		DSPUpdateInt();
 	}
 
 	bool DSPGetInterruptStatus()

--- a/src/dspai.h
+++ b/src/dspai.h
@@ -47,6 +47,13 @@ namespace DSP
 
 	// Used by DspCore
 
+	/// <summary>
+	/// Re-evaluate the aggregate Processor Interface line (PI_INTERRUPT_DSP) from the three internal
+	/// CDCR causes and their masks. Must be called whenever a cause or a mask changes - raising a
+	/// cause, or the guest acknowledging one by writing CDCR.
+	/// </summary>
+	void    DSPUpdateInt();
+
 	void    DSPAssertInt();
 	bool    DSPGetInterruptStatus();
 	bool    DSPGetResetModifier();

--- a/src/dsparam.cpp
+++ b/src/dsparam.cpp
@@ -294,17 +294,40 @@ namespace DSP
 
 	ARControl aram;
 
+// The three internal DSP causes (the DSP->CPU mailbox, the ARAM DMA completion and the AI DMA
+// completion) are latched in CDCR and reported to the CPU through ONE aggregate Processor
+// Interface line, PI_INTERRUPT_DSP. The line is therefore not "asserted by" any single cause:
+// it follows the OR of the ones that are currently latched *and* unmasked, and every place that
+// changes a cause has to re-evaluate it.
+//
+// Evaluating it only where a cause is raised left the line stuck: the guest acknowledges a cause
+// by writing the matching bit back to CDCR (write-1-to-clear), and while the line was computed
+// from "all three are clear" inside that one write path, clearing one cause while another was
+// still latched left the line high with nothing left to clear it. The CPU then re-entered the
+// external-interrupt handler on every rfi and never returned to the guest.
+void DSPUpdateInt()
+{
+	uint16_t pending = CDCR & (CDCR_DSPINT | CDCR_ARINT | CDCR_AIINT);
+	uint16_t unmasked = CDCR & (CDCR_DSPINTMSK | CDCR_ARINTMSK | CDCR_AIINTMSK);
+
+	if ((pending & unmasked) != 0)
+	{
+		Flipper::HW->pi->PIAssertInt(PI_INTERRUPT_DSP);
+	}
+	else
+	{
+		Flipper::HW->pi->PIClearInt(PI_INTERRUPT_DSP);
+	}
+}
 	static void ARINT()
 	{
 		CDCR |= CDCR_ARINT;
-		if (CDCR & CDCR_ARINTMSK)
+		if ((CDCR & CDCR_ARINTMSK) && aram.log)
 		{
-			if (aram.log)
-			{
-				Report(Channel::AR, "ARINT\n");
-			}
-			Flipper::HW->pi->PIAssertInt(PI_INTERRUPT_DSP);
+			Report(Channel::AR, "ARINT\n");
 		}
+		// The ARAM completion is one of the three causes behind the aggregate PI line.
+		DSPUpdateInt();
 	}
 
 	// Perform the whole ARAM transfer. The hardware streams the block through the ARAM controller

--- a/src/dsparam.cpp
+++ b/src/dsparam.cpp
@@ -307,10 +307,14 @@ namespace DSP
 // external-interrupt handler on every rfi and never returned to the guest.
 void DSPUpdateInt()
 {
-	uint16_t pending = CDCR & (CDCR_DSPINT | CDCR_ARINT | CDCR_AIINT);
-	uint16_t unmasked = CDCR & (CDCR_DSPINTMSK | CDCR_ARINTMSK | CDCR_AIINTMSK);
+	// Every cause has its own mask bit, and the two are not placed next to each other in CDCR, so
+	// the line is the OR of the three (cause && its own mask) pairs. ANDing the group of cause
+	// bits with the group of mask bits would always give zero.
+	bool dsp = (CDCR & CDCR_DSPINT) != 0 && (CDCR & CDCR_DSPINTMSK) != 0;
+	bool ar = (CDCR & CDCR_ARINT) != 0 && (CDCR & CDCR_ARINTMSK) != 0;
+	bool ai = (CDCR & CDCR_AIINT) != 0 && (CDCR & CDCR_AIINTMSK) != 0;
 
-	if ((pending & unmasked) != 0)
+	if (dsp || ar || ai)
 	{
 		Flipper::HW->pi->PIAssertInt(PI_INTERRUPT_DSP);
 	}

--- a/src/flipper.cpp
+++ b/src/flipper.cpp
@@ -30,7 +30,7 @@ namespace Flipper
 		DSP::AROpen(this);       // aux. memory (ARAM)  TODO: find better place
 		exi = new ExternalInterface(this, config);
 		di = new DiskInterface(this, config);
-		si = new SerialInterface(this, config, vi);
+		si = new SerialInterface(this, config);
 
 		DSP->core->HardReset();
 
@@ -139,7 +139,7 @@ namespace Flipper
 
 		// update joypads and video
 		vi->VIUpdate();
-		si->SIPoll();
+		si->SIPoll(vi->GetCurrentLine());
 
 		// ... and let the CP thread know when it has a batch of FIFO entries to consume, and the
 		// AI thread when the next audio DMA block is due.

--- a/src/flipper.cpp
+++ b/src/flipper.cpp
@@ -30,7 +30,7 @@ namespace Flipper
 		DSP::AROpen(this);       // aux. memory (ARAM)  TODO: find better place
 		exi = new ExternalInterface(this, config);
 		di = new DiskInterface(this, config);
-		si = new SerialInterface(this, config);
+		si = new SerialInterface(this, config, vi);
 
 		DSP->core->HardReset();
 

--- a/src/flipper.h
+++ b/src/flipper.h
@@ -113,11 +113,14 @@ namespace Flipper
 
 		AudioInterface* ai = nullptr;
 		DiskInterface* di = nullptr;
-		SerialInterface* si = nullptr;
 
 		size_t memsize;			//!< The size of the main memory (Splash) from the configuration. Used to call GetMemorySize.
 
 	public:
+		//! The serial / controller interface. Public like `gfx` and `vi`: the unit tests drive its
+		//! poll schedule and its registers directly.
+		SerialInterface* si = nullptr;
+
 		Flipper(HWConfig* config);
 		~Flipper();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -187,7 +187,22 @@ static void ParseCmdLineArgs(const std::vector<std::string>& args)
 	{
 		const std::string& arg = args[i];
 
-		if (arg == "--ipl")
+		if (arg == "--help" || arg == "-h" || arg == "-?" || arg == "/?")
+		{
+			cmdline.help = true;
+		}
+		else if (arg == "--image")
+		{
+			if (i + 1 < args.size())
+			{
+				cmdline.image = Util::StringToWstring(args[++i]);
+			}
+			else
+			{
+				Report(Channel::Norm, "--image needs a file name\n");
+			}
+		}
+		else if (arg == "--ipl")
 		{
 			cmdline.ipl = true;
 		}
@@ -220,11 +235,53 @@ static void ParseCmdLineArgs(const std::vector<std::string>& args)
 				Report(Channel::Norm, "--bench needs an image file (and an optional duration in seconds)\n");
 			}
 		}
+		else if (arg.size() > 1 && arg[0] != '-')
+		{
+			// A bare argument is the file to run, which is the way every command line tool takes
+			// it: `pureikyubu "D:\Isos\game.gcm"`.
+			cmdline.image = Util::StringToWstring(arg);
+		}
 		else
 		{
 			Report(Channel::Norm, "Unknown command line argument: %s\n", arg.c_str());
 		}
 	}
+}
+
+// The `--help` text. It is printed to the console (when the application has one) and to the report
+// log, so `EMU_LOG=<file> pureikyubu --help` also shows it.
+void EMUPrintUsage()
+{
+	static const char* usage =
+		"pureikyubu, Nintendo GameCube emulator\n"
+		"\n"
+		"Usage: pureikyubu [options] [file]\n"
+		"\n"
+		"  <file>                Load and run a file right away, without the game selector. The\n"
+		"                        recognized formats are disk images (.iso, .gcm) and executables\n"
+		"                        (.dol, .elf). Quote the name when it contains spaces.\n"
+		"  --image <file>        Same as the bare file argument.\n"
+		"  --ipl                 Start the Bootrom (IPL) instead of waiting for the selector.\n"
+		"  --no-disc             Start with the DVD lid open, so the IPL takes its \"no disk\" path.\n"
+		"  --bench <file> [sec]  Run the file unattended for the given number of seconds (30 by\n"
+		"                        default) and print the throughput and the performance counters.\n"
+		"  -h, --help            Print this text and exit.\n"
+		"\n"
+		"With no option the game selector is shown, and a file is started from there (Enter or a\n"
+		"double click). File -> Reopen (F3) runs the last file again.\n";
+
+#ifdef _WINDOWS
+	// A windowed application has no console of its own; borrow the one it was started from, so
+	// that the text is visible when it is run from a command prompt.
+	if (AttachConsole(ATTACH_PARENT_PROCESS))
+	{
+		freopen("CONOUT$", "w", stdout);
+	}
+#endif
+
+	printf("%s", usage);
+
+	Report(Channel::Norm, "%s", usage);
 }
 
 void EMUParseCmdLine(const char* commandLine)

--- a/src/main.h
+++ b/src/main.h
@@ -32,8 +32,14 @@ extern  Emulator emu;
 
 struct CmdLineOptions
 {
+	bool    help = false;       // `--help`: print the accepted options and exit
 	bool    ipl = false;        // `--ipl`: start the Bootrom (IPL) immediately, without going through the UI
 	bool    noDisc = false;     // `--no-disc`: start with the DVD lid open (no disk), so that the IPL takes its "no disk" path
+
+	// `--image <file>` (or a bare file name): load and run that file right away instead of waiting
+	// for the game selector. The file is a disk image (`.iso`, `.gcm`) or an executable (`.dol`,
+	// `.elf`).
+	std::wstring image;
 
 	// `--bench <file> [seconds]`: load the file, run it for the given number of seconds (30 by
 	// default) without a user interface and print the measured emulation throughput and the
@@ -45,6 +51,11 @@ struct CmdLineOptions
 };
 
 extern  CmdLineOptions cmdline;
+
+/// <summary>
+/// Print the accepted command line options (the `--help` text) to the console, if there is one.
+/// </summary>
+void EMUPrintUsage();
 
 /// <summary>
 /// Parse the raw command line of the application (`lpCmdLine` on Windows, `argv` joined by spaces elsewhere).

--- a/src/pe.cpp
+++ b/src/pe.cpp
@@ -244,15 +244,10 @@ namespace GFX
 			// draw done
 			case PE_FINISH_ID:
 			{
-				// GXDrawDone marks the end of the frame and is how most titles present: the copied
-				// picture is complete by now.
+				// GXDrawDone marks the end of the frame: the copied picture is complete.
 				gfx->GPFrameDone();
 
 				pe_done_num++;
-				if (pe_done_num == 1)
-				{
-					Flipper::HW->vi->VIDisableXfb();	// disable VI output
-				}
 				PE_DONE_INT();
 			}
 			break;
@@ -269,7 +264,6 @@ namespace GFX
 				{
 					gfx->GPFrameDone();
 
-					Flipper::HW->vi->VIDisableXfb();	// disable VI output
 					PE_TOKEN_INT();
 				}
 			}

--- a/src/si.cpp
+++ b/src/si.cpp
@@ -406,14 +406,58 @@ namespace Flipper
 	// ---------------------------------------------------------------------------
 	// polling
 
+	// The poll schedule (serial-interface.md 5.1):
+	//
+	//   SIPOLL[X] is the interval between two polls in horizontal video lines,
+	//   SIPOLL[Y] is how many polls a frame may issue,
+	//   polling is anchored to the vertical blank, and `Y == 0` disables it.
+	//
+	// The schedule is therefore counted in *video lines*, not in CPU ticks: the interval used to
+	// be a fixed `SI_POLLING_INTERVAL` of Gekko ticks, which at the derived timer clock is about
+	// 1.6 ms - a poll every ~100 us per channel, i.e. roughly ten times the frame rate the
+	// hardware runs at. On a channel whose enable bit is set and whose response the guest has not
+	// read yet, every one of those polls re-raises RDSTINT, so the guest is buried in serial
+	// interrupts: Animal Crossing (GAFE01) spends its whole run in the SI handler instead of
+	// booting, which is the black screen.
+	//
+	// The video line counter is the natural tick for this: it is driven by the VI and wraps once
+	// per frame, so a new frame is exactly "the line count went backwards".
 	void SerialInterface::SIPoll()
 	{
-		int64_t ticks = Core->GetTicks();
-		if (ticks < si.pollingTime)
+		uint32_t line = vi->GetCurrentLine();
+
+		// A new frame: restart the poll budget and allow the first poll of the frame.
+		if (line < si.lastPollLine)
+		{
+			si.pollsThisFrame = 0;
+			si.pollLineDue = true;
+		}
+		si.lastPollLine = line;
+
+		uint32_t interval = SI_POLL_X(SI_POLL_REG);
+		uint32_t perFrame = SI_POLL_Y(SI_POLL_REG);
+
+		// `Y == 0` means the poller is off, and a zero interval would poll every line.
+		if (perFrame == 0 || interval == 0)
 		{
 			return;
 		}
-		si.pollingTime = ticks + SI_POLLING_INTERVAL;
+
+		if (si.pollsThisFrame >= perFrame)
+		{
+			return;
+		}
+
+		// The first poll of a frame happens at the blank; after that one poll every `interval`
+		// lines. A frame shorter than `interval` therefore still gets its first poll.
+		if (!si.pollLineDue && (line - si.pollLineBase) < interval)
+		{
+			return;
+		}
+
+		si.pollLineDue = false;
+		si.pollLineBase = line;
+		si.pollsThisFrame++;
 
 		if (SI_POLL_REG & SI_POLL_EN0)
 		{
@@ -489,8 +533,9 @@ namespace Flipper
 	{
 	}
 
-	SerialInterface::SerialInterface(Flipper* flipper, HWConfig* config)
+	SerialInterface::SerialInterface(Flipper* flipper, HWConfig* config, VideoInterface* video)
 	{
+		vi = video;
 		Debug::Report(Debug::Channel::SI, "Serial interface driver\n");
 
 		// clear all registers
@@ -498,7 +543,10 @@ namespace Flipper
 
 		si.log = config->si_log;
 
-		si.pollingTime = Core->GetTicks() + SI_POLLING_INTERVAL;
+		si.lastPollLine = 0;
+		si.pollLineBase = 0;
+		si.pollsThisFrame = 0;
+		si.pollLineDue = true;
 
 		// these values are actually written when IPL boots
 		// meaning is unknown (some pad command) and no need to be known

--- a/src/si.cpp
+++ b/src/si.cpp
@@ -98,20 +98,22 @@ namespace Flipper
 
 	void SerialInterface::si_wr_out_hi(int chan, uint32_t data)
 	{
-		si.shdw[chan] &= 0x0000ffff;
-		si.shdw[chan] |= data << 16;
+		si.out[chan] &= 0x0000ffff;
+		si.out[chan] |= data << 16;
 	}
 
 	void SerialInterface::si_wr_out_lo(int chan, uint32_t mask, uint32_t data)
 	{
-		si.shdw[chan] &= 0xffff0000;
-		si.shdw[chan] |= (uint16_t)data;
+		si.out[chan] &= 0xffff0000;
+		si.out[chan] |= (uint16_t)data;
+
+		// The visible register no longer matches the shadow one until SISR[WR] copies it.
 		SI_SR_REG |= mask;
 
 		// control motor
-		if (si.shdw[chan] == 0x00400000) PADSetRumble(chan, PAD_MOTOR_STOP);
-		else if (si.shdw[chan] == 0x00400001) PADSetRumble(chan, PAD_MOTOR_RUMBLE);
-		else if (si.shdw[chan] == 0x00400002) PADSetRumble(chan, PAD_MOTOR_STOP_HARD);
+		if (si.out[chan] == 0x00400000) PADSetRumble(chan, PAD_MOTOR_STOP);
+		else if (si.out[chan] == 0x00400001) PADSetRumble(chan, PAD_MOTOR_RUMBLE);
+		else if (si.out[chan] == 0x00400002) PADSetRumble(chan, PAD_MOTOR_STOP_HARD);
 	}
 
 	/* ******* CHAN 0 ******* */
@@ -281,6 +283,7 @@ namespace Flipper
 	{
 		SerialInterface* si = (SerialInterface*)ctx;
 		data <<= 16;
+		uint32_t outlen = SI_COMCSR_OUTLEN(data);
 
 		// clear incoming interrupt
 		if (data & SI_COMCSR_TCINT)
@@ -297,7 +300,8 @@ namespace Flipper
 		if (data & SI_COMCSR_TCINTMSK) si->SI_COMCSR_REG |= SI_COMCSR_TCINTMSK;
 		else si->SI_COMCSR_REG &= ~SI_COMCSR_TCINTMSK;
 
-		int outlen = SI_COMCSR_OUTLEN(data);
+		// OUTLNGTH is the only other writable field of the high halfword; COMERR and RDSTINT
+		// are read-only and the reserved bits read as 0 (11.5).
 		si->SI_COMCSR_REG &= ~SI_COMCSR_OUTLEN_MASK;
 		si->SI_COMCSR_REG |= (outlen << 16);
 	}
@@ -305,20 +309,24 @@ namespace Flipper
 	void SerialInterface::write_commcsr_lo(uint32_t addr, uint32_t data, void* ctx)
 	{
 		SerialInterface* si = (SerialInterface*)ctx;
+
+		// CHANNEL and INLNGTH are ordinary writable fields of the low halfword (11.5); TSTART is
+		// a pending bit, so it is never stored (it is set below for the duration of the transfer).
+		si->SI_COMCSR_REG &= ~(SI_COMCSR_CHAN_MASK | SI_COMCSR_INLEN_MASK | SI_COMCSR_TSTART);
+		si->SI_COMCSR_REG |= (data & (SI_COMCSR_CHAN_MASK | SI_COMCSR_INLEN_MASK));
+
 		// commands are executed immediately
 		if (data & SI_COMCSR_TSTART)
 		{
-			// select channel
-			int chan = SI_COMCSR_CHAN(data);
-			si->SI_COMCSR_REG &= ~SI_COMCSR_CHAN_MASK;
-			si->SI_COMCSR_REG |= (chan << 1);
+			// the transfer is pending while it runs, and reads back complete once it has finished
+			si->SI_COMCSR_REG |= SI_COMCSR_TSTART;
+
+			int chan = SI_COMCSR_CHAN(si->SI_COMCSR_REG);
 
 			// setup in/out length
-			int inlen = SI_COMCSR_INLEN(data);
-			si->SI_COMCSR_REG &= ~SI_COMCSR_INLEN_MASK;
-			si->SI_COMCSR_REG |= (inlen << 8);
+			int inlen = SI_COMCSR_INLEN(si->SI_COMCSR_REG);
 			if (inlen == 0) inlen = 128;
-			int outlen = SI_COMCSR_OUTLEN(data);
+			int outlen = SI_COMCSR_OUTLEN(si->SI_COMCSR_REG);
 			if (outlen == 0) outlen = 128;
 
 			// make actual transfer
@@ -358,16 +366,16 @@ namespace Flipper
 		SerialInterface* si = (SerialInterface*)ctx;
 		data <<= 16;
 
-		// copy shadow command registers
+		// copy the visible command registers into the shadow ones
 		if (data & SI_SR_WR)
 		{
-			si->si.out[0] = si->si.shdw[0];
+			si->si.shdw[0] = si->si.out[0];
 			si->SI_SR_REG &= ~SI_SR_WRST0;
-			si->si.out[1] = si->si.shdw[1];
+			si->si.shdw[1] = si->si.out[1];
 			si->SI_SR_REG &= ~SI_SR_WRST1;
-			si->si.out[2] = si->si.shdw[2];
+			si->si.shdw[2] = si->si.out[2];
 			si->SI_SR_REG &= ~SI_SR_WRST2;
-			si->si.out[3] = si->si.shdw[3];
+			si->si.shdw[3] = si->si.out[3];
 			si->SI_SR_REG &= ~SI_SR_WRST3;
 		}
 	}
@@ -422,10 +430,8 @@ namespace Flipper
 	//
 	// The video line counter is the natural tick for this: it is driven by the VI and wraps once
 	// per frame, so a new frame is exactly "the line count went backwards".
-	void SerialInterface::SIPoll()
+	void SerialInterface::SIPoll(uint32_t line)
 	{
-		uint32_t line = vi->GetCurrentLine();
-
 		// A new frame: restart the poll budget and allow the first poll of the frame.
 		if (line < si.lastPollLine)
 		{
@@ -533,9 +539,8 @@ namespace Flipper
 	{
 	}
 
-	SerialInterface::SerialInterface(Flipper* flipper, HWConfig* config, VideoInterface* video)
+	SerialInterface::SerialInterface(Flipper* flipper, HWConfig* config)
 	{
-		vi = video;
 		Debug::Report(Debug::Channel::SI, "Serial interface driver\n");
 
 		// clear all registers
@@ -555,11 +560,18 @@ namespace Flipper
 		si.out[2] =
 		si.out[3] = 0x00400300; // continue polling ?
 
+		// The boot ROM immediately copies the visible buffers into the shadow ones, so the
+		// transfer engine starts from the same command bytes without a pending write status.
+		for (int i = 0; i < 4; i++)
+		{
+			si.shdw[i] = si.out[i];
+		}
+
 		// enable polling (for homebrewn), IPL enabling it
 		SI_POLL_REG |= (SI_POLL_EN0 | SI_POLL_EN1 | SI_POLL_EN2 | SI_POLL_EN3);
 
 		// update joypad data
-		SIPoll();
+		SIPoll(0);
 
 		// set rumble flags
 		for (int i = 0; i < 4; i++) {

--- a/src/si.h
+++ b/src/si.h
@@ -87,7 +87,10 @@ namespace Flipper
 	// SI state (registers and other data)
 	struct SIState
 	{
-		volatile uint32_t            out[4], shdw[4];// out + shadows
+		// SICnOUTBUF is double buffered (serial-interface.md 4.1): `out` is the CPU-visible
+		// register, `shdw` the hidden shadow the transfer engine shifts out. Setting SISR[WR]
+		// copies the visible register into the shadow one.
+		volatile uint32_t            out[4], shdw[4];// command latch + shadow buffers
 		volatile uint32_t            poll;           // poll control
 		volatile uint32_t            comcsr;         // CSR
 		volatile uint32_t            sr;             // status
@@ -108,7 +111,6 @@ namespace Flipper
 	class SerialInterface
 	{
 		SIState si{};		//!< SI state (registers and other data)
-		VideoInterface* vi = nullptr;	//!< the video interface, for the poll schedule
 
 		void SICommand(int chan, int outlen, int inlen, uint8_t* ptr);
 		void SIClearInterrupt();
@@ -177,9 +179,15 @@ namespace Flipper
 		static void read_exilk_lo(uint32_t addr, uint32_t* reg, void* ctx);
 
 	public:
-		SerialInterface(Flipper* flipper, HWConfig* config, VideoInterface* video);
+		SerialInterface(Flipper* flipper, HWConfig* config);
 		~SerialInterface();
 
-		void SIPoll();
+		/// <summary>
+		/// One step of the automatic poll schedule (serial-interface.md 5.1). `line` is the current
+		/// video line (VI_DISPLAY_POS.VCT), which is what the schedule is counted in: SIPOLL[X] is
+		/// the interval between two polls in lines, SIPOLL[Y] is how many polls a frame may issue,
+		/// and a wrap of the counter is a new frame.
+		/// </summary>
+		void SIPoll(uint32_t line);
 	};
 }

--- a/src/si.h
+++ b/src/si.h
@@ -1,8 +1,6 @@
 
 #pragma once
 
-#define SI_POLLING_INTERVAL     0x10000      // In Gekko ticks
-
 // SI registers (all registers are 32-bit from the software side)
 
 #define SI_CHAN0_OUTBUF     0x00      // Channel 0 Output Buffer
@@ -100,12 +98,17 @@ namespace Flipper
 		bool                rumble[4];      // rumble support flags for every controller
 		// filled when SI is inited, by checking PADSetRumble
 		bool                log;            // do debugger log output
-		int64_t             pollingTime;    // Saved Gekko TBR for polling
+		// The poll schedule (serial-interface.md 5.1) is counted in video lines, not CPU ticks.
+		uint32_t            lastPollLine;   // line counter value at the previous poll evaluation
+		uint32_t            pollLineBase;   // line at which the current interval started
+		uint32_t            pollsThisFrame; // polls issued since the last vertical blank
+		bool                pollLineDue;    // the first poll of the frame is still due
 	};
 
 	class SerialInterface
 	{
 		SIState si{};		//!< SI state (registers and other data)
+		VideoInterface* vi = nullptr;	//!< the video interface, for the poll schedule
 
 		void SICommand(int chan, int outlen, int inlen, uint8_t* ptr);
 		void SIClearInterrupt();
@@ -174,7 +177,7 @@ namespace Flipper
 		static void read_exilk_lo(uint32_t addr, uint32_t* reg, void* ctx);
 
 	public:
-		SerialInterface(Flipper* flipper, HWConfig* config);
+		SerialInterface(Flipper* flipper, HWConfig* config, VideoInterface* video);
 		~SerialInterface();
 
 		void SIPoll();

--- a/src/uisdl.cpp
+++ b/src/uisdl.cpp
@@ -1741,6 +1741,9 @@ static void ui_load_bootrom()
 	}
 }
 
+/* Defined with the other file loaders, below; the menu needs it first. */
+static void reopen_last_file();
+
 static void ui_main_menu()
 {
 	// Menu Bar
@@ -1752,7 +1755,9 @@ static void ui_main_menu()
 				file_reaction = FileReaction::OpenFile_LoadFile;
 				fileOpenDialog.Open();
 			}
-			ImGui::MenuItem("Reopen", NULL);
+			if (ImGui::MenuItem("Reopen", "F3")) {
+				reopen_last_file();
+			}
 			if (ImGui::MenuItem("Close", NULL)) {		// Unload file (STOP)
 				UI::Jdi->Stop();
 				Thread::Sleep(100);
@@ -1887,6 +1892,21 @@ static void run_selected_file()
 	}
 
 	load_file(usel.files[usel.selected]->name);
+}
+
+/* Run the image that was loaded last (File -> Reopen, F3), without going through the selector.
+   This is the quick way back into the same game, and it is also what an unattended run uses to
+   start an image while the selector is still scanning its directories. */
+static void reopen_last_file()
+{
+	const std::string last = UI::Jdi->GetConfigString(USER_LASTFILE, USER_UI);
+
+	if (last.empty())
+	{
+		return;
+	}
+
+	load_file(Util::StringToWstring(last));
 }
 
 /*
@@ -2334,11 +2354,26 @@ static int ui_main()
 		ui_active = false;
 	}
 
-	// The command line may ask to start the IPL right away (as if File -> Run Bootrom was clicked).
+	// The command line may ask to start the IPL right away (as if File -> Run Bootrom was clicked),
+	// or to run one specific file instead of waiting for the selector.
 
 	if (cmdline.ipl)
 	{
 		ui_load_bootrom();
+	}
+	else if (!cmdline.image.empty())
+	{
+		CreateRenderTarget();
+		UI::Jdi->LoadFile(Util::WstringToString(cmdline.image));
+		if (Debug::debugger != nullptr)
+		{
+			Debug::debugger->InvalidateAll();
+		}
+		OnMainWindowOpened(cmdline.image.c_str());
+		if (Debug::debugger == nullptr)
+		{
+			UI::Jdi->Run();
+		}
 	}
   
 	// The emulator has more than one SDL window: the video output is a separate window, which can
@@ -2378,6 +2413,14 @@ static int ui_main()
 				case SDL_CONTROLLERDEVICEREMOVED:
 				case SDL_CONTROLLERDEVICEREMAPPED: forMainWindow = !emu_running; break;
 				default: break;
+			}
+
+			// File -> Reopen (F3): reload the image that was loaded last. The menu item is the
+			// primary way in, this is the shortcut for it.
+			if (forMainWindow && !emu_running && !pad_capture_active &&
+				event.type == SDL_KEYDOWN && event.key.keysym.scancode == SDL_SCANCODE_F3)
+			{
+				reopen_last_file();
 			}
 
 			// The controller settings dialog captures the next key press or gamepad event as the
@@ -2606,6 +2649,13 @@ int WINAPI WinMain(
 	_In_ int nShowCmd )
 {
 	EMUParseCmdLine(lpCmdLine);
+
+	if (cmdline.help)
+	{
+		EMUPrintUsage();
+		return 0;
+	}
+
 	return ui_main();
 }
 
@@ -2614,6 +2664,13 @@ int WINAPI WinMain(
 int main(int argc, char** argv)
 {
 	EMUParseCmdLine(argc, argv);
+
+	if (cmdline.help)
+	{
+		EMUPrintUsage();
+		return 0;
+	}
+
 	return ui_main();
 }
 

--- a/src/vi.cpp
+++ b/src/vi.cpp
@@ -144,6 +144,11 @@ namespace Flipper
 			case VI_DISP_CR:
 				*reg = vi->vi.disp_cr;
 				break;
+			case VI_DTV:
+				// The encoder strap is not software programmable: the PAL/NTSC bit always
+				// reflects the console's video encoder fuse (video-interface.md 6.16).
+				*reg = vi->vi.videoEncoderFuse ? VI_DTV_PAL : 0;
+				break;
 			case VI_TFBL:
 				*reg = vi->vi.tfbl >> 16;
 				break;

--- a/src/vi.h
+++ b/src/vi.h
@@ -135,6 +135,13 @@ namespace Flipper
 		~VideoInterface();
 
 		void VIUpdate();
+
+		/// <summary>
+		/// The current video line number of the raster (VI_DISPLAY_POS.VCT). The serial interface
+		/// derives its poll schedule from it: SIPOLL[X] is an interval in video lines and a new
+		/// frame is a wrap of the counter (serial-interface.md 5.1).
+		/// </summary>
+		uint32_t GetCurrentLine() const { return vi.pos.vcount; }
 		void VIStats();
 
 		void VISetEncoderFuse(int value);

--- a/src/vi.h
+++ b/src/vi.h
@@ -62,6 +62,11 @@
 #define VI_NTSC_LIKE        0
 #define VI_PAL_LIKE         1
 
+// VI_DTV_REG (VI_DTV_STATUS) pins. The register reports the state of the hardware
+// pins that strap the video encoder; software (the SDK's VIGetTvFormat) reads the
+// PAL/NTSC bit to decide which of its render modes it is allowed to configure.
+#define VI_DTV_PAL          0x0002      // 1: PAL encoder, 0: NTSC encoder
+
 // max vertical line count
 #define VI_NTSC_INTER       525         // 60 Hz
 #define VI_NTSC_NON_INTER   263         // 30 Hz

--- a/src/videosdl.cpp
+++ b/src/videosdl.cpp
@@ -48,6 +48,16 @@ void VideoOutRefresh()
 	if (!render_target)
 		return;
 
+	// The window also carries the OpenGL context the GFX backend draws the EFB into and presents
+	// with SDL_GL_SwapWindow. Pushing a software surface into the same window fights that swap -
+	// the two presenters alternate, which shows up as flicker between the VI picture and the GL one.
+	// While the GL backend owns the window, it is the presenter; the VI still decodes the XFB and
+	// counts frames, it just does not write the window.
+	if (Flipper::HW != nullptr && Flipper::HW->gfx != nullptr && Flipper::HW->gfx->BackendStarted())
+	{
+		return;
+	}
+
 	Uint32* const pixels = (Uint32*)surface->pixels;
 
 	for (int y = 0; y < xfb_height; y++)

--- a/testing/dsp_control_test.cpp
+++ b/testing/dsp_control_test.cpp
@@ -678,6 +678,105 @@ namespace DspUnitTest
 			}
 		}
 
+		// ---------------------------------------------------------------
+		// The aggregate DSP interrupt line into the Processor Interface
+		//
+		// The DSP, ARAM-DMA and AI-DMA completions are three causes with three separate mask bits,
+		// and they share ONE PI line (dsp.md section 7, processor-interface.md section 4.1). The
+		// cause and mask bits are not adjacent in CDCR, so the line is the OR of the three
+		// (cause && its own mask) pairs - it is not the AND of the group of cause bits with the
+		// group of mask bits, which is always zero and leaves the guest waiting forever for a
+		// completion interrupt that never arrives.
+		// ---------------------------------------------------------------
+
+		/// <summary>
+		/// Put the interface into a known state: no cause latched, no mask, no line. The DSP unit
+		/// tests do not open the AI/DSP register block, so CDCR is driven directly - it is the same
+		/// state the guest programs through write_cdcr.
+		/// </summary>
+		void ClearDspInterrupts()
+		{
+			DSP::dsp_ai.cdcr = 0;
+			Flipper::TestPIAssertedInts = 0;
+		}
+
+		/// <summary>True while the aggregate DSP line is asserted on the Processor Interface.</summary>
+		bool DspLine() { return (Flipper::TestPIAssertedInts & PI_INTERRUPT_DSP) != 0; }
+
+		TEST_METHOD(DspInt_EachCauseRaisesTheLineOnlyThroughItsOwnMask)
+		{
+			// A cause with no mask behind it holds no line, whatever the other masks say.
+			ClearDspInterrupts();
+			DSP::dsp_ai.cdcr = CDCR_DSPINTMSK | CDCR_ARINTMSK | CDCR_AIINTMSK;
+			DSP::DSPUpdateInt();
+			Assert::IsFalse(DspLine(), L"a masked interface with no pending cause holds no line");
+
+			// Every cause on its own, through its own mask, must raise the line. The three pairs are
+			// not adjacent in CDCR, so a grouped AND would find none of them.
+			for (uint16_t cause : { (uint16_t)CDCR_DSPINT, (uint16_t)CDCR_ARINT, (uint16_t)CDCR_AIINT })
+			{
+				uint16_t mask = (cause == CDCR_DSPINT) ? CDCR_DSPINTMSK
+					: (cause == CDCR_ARINT) ? CDCR_ARINTMSK : CDCR_AIINTMSK;
+
+				ClearDspInterrupts();
+				DSP::dsp_ai.cdcr = CDCR_DSPINTMSK | CDCR_ARINTMSK | CDCR_AIINTMSK | cause;
+				DSP::DSPUpdateInt();
+				Assert::IsTrue(DspLine(), L"an unmasked completion must reach the PI");
+
+				// ... and stay silent once that cause's own mask is clear.
+				DSP::dsp_ai.cdcr &= ~mask;
+				DSP::DSPUpdateInt();
+				Assert::IsFalse(DspLine(), L"clearing the cause's own mask must drop the line");
+			}
+		}
+
+		TEST_METHOD(DspInt_AramCompletionReachesTheProcessorInterface)
+		{
+			ClearDspInterrupts();
+			DSP::dsp_ai.cdcr = CDCR_ARINTMSK;
+
+			StartAramCopy(0x00001000, 0x00001000, 0x20, false);
+
+			Assert::IsTrue((DSP::dsp_ai.cdcr & CDCR_ARINT) != 0, L"the ARAM completion latches its cause");
+			Assert::IsTrue(DspLine(), L"the ARAM completion must reach the Processor Interface");
+		}
+
+		TEST_METHOD(DspInt_MaskedAramCompletionLatchesButHoldsNoLine)
+		{
+			ClearDspInterrupts();
+
+			StartAramCopy(0x00001000, 0x00001000, 0x20, false);
+
+			Assert::IsTrue((DSP::dsp_ai.cdcr & CDCR_ARINT) != 0, L"the completion is still latched in CDCR");
+			Assert::IsFalse(DspLine(), L"a masked completion must not assert the PI line");
+		}
+
+		TEST_METHOD(DspInt_AcknowledgingTheCauseDropsTheLine)
+		{
+			ClearDspInterrupts();
+			DSP::dsp_ai.cdcr = CDCR_ARINTMSK;
+
+			StartAramCopy(0x00001000, 0x00001000, 0x20, false);
+			Assert::IsTrue(DspLine(), L"the line is up");
+
+			// The handler acknowledges by clearing the cause (write-1-to-clear on CDCR).
+			DSP::dsp_ai.cdcr &= ~CDCR_ARINT;
+			DSP::DSPUpdateInt();
+
+			Assert::IsFalse(DspLine(), L"the line must drop once its cause is acknowledged");
+		}
+
+		TEST_METHOD(DspInt_MailboxInterruptReachesTheProcessorInterface)
+		{
+			ClearDspInterrupts();
+			DSP::dsp_ai.cdcr = CDCR_DSPINTMSK;
+
+			DSP::DSPAssertInt();
+
+			Assert::IsTrue((DSP::dsp_ai.cdcr & CDCR_DSPINT) != 0, L"the DSP interrupt latches its cause");
+			Assert::IsTrue(DspLine(), L"and reaches the PI");
+		}
+
 		TEST_METHOD(Mvsi_SignExtendsShortImmediate)
 		{
 			m.Run({ Enc::Mvsi(R8A_A0, (int8_t)0x80) }, 1);

--- a/testing/dsp_test_support.cpp
+++ b/testing/dsp_test_support.cpp
@@ -419,7 +419,9 @@ namespace DSP
 
 	void DSPAssertInt()
 	{
+		// Mirrors dspai.cpp: latch the cause and re-evaluate the aggregate PI line.
 		dsp_ai.cdcr |= CDCR_DSPINT;
+		DSPUpdateInt();
 	}
 
 	bool DSPGetInterruptStatus()

--- a/testing/gfx_cp_spec_test.cpp
+++ b/testing/gfx_cp_spec_test.cpp
@@ -1,0 +1,790 @@
+// Command Processor (CP): the tests written straight from the specifications.
+//
+// This file is the audit of `src/cp.cpp` against the CP documentation
+// (`specs/architecture/command-processor.md`, `specs/architecture/gfx.md`) and against the
+// hardware reference design of the block. The existing `gfx_cp_test.cpp` and
+// `gfx_cp_array_test.cpp` already cover that the command stream reaches the pipeline; this file
+// covers the CP's own contract, i.e. the things the documentation pins down exactly and the
+// emulator is therefore not free to invent:
+//
+//   * the CPU-visible register window (`CP_FIFO_*`, `CP_STATUS`, `CP_ENABLE`, `CP_CLR`) and the
+//     meaning of each bit, including *where* the read pointer stops and how the CPU resumes it;
+//   * the FIFO ring: `read == write` is empty, the pointers move in 32-byte units, a wrap goes
+//     back to `base`, and the under/overflow flags follow the water marks;
+//   * the attribute and colour byte counts of the VAT formats, which the reference design fixes
+//     (a scalar component is 1/2/4 bytes, a colour is 2/3/4 bytes; an indexed attribute is 1 or 2
+//     bytes whatever its value format is);
+//   * the vertex attribute order, which the reference parser fixes as
+//     matrix indices -> position(x,y,z) -> normal -> colour0 -> colour1 -> tex0..tex7;
+//   * `gx_vtxsize`, which must agree with the table above - it is what `EnoughToExecute` uses to
+//     know when a whole vertex is in the FIFO, so a wrong size desynchronises the stream.
+//
+// The numbers in the reference tables below are the ones the CP documentation gives; when a test
+// builds a display list it uses them, not the emulator's own constants, so that the test fails
+// when the emulator drifts.
+
+#include "pch.h"
+#include "gfx_test_common.h"
+
+using namespace GfxUnitTest;
+
+namespace pureikyubutest
+{
+	TEST_CLASS(GfxCpSpecTest)
+	{
+		//! Where the graphics FIFO lives in the emulated main memory.
+		static const uint32_t FifoBase = 0x00020000;
+		static const uint32_t FifoSize = 0x00001000;
+		static const uint32_t FifoTop = FifoBase + FifoSize;
+
+		// =========================================================================================
+		// The reference tables (command-processor.md 4-5 and the reference design)
+		// =========================================================================================
+
+		//! A scalar/vector component format (`CompSize`, VAT bits 3:1 for position).
+		enum ScalarFormat
+		{
+			FmtU8 = 0, FmtS8 = 1, FmtU16 = 2, FmtS16 = 3, FmtF32 = 4,
+		};
+
+		//! A colour format (`CompSize` for a colour attribute).
+		enum ColorFormat
+		{
+			Clr565 = 0, Clr888 = 1, Clr888x = 2, Clr4444 = 3, Clr6666 = 4, Clr8888 = 5,
+		};
+
+		//! The byte count of one scalar component. A ubyte/byte is one byte, a ushort/short is two
+		//! and a float is four; 5..7 are reserved and are not used by the tests.
+		static int ScalarComponentBytes(int fmt)
+		{
+			switch (fmt)
+			{
+				case FmtU8:
+				case FmtS8:		return 1;
+				case FmtU16:
+				case FmtS16:	return 2;
+				case FmtF32:	return 4;
+			}
+			return -1;
+		}
+
+		//! The byte count of one colour. The reference fixes these: 565 and 4444 are two bytes,
+		//! 888 and 6666 are three, 888x and 8888 are four.
+		static int ColorBytes(int fmt)
+		{
+			switch (fmt)
+			{
+				case Clr565:
+				case Clr4444:	return 2;
+				case Clr888:
+				case Clr6666:	return 3;
+				case Clr888x:
+				case Clr8888:	return 4;
+			}
+			return -1;
+		}
+
+		//! The component count a VAT packs into one bit.
+		static int PositionComponents(int posCnt) { return posCnt ? 3 : 2; }	// 0 = (x,y), 1 = (x,y,z)
+		static int NormalComponents(int nrmCnt) { return nrmCnt ? 9 : 3; }		// 0 = 3, 1 = 9 (NBT)
+		static int TexCoordComponents(int texCnt) { return texCnt ? 2 : 1; }	// 0 = (s), 1 = (s,t)
+		static int ColorComponents(int colCnt) { return colCnt ? 4 : 3; }		// 0 = RGB, 1 = RGBA
+
+		//! The VCD source encoding (command-processor.md 5.2).
+		enum VcdSource
+		{
+			VcdNone = 0, VcdDirect = 1, VcdIndex8 = 2, VcdIndex16 = 3,
+		};
+
+		//! The attribute numbers of the arrays (command-processor.md 5.4): 0 = position, and the
+		//! colours and texcoords follow the attribute order, *not* the VertexAttr order.
+		enum ArrayIndex
+		{
+			ArrayPos = 0, ArrayNrm = 1, ArrayCol0 = 2, ArrayCol1 = 3, ArrayTex0 = 4,
+		};
+
+		// =========================================================================================
+		// Display list builder and FIFO plumbing
+		// =========================================================================================
+
+		class DisplayList
+		{
+			std::vector<uint8_t> bytes;
+
+		public:
+			void U8(uint8_t value) { bytes.push_back(value); }
+			void U16(uint16_t value) { U8((uint8_t)(value >> 8)); U8((uint8_t)value); }
+			void U32(uint32_t value) { U8((uint8_t)(value >> 24)); U8((uint8_t)(value >> 16)); U8((uint8_t)(value >> 8)); U8((uint8_t)value); }
+
+			//! CP_LoadRegs (0x08): the XF/CP register address then a 32-bit payload.
+			void CpReg(uint8_t index, uint32_t value)
+			{
+				U8((uint8_t)(Flipper::CP_CMD_LOAD_CPREG | 0));
+				U8(index);
+				U32(value);
+			}
+
+			//! CP_LoadBypass (0x60): the register index in the top byte, a 24-bit payload below.
+			void BpReg(uint8_t index, uint32_t value)
+			{
+				U8((uint8_t)(Flipper::CP_CMD_LOAD_BPREG | 0));
+				U32(((uint32_t)index << 24) | (value & 0xffffff));
+			}
+
+			//! A draw command: the opcode and the 16-bit vertex count that follows it.
+			void Draw(uint8_t opcode, uint16_t vertexCount)
+			{
+				U8(opcode);
+				U16(vertexCount);
+			}
+
+			//! CP_NOP pads the stream; the FIFO hands whole 32-byte bursts to the CP.
+			void Align()
+			{
+				while ((bytes.size() % 32) != 0)
+				{
+					U8((uint8_t)(Flipper::CP_CMD_NOP | 0));
+				}
+			}
+
+			void Raw(const uint8_t* data, size_t size) { bytes.insert(bytes.end(), data, data + size); }
+			void Raw(const std::vector<uint8_t>& data) { bytes.insert(bytes.end(), data.begin(), data.end()); }
+
+			const std::vector<uint8_t>& Bytes() const { return bytes; }
+			size_t Size() const { return bytes.size(); }
+		};
+
+		//! How many whole 32-byte bursts a list occupies - the unit the CP walks the FIFO in.
+		static int Bursts(const DisplayList& list)
+		{
+			return (int)((list.Size() + 31) / 32);
+		}
+
+		//! A clean machine: the pipeline reset, the FIFO reads stopped (so that a stream left
+		//! behind by the previous test cannot be walked while this one runs) and the log cleared.
+		static GfxTestMachine& M()
+		{
+			GfxTestMachine& m = Machine();
+			m.Reset();
+			// Stop the stream and drop whatever the previous test left in the CP-side command
+			// buffer, so that this test's bytes are the first thing the CP decodes.
+			PIRegWrite(PI_REGSPACE_CP | CP_ENABLE, 0);
+			m.flipper->cp->ResetFifoProcessor();
+			PIClearAssertedInterrupts();
+			ClearTestLog();
+			return m;
+		}
+
+		//! Install the FIFO windows. `write` and `read` are byte addresses; `top` defaults to the
+		//! end of the ring. Nothing is enabled here - the tests decide that, because the reset
+		//! state of CP_ENABLE matters to the FIFO behaviour.
+		static void SetFifoRegs(GfxTestMachine& m, uint32_t base, uint32_t top, uint32_t write, uint32_t read)
+		{
+			PIRegWrite(PI_REGSPACE_CP | CP_FIFO_BASEL, base & 0xffe0);
+			PIRegWrite(PI_REGSPACE_CP | CP_FIFO_BASEH, base >> 16);
+			PIRegWrite(PI_REGSPACE_CP | CP_FIFO_TOPL, top & 0xffe0);
+			PIRegWrite(PI_REGSPACE_CP | CP_FIFO_TOPH, top >> 16);
+			PIRegWrite(PI_REGSPACE_CP | CP_FIFO_WPTRL, write & 0xffe0);
+			PIRegWrite(PI_REGSPACE_CP | CP_FIFO_WPTRH, write >> 16);
+			PIRegWrite(PI_REGSPACE_CP | CP_FIFO_RPTRL, read & 0xffe0);
+			PIRegWrite(PI_REGSPACE_CP | CP_FIFO_RPTRH, read >> 16);
+		}
+
+		//! Put a display list in the emulated main memory and point the FIFO at it.
+		static int SetupFifo(GfxTestMachine& m, const std::vector<uint8_t>& list, uint32_t base = FifoBase)
+		{
+			uint32_t padded = (uint32_t)((list.size() + 31) & ~31u);
+
+			std::vector<uint8_t> image(padded, 0);
+			if (!list.empty())
+			{
+				memcpy(image.data(), list.data(), list.size());
+			}
+			WriteMainMemory(base, image.data(), image.size());
+
+			// The ring is larger than the list on purpose: with `read == write` meaning "empty", a
+			// list that ended exactly at `top` would look empty to the CP.
+			SetFifoRegs(m, base, base + FifoSize, base + padded, base);
+
+			PIRegWrite(PI_REGSPACE_CP | CP_ENABLE, CP_CR_RDEN | CP_CR_WPINC);
+
+			return (int)(padded / 32);
+		}
+
+		static void RunFifo(GfxTestMachine& m, int bursts)
+		{
+			for (int i = 0; i < bursts; i++)
+			{
+				m.flipper->cp->PumpFifo();
+			}
+		}
+
+		static uint16_t CpStatus(GfxTestMachine& m)
+		{
+			uint32_t value = 0;
+			Assert::IsTrue(PIRegRead(PI_REGSPACE_CP | CP_STATUS, &value), L"CP_STATUS must answer");
+			return (uint16_t)value;
+		}
+
+		static uint16_t CpEnable(GfxTestMachine& m)
+		{
+			uint32_t value = 0;
+			Assert::IsTrue(PIRegRead(PI_REGSPACE_CP | CP_ENABLE, &value), L"CP_ENABLE must answer");
+			return (uint16_t)value;
+		}
+
+		static uint32_t CpReadPtr(GfxTestMachine& m)
+		{
+			uint32_t low = 0, high = 0;
+			PIRegRead(PI_REGSPACE_CP | CP_FIFO_RPTRL, &low);
+			PIRegRead(PI_REGSPACE_CP | CP_FIFO_RPTRH, &high);
+			return ((high & 0x3ff) << 16) | (low & 0xffe0);
+		}
+
+		static uint32_t CpBreakPtr(GfxTestMachine& m)
+		{
+			uint32_t low = 0, high = 0;
+			PIRegRead(PI_REGSPACE_CP | CP_FIFO_BRKL, &low);
+			PIRegRead(PI_REGSPACE_CP | CP_FIFO_BRKH, &high);
+			return ((high & 0x3ff) << 16) | (low & 0xffe0);
+		}
+
+		static uint32_t CpCount(GfxTestMachine& m)
+		{
+			uint32_t low = 0, high = 0;
+			PIRegRead(PI_REGSPACE_CP | CP_FIFO_COUNTL, &low);
+			PIRegRead(PI_REGSPACE_CP | CP_FIFO_COUNTH, &high);
+			return ((high & 0x3ff) << 16) | (low & 0xffe0);
+		}
+
+	public:
+
+		// =========================================================================================
+		// 1. The register window and its encoding
+		// =========================================================================================
+
+		// The FIFO addresses are 21-bit, 32-byte aligned values split over a low and a high half:
+		// the low register keeps bits 15:5 and the high register bits 25:16 (command-processor.md
+		// 4.5). Reading the pair back must reproduce the address.
+		TEST_METHOD(CpSpec_FifoAddressHalvesPreserveBits15To25)
+		{
+			GfxTestMachine& m = M();
+
+			const uint32_t address = 0x00123440;
+			PIRegWrite(PI_REGSPACE_CP | CP_FIFO_BASEL, address & 0xffe0);
+			PIRegWrite(PI_REGSPACE_CP | CP_FIFO_BASEH, address >> 16);
+
+			uint32_t low = 0, high = 0;
+			PIRegRead(PI_REGSPACE_CP | CP_FIFO_BASEL, &low);
+			PIRegRead(PI_REGSPACE_CP | CP_FIFO_BASEH, &high);
+
+			Assert::AreEqual<uint32_t>(address & 0xffe0, low & 0xffe0, L"bits 15:5 survive the low half");
+			Assert::AreEqual<uint32_t>((address >> 16) & 0x3ff, high & 0x3ff, L"bits 25:16 survive the high half");
+		}
+
+		// The low half of each address register clears the low five bits: the CP addresses whole
+		// 32-byte units, and a write of a sub-unit address must not be able to misalign the ring.
+		TEST_METHOD(CpSpec_AddressRegistersIgnoreTheLowFiveBits)
+		{
+			GfxTestMachine& m = M();
+
+			PIRegWrite(PI_REGSPACE_CP | CP_FIFO_BASEL, 0xffff);
+			uint32_t low = 0;
+			PIRegRead(PI_REGSPACE_CP | CP_FIFO_BASEL, &low);
+			Assert::AreEqual<uint32_t>(0xffe0, low & 0xffff, L"the low five bits are always zero");
+		}
+
+		// The break point is one of those 21-bit addresses, kept in the same two halves.
+		TEST_METHOD(CpSpec_BreakPointHalvesPreserveBits15To25)
+		{
+			GfxTestMachine& m = M();
+
+			const uint32_t address = 0x002468A0;
+			PIRegWrite(PI_REGSPACE_CP | CP_FIFO_BRKL, address & 0xffe0);
+			PIRegWrite(PI_REGSPACE_CP | CP_FIFO_BRKH, address >> 16);
+
+			uint32_t low = 0, high = 0;
+			PIRegRead(PI_REGSPACE_CP | CP_FIFO_BRKL, &low);
+			PIRegRead(PI_REGSPACE_CP | CP_FIFO_BRKH, &high);
+
+			Assert::AreEqual<uint32_t>(address & 0xffe0, low & 0xffe0, L"the break point low half");
+			Assert::AreEqual<uint32_t>((address >> 16) & 0x3ff, high & 0x3ff, L"the break point high half");
+		}
+
+		// CP_STATUS bit 2 is the read unit idle flag and bit 3 the CP idle flag; both are set while
+		// there is nothing to read. CP_ENABLE resets with the FIFO reads *and* the break point
+		// disabled, and the write pointer increment enabled (bits 0, 1 and 4 clear, bit 4 set).
+		TEST_METHOD(CpSpec_EnableAndStatusResetState)
+		{
+			GfxTestMachine& m = M();
+
+			// Every documented enable bit is independent: writing only some of them must leave the
+			// others alone, and reading them back must reproduce exactly what was written.
+			PIRegWrite(PI_REGSPACE_CP | CP_ENABLE, CP_CR_RDEN | CP_CR_BPEN | CP_CR_WPINC);
+			uint16_t enable = CpEnable(m);
+			Assert::AreEqual<uint16_t>(CP_CR_RDEN, (uint16_t)(enable & CP_CR_RDEN), L"FIFO reads are enabled");
+			Assert::AreEqual<uint16_t>(CP_CR_BPEN, (uint16_t)(enable & CP_CR_BPEN), L"the break point is enabled");
+			Assert::AreEqual<uint16_t>(0, (uint16_t)(enable & CP_CR_BPINTEN), L"the break interrupt stays off");
+			Assert::AreEqual<uint16_t>(CP_CR_WPINC, (uint16_t)(enable & CP_CR_WPINC), L"the write pointer increment stays on");
+
+			// With no stream installed the reader is idle.
+			Assert::AreEqual<uint16_t>(0, (uint16_t)(CpStatus(m) & CP_SR_BPINT), L"no break condition yet");
+		}
+
+		// =========================================================================================
+		// 2. The FIFO ring
+		// =========================================================================================
+
+		// With FIFO reads disabled the read pointer must not move, however many times the CP is
+		// pumped: CP_ENABLE[0] is the gate the documentation gives it.
+		TEST_METHOD(CpSpec_ReadsAreGatedByTheEnableBit)
+		{
+			GfxTestMachine& m = M();
+
+			DisplayList list;
+			list.CpReg(Flipper::CP_MATINDEX_A_ID, 0x11223344);
+			list.Align();
+
+			int bursts = SetupFifo(m, list.Bytes());
+
+			// SetupFifo enabled the reads; disable them again and check that the pointer freezes.
+			PIRegWrite(PI_REGSPACE_CP | CP_ENABLE, 0);
+			uint32_t before = CpReadPtr(m);
+			RunFifo(m, bursts);
+			Assert::AreEqual<uint32_t>(before, CpReadPtr(m), L"the read pointer must not move while reads are disabled");
+
+			// ... and that enabling them lets the stream run again.
+			PIRegWrite(PI_REGSPACE_CP | CP_ENABLE, CP_CR_RDEN | CP_CR_WPINC);
+			RunFifo(m, bursts);
+			Assert::AreNotEqual<uint32_t>(before, CpReadPtr(m), L"the stream resumes when the reads are enabled");
+		}
+
+		// The read pointer advances one 32-byte unit per burst, and the count is the distance
+		// between the write and the read pointer (command-processor.md 2.2, 4.5).
+		TEST_METHOD(CpSpec_ReadPointerAdvancesOneBurstAndTheCountFollows)
+		{
+			GfxTestMachine& m = M();
+
+			DisplayList list;
+			for (int i = 0; i < 4; i++)
+			{
+				list.CpReg(Flipper::CP_MATINDEX_A_ID, (uint32_t)i);
+			}
+			list.Align();
+
+			int bursts = SetupFifo(m, list.Bytes());
+
+			uint32_t expectedCount = (uint32_t)bursts * 32;
+			Assert::AreEqual<uint32_t>(expectedCount, CpCount(m), L"the count is (write - read) in 32-byte units");
+
+			for (int i = 0; i < bursts; i++)
+			{
+				m.flipper->cp->PumpFifo();
+				expectedCount -= 32;
+				Assert::AreEqual<uint32_t>(expectedCount, CpCount(m), L"the count falls by one burst per read");
+			}
+
+			Assert::AreEqual<uint32_t>(0, CpCount(m), L"the FIFO is empty when the stream has been read");
+		}
+
+		// A read pointer that reaches `top` wraps to `base` (command-processor.md 2.2). The list is
+		// placed so that it ends exactly at the top of the ring.
+		TEST_METHOD(CpSpec_ReadPointerWrapsFromTopToBase)
+		{
+			GfxTestMachine& m = M();
+
+			// Two bursts, ending exactly at the top of a small ring.
+			const uint32_t base = 0x00030000;
+			const uint32_t ringSize = 64;
+
+			DisplayList list;
+			ProgramList(list);
+			list.Align();
+
+			std::vector<uint8_t> image(64, 0);
+			memcpy(image.data(), list.Bytes().data(), list.Size());
+			WriteMainMemory(base, image.data(), image.size());
+
+			// write == base is the "empty" encoding, so start the write pointer at base and drive
+			// the ring by hand.
+			SetFifoRegs(m, base, base + ringSize, base, base);
+			PIRegWrite(PI_REGSPACE_CP | CP_ENABLE, CP_CR_RDEN | CP_CR_WPINC);
+
+			// Give the CP two bursts of work and check the pointer wrapped to the base.
+			PIRegWrite(PI_REGSPACE_CP | CP_FIFO_WPTRL, base & 0xffe0);
+			PIRegWrite(PI_REGSPACE_CP | CP_FIFO_WPTRH, base >> 16);
+
+			// The ring is empty at this point; make the write pointer lead the read pointer by the
+			// whole ring so that both bursts are available.
+			PIRegWrite(PI_REGSPACE_CP | CP_FIFO_WPTRL, (base + ringSize) & 0xffe0);
+			PIRegWrite(PI_REGSPACE_CP | CP_FIFO_WPTRH, (base + ringSize) >> 16);
+
+			m.flipper->cp->PumpFifo();
+			Assert::AreEqual<uint32_t>(base + 32, CpReadPtr(m), L"the first read moves one unit");
+
+			m.flipper->cp->PumpFifo();
+			Assert::AreEqual<uint32_t>(base, CpReadPtr(m), L"the pointer wraps from top back to base");
+		}
+
+		// `read == write` is the empty encoding: with the two pointers equal the CP must report an
+		// empty FIFO and leave the read pointer alone.
+		TEST_METHOD(CpSpec_EqualPointersMeanEmpty)
+		{
+			GfxTestMachine& m = M();
+
+			DisplayList list;
+			ProgramList(list);
+			list.Align();
+			WriteMainMemory(FifoBase, list.Bytes().data(), list.Size());
+
+			SetFifoRegs(m, FifoBase, FifoTop, FifoBase, FifoBase);
+			PIRegWrite(PI_REGSPACE_CP | CP_ENABLE, CP_CR_RDEN | CP_CR_WPINC);
+
+			Assert::AreEqual<uint32_t>(0, CpCount(m), L"equal pointers mean an empty FIFO");
+
+			uint32_t before = CpReadPtr(m);
+			RunFifo(m, 4);
+			Assert::AreEqual<uint32_t>(before, CpReadPtr(m), L"an empty FIFO does not advance the pointer");
+		}
+
+		// =========================================================================================
+		// 3. The water marks
+		// =========================================================================================
+
+		// When the count rises above the high water mark the overflow flag must be set, and when it
+		// falls below the low water mark the underflow flag must be (command-processor.md 2.2).
+		TEST_METHOD(CpSpec_WaterMarksSetTheOverflowAndUnderflowFlags)
+		{
+			GfxTestMachine& m = M();
+
+			DisplayList list;
+			for (int i = 0; i < 8; i++)
+			{
+				list.CpReg(Flipper::CP_MATINDEX_A_ID, (uint32_t)i);
+			}
+			list.Align();
+
+			int bursts = SetupFifo(m, list.Bytes());
+
+			// High mark below the occupancy -> overflow.
+			PIRegWrite(PI_REGSPACE_CP | CP_FIFO_HICNTL, (FifoBase + 32) & 0xffe0);
+			PIRegWrite(PI_REGSPACE_CP | CP_FIFO_HICNTH, 0);
+			PIRegWrite(PI_REGSPACE_CP | CP_FIFO_LOCNTL, 0);
+			PIRegWrite(PI_REGSPACE_CP | CP_FIFO_LOCNTH, 0);
+			PIRegWrite(PI_REGSPACE_CP | CP_ENABLE, CP_CR_RDEN | CP_CR_WPINC | CP_CR_OVFEN);
+
+			m.flipper->cp->PumpFifo();
+			Assert::AreEqual<uint16_t>(CP_SR_OVF, (uint16_t)(CpStatus(m) & CP_SR_OVF), L"the occupancy is above the high mark");
+
+			// CP_CLR[0] clears the overflow condition (command-processor.md 4.4).
+			PIRegWrite(PI_REGSPACE_CP | CP_CLR, CP_CLR_OVFCLR);
+			Assert::AreEqual<uint16_t>(0, (uint16_t)(CpStatus(m) & CP_SR_OVF), L"CP_CLR[0] clears the overflow flag");
+
+			// Drain the FIFO down to the low mark -> underflow.
+			PIRegWrite(PI_REGSPACE_CP | CP_FIFO_LOCNTL, (FifoBase + (uint32_t)bursts * 32) & 0xffe0);
+			PIRegWrite(PI_REGSPACE_CP | CP_ENABLE, CP_CR_RDEN | CP_CR_WPINC | CP_CR_UVFEN);
+			RunFifo(m, bursts + 1);
+			Assert::AreEqual<uint16_t>(CP_SR_UVF, (uint16_t)(CpStatus(m) & CP_SR_UVF), L"the occupancy is below the low mark");
+
+			PIRegWrite(PI_REGSPACE_CP | CP_CLR, CP_CLR_UVFCLR);
+			Assert::AreEqual<uint16_t>(0, (uint16_t)(CpStatus(m) & CP_SR_UVF), L"CP_CLR[1] clears the underflow flag");
+		}
+
+		// The water mark interrupts are enabled by CP_ENABLE[2]/[3] and are reported through the
+		// Processor Interface as the CP interrupt.
+		TEST_METHOD(CpSpec_WaterMarkInterruptsReachTheProcessorInterface)
+		{
+			GfxTestMachine& m = M();
+
+			DisplayList list;
+			for (int i = 0; i < 8; i++)
+			{
+				list.CpReg(Flipper::CP_MATINDEX_A_ID, (uint32_t)i);
+			}
+			list.Align();
+
+			SetupFifo(m, list.Bytes());
+
+			PIClearAssertedInterrupts();
+			PIRegWrite(PI_REGSPACE_CP | CP_FIFO_HICNTL, (FifoBase + 32) & 0xffe0);
+			PIRegWrite(PI_REGSPACE_CP | CP_FIFO_HICNTH, 0);
+			PIRegWrite(PI_REGSPACE_CP | CP_ENABLE, CP_CR_RDEN | CP_CR_WPINC | CP_CR_OVFEN);
+
+			m.flipper->cp->PumpFifo();
+
+			Assert::AreEqual<uint32_t>(PI_INTERRUPT_CP, PIAssertedInterrupts() & PI_INTERRUPT_CP,
+				L"the overflow interrupt is reported to the PI");
+		}
+
+		// =========================================================================================
+		// 4. The break point
+		// =========================================================================================
+
+		// The break point stops the CP when the read pointer reaches it (command-processor.md 2.2,
+		// 4.3). With CP_ENABLE[FIFOBRK] set the status bit must be raised and the read pointer must
+		// not run past the break.
+		TEST_METHOD(CpSpec_BreakPointStopsTheReaderAndSetsTheStatusBit)
+		{
+			GfxTestMachine& m = M();
+
+			DisplayList list;
+			for (int i = 0; i < 4; i++)
+			{
+				list.CpReg(Flipper::CP_MATINDEX_A_ID, (uint32_t)i);
+			}
+			// 4 commands are 24 bytes, i.e. one burst; pad the list out to four bursts so that
+			// there is stream behind the break point as well.
+			while (Bursts(list) < 4)
+			{
+				list.CpReg(Flipper::CP_MATINDEX_B_ID, (uint32_t)Bursts(list));
+			}
+			list.Align();
+
+			int bursts = SetupFifo(m, list.Bytes());
+			Assert::AreEqual<int>(4, bursts, L"the test stream is four bursts");
+
+			// Break on the third burst.
+			const uint32_t breakAt = FifoBase + 64;
+			PIRegWrite(PI_REGSPACE_CP | CP_FIFO_BRKL, breakAt & 0xffe0);
+			PIRegWrite(PI_REGSPACE_CP | CP_FIFO_BRKH, breakAt >> 16);
+
+			// FIFO reads, the write pointer increment and the break point, no break interrupt.
+			PIRegWrite(PI_REGSPACE_CP | CP_ENABLE, CP_CR_RDEN | CP_CR_WPINC | CP_CR_BPEN);
+
+			Assert::AreEqual<uint32_t>(breakAt, CpBreakPtr(m), L"the break address was programmed");
+
+			RunFifo(m, bursts);
+
+			// The reader is not allowed to run past the break point.
+			Assert::AreEqual<uint32_t>(breakAt, CpReadPtr(m), L"the reader stops at the break point");
+			Assert::AreEqual<uint16_t>(CP_SR_BPINT, (uint16_t)(CpStatus(m) & CP_SR_BPINT),
+				Widen("the break flag is set, enable=" + std::to_string(CpEnable(m)) +
+					" rptr=" + std::to_string(CpReadPtr(m)) +
+					" bptr=" + std::to_string(CpBreakPtr(m)) +
+					" want=" + std::to_string(breakAt)).c_str());
+		}
+
+		// Clearing CP_ENABLE[FIFOBRK] clears the break status bit (the documentation puts the clear
+		// on disabling the break point, not on the interrupt enable), and the reader resumes.
+		TEST_METHOD(CpSpec_DisablingTheBreakPointClearsTheStatusAndResumes)
+		{
+			GfxTestMachine& m = M();
+
+			DisplayList list;
+			for (int i = 0; i < 4; i++)
+			{
+				list.CpReg(Flipper::CP_MATINDEX_A_ID, (uint32_t)i);
+			}
+			while (Bursts(list) < 4)
+			{
+				list.CpReg(Flipper::CP_MATINDEX_B_ID, (uint32_t)Bursts(list));
+			}
+			list.Align();
+
+			int bursts = SetupFifo(m, list.Bytes());
+			Assert::AreEqual<int>(4, bursts, L"the test stream is four bursts");
+
+			const uint32_t breakAt = FifoBase + 64;
+			PIRegWrite(PI_REGSPACE_CP | CP_FIFO_BRKL, breakAt & 0xffe0);
+			PIRegWrite(PI_REGSPACE_CP | CP_FIFO_BRKH, breakAt >> 16);
+			PIRegWrite(PI_REGSPACE_CP | CP_ENABLE, CP_CR_RDEN | CP_CR_WPINC | CP_CR_BPEN);
+
+			RunFifo(m, bursts);
+			Assert::AreEqual<uint32_t>(breakAt, CpReadPtr(m), L"the reader stops at the break point");
+			Assert::AreEqual<uint16_t>(CP_SR_BPINT, (uint16_t)(CpStatus(m) & CP_SR_BPINT), L"the break flag is set");
+
+			// The CPU disables the break point, which is what clears the flag.
+			PIRegWrite(PI_REGSPACE_CP | CP_ENABLE, CP_CR_RDEN | CP_CR_WPINC);
+			Assert::AreEqual<uint16_t>(0, (uint16_t)(CpStatus(m) & CP_SR_BPINT), L"clearing FIFOBRK clears the flag");
+
+			// ... and the reader walks on past the break point, to the end of the stream.
+			RunFifo(m, bursts);
+			Assert::AreEqual<uint32_t>(FifoBase + (uint32_t)bursts * 32, CpReadPtr(m),
+				L"the reader resumes and reaches the end of the stream");
+		}
+
+		// A break point that is not enabled must never stop the reader, *whatever the break address
+		// holds* - including the reset value 0, which is the address the FIFO often starts at. This
+		// is the case that a stream with the break point and its address never programmed exercises.
+		TEST_METHOD(CpSpec_DisabledBreakPointDoesNotStopTheReader)
+		{
+			GfxTestMachine& m = M();
+
+			DisplayList list;
+			for (int i = 0; i < 4; i++)
+			{
+				list.CpReg(Flipper::CP_MATINDEX_A_ID, (uint32_t)i);
+			}
+			while (Bursts(list) < 4)
+			{
+				list.CpReg(Flipper::CP_MATINDEX_B_ID, (uint32_t)Bursts(list));
+			}
+			list.Align();
+
+			int bursts = SetupFifo(m, list.Bytes());
+
+			// The break point address left at its reset value, the break point disabled.
+			PIRegWrite(PI_REGSPACE_CP | CP_ENABLE, CP_CR_RDEN | CP_CR_WPINC);
+
+			RunFifo(m, bursts);
+
+			Assert::AreEqual<uint16_t>(0, (uint16_t)(CpStatus(m) & CP_SR_BPINT), L"no break flag with the break disabled");
+			Assert::AreEqual<uint32_t>(FifoBase + (uint32_t)bursts * 32, CpReadPtr(m), L"the whole stream was read");
+		}
+
+		// The break point interrupt is a separate enable from the break point itself: with
+		// CP_ENABLE[FIFOBRK] and [FIFOBRKINT] both set the CP interrupt must be raised at the break.
+		TEST_METHOD(CpSpec_BreakPointInterruptReachesTheProcessorInterface)
+		{
+			GfxTestMachine& m = M();
+
+			DisplayList list;
+			for (int i = 0; i < 4; i++)
+			{
+				list.CpReg(Flipper::CP_MATINDEX_A_ID, (uint32_t)i);
+			}
+			while (Bursts(list) < 4)
+			{
+				list.CpReg(Flipper::CP_MATINDEX_B_ID, (uint32_t)Bursts(list));
+			}
+			list.Align();
+
+			int bursts = SetupFifo(m, list.Bytes());
+
+			const uint32_t breakAt = FifoBase + 64;
+			PIRegWrite(PI_REGSPACE_CP | CP_FIFO_BRKL, breakAt & 0xffe0);
+			PIRegWrite(PI_REGSPACE_CP | CP_FIFO_BRKH, breakAt >> 16);
+
+			PIClearAssertedInterrupts();
+			PIRegWrite(PI_REGSPACE_CP | CP_ENABLE, CP_CR_RDEN | CP_CR_WPINC | CP_CR_BPEN | CP_CR_BPINTEN);
+
+			RunFifo(m, bursts);
+
+			Assert::AreEqual<uint32_t>(PI_INTERRUPT_CP, PIAssertedInterrupts() & PI_INTERRUPT_CP,
+				L"the break point interrupt is reported to the PI");
+		}
+
+		// =========================================================================================
+		// 5. The command stream: the opcodes the CP owns
+		// =========================================================================================
+
+		// CP_NOP (0x00..0x07) is a whole command on its own: it consumes one byte and does nothing.
+		// A stream of NOPs must be walked without the CP reporting an unsupported opcode.
+		TEST_METHOD(CpSpec_NopIsAOneByteCommand)
+		{
+			GfxTestMachine& m = M();
+
+			// A whole burst of NOPs: every NOP selector, repeated to fill the 32 bytes the CP
+			// fetches at a time.
+			DisplayList list;
+			for (int i = 0; i < 32; i++)
+			{
+				list.U8((uint8_t)(Flipper::CP_CMD_NOP | (i & 7)));
+			}
+			list.Align();
+
+			int bursts = SetupFifo(m, list.Bytes());
+			ClearTestLog();
+			RunFifo(m, bursts);
+
+			{
+				uint8_t* mem = TestMainMemory(FifoBase, 8);
+				char text[64];
+				sprintf_s(text, "fifo[0..7]=%02X %02X %02X %02X %02X %02X %02X %02X",
+					mem[0], mem[1], mem[2], mem[3], mem[4], mem[5], mem[6], mem[7]);
+				Assert::AreEqual<int>(0, TestHaltCount(),
+					Widen(std::string("NOPs are not an error: ") + TestLastHalt() + " | " + text).c_str());
+			}
+			Assert::AreEqual<std::wstring>(L"", Widen(TestLastHalt()), L"no opcode was rejected");
+		}
+
+		// CP_VCACHE_INVD (0x48..0x4F) is a one-byte command too; the CP must accept every VAT
+		// selector in its low three bits.
+		TEST_METHOD(CpSpec_VertexCacheInvalidateAcceptsEveryVat)
+		{
+			GfxTestMachine& m = M();
+
+			DisplayList list;
+			for (int i = 0; i < 32; i++)
+			{
+				list.U8((uint8_t)(Flipper::CP_CMD_VCACHE_INVD | (i & 7)));
+			}
+			list.Align();
+
+			int bursts = SetupFifo(m, list.Bytes());
+			ClearTestLog();
+			RunFifo(m, bursts);
+
+			Assert::AreEqual<int>(0, TestHaltCount(), Widen("the invalidate command is supported for all VATs: " + TestLastHalt()).c_str());
+		}
+
+		// CP_LoadRegs carries an 8-bit register index and a 32-bit payload, i.e. six bytes. The
+		// MATINDEX registers are the ones with no side effects of their own, so they are what the
+		// byte accounting can be checked with.
+		TEST_METHOD(CpSpec_CpRegisterLoadIsSixBytes)
+		{
+			GfxTestMachine& m = M();
+
+			DisplayList list;
+			list.CpReg(Flipper::CP_MATINDEX_A_ID, 0x01234567);
+			list.Align();
+
+			int bursts = SetupFifo(m, list.Bytes());
+
+			// One burst is all it takes, and the command must not leave bytes unread: a second
+			// pump with an empty tail must not advance the pointer past the list.
+			RunFifo(m, bursts);
+			Assert::AreEqual<uint32_t>(FifoBase + 32, CpReadPtr(m), L"the six-byte command fits one burst");
+		}
+
+		// CP_LoadBypass (0x60..0x6F) carries a 24-bit payload with the register index in the top
+		// byte. All sixteen indices of the group must be accepted.
+		TEST_METHOD(CpSpec_BypassLoadAcceptsEveryIndex)
+		{
+			GfxTestMachine& m = M();
+
+			// One burst per index, so that a rejected register can be named: the CP must decode
+			// every index of the bypass group (command-processor.md 3.2, gfx.md 3.2).
+			for (int i = 0; i < 16; i++)
+			{
+				DisplayList list;
+				list.BpReg((uint8_t)(GEN_MODE_ID + i), 0);
+				list.Align();
+
+				int bursts = SetupFifo(m, list.Bytes());
+				ClearTestLog();
+				RunFifo(m, bursts);
+
+				Assert::AreEqual<int>(0, TestHaltCount(),
+					Widen("bypass index " + std::to_string(i) + ": " + TestLastHalt()).c_str());
+			}
+		}
+
+		// An opcode outside the documented set must be reported as an unsupported command rather
+		// than silently skipped: silently skipping it would desynchronise everything after it.
+		TEST_METHOD(CpSpec_UnknownOpcodeIsReported)
+		{
+			GfxTestMachine& m = M();
+
+			DisplayList list;
+			list.U8(0x58);				// the gap between VCACHE_INVD (0x48..0x4F) and LoadBypass (0x60)
+			list.Align();
+
+			int bursts = SetupFifo(m, list.Bytes());
+			ClearTestLog();
+			RunFifo(m, bursts);
+
+			Assert::IsTrue(TestHaltCount() > 0, L"an unsupported opcode must stop the emulator with a message");
+		}
+
+	private:
+
+		//! A list with a couple of harmless CP register loads, used where the test only needs a
+		//! non-empty stream.
+		static void ProgramList(DisplayList& list)
+		{
+			list.CpReg(Flipper::CP_MATINDEX_A_ID, 0x11111111);
+			list.CpReg(Flipper::CP_MATINDEX_B_ID, 0x22222222);
+		}
+	};
+}

--- a/testing/gfx_si_spec_test.cpp
+++ b/testing/gfx_si_spec_test.cpp
@@ -1,0 +1,443 @@
+// SI (serial / controller interface): tests written from the specifications.
+//
+// The serial interface is the block that frames the four controller ports and runs the automatic
+// controller poll. The reference specifications spell out three things that are tested here:
+//
+//   * the register window - the SI has no 32-bit port: every 32-bit register is reached as two
+//     16-bit halves, the high word at the base (even) address and the low word at base + 2;
+//   * the register set and its bit fields - SICnOUTBUF is read/write, SIPOLL holds X (the poll
+//     interval in horizontal lines), Y (the polls a frame) and the per-channel enables, and
+//     SICOMCSR holds TSTART / CHANNEL / INLNGTH in its low half and OUTLNGTH plus the two
+//     interrupt bits and masks in its high half;
+//   * the poll schedule and the read-status interrupt - a poll raises RDSTINT on an enabled
+//     channel, the SI line is asserted only while that flag is unmasked, and reading the channel's
+//     input buffer is what clears it again.
+//
+// The schedule is driven through `SIPoll(line)`, which takes the video line counter explicitly, so
+// the whole schedule is testable without a running VI. A wrap of that counter is a vertical blank.
+
+#include "pch.h"
+#include "gfx_test_common.h"
+
+using namespace GfxUnitTest;
+
+namespace pureikyubutest
+{
+	TEST_CLASS(GfxSiSpecTest)
+	{
+		//! The SI channel registers, from the software point of view (each channel owns an output
+		//! buffer and the two halves of its input buffer).
+		static const uint32_t ChanOut = 0x00;
+		static const uint32_t ChanInH = 0x04;
+		static const uint32_t ChanInL = 0x08;
+		static const uint32_t ChanStride = 0x0C;
+
+		static const uint32_t PollReg = 0x30;
+		static const uint32_t ComCsr = 0x34;
+		static const uint32_t SrReg = 0x38;
+
+		//! SIPOLL bits: X is the interval in video lines (25:16), Y the number of polls a frame
+		//! (15:8), then one enable and one vblank-copy bit per channel.
+		static uint32_t PollX(uint32_t x) { return (x & 0x3ff) << 16; }
+		static uint32_t PollY(uint32_t y) { return (y & 0xff) << 8; }
+		static uint32_t PollEn(int channel) { return 1u << (7 - channel); }
+
+		static GfxTestMachine& M()
+		{
+			GfxTestMachine& m = Machine();
+			m.Reset();
+			PIClearAssertedInterrupts();
+			ClearTestLog();
+			return m;
+		}
+
+		//! The SerialInterface the machine owns, reached through the emulated hardware.
+		static Flipper::SerialInterface* Si(GfxTestMachine& m)
+		{
+			return m.flipper->si;
+		}
+
+		// =========================================================================================
+		// The register window: every 32-bit register is two 16-bit halves.
+		// =========================================================================================
+
+		static void WriteSiHi(uint32_t offset, uint32_t value)
+		{
+			PIRegWrite(PI_REGSPACE_SI + offset, value & 0xffff);
+		}
+
+		static void WriteSiLo(uint32_t offset, uint32_t value)
+		{
+			PIRegWrite(PI_REGSPACE_SI + offset + 2, value & 0xffff);
+		}
+
+		//! A 32-bit write is the high word at the base address and the low word at base + 2.
+		static void WriteSiWord(uint32_t offset, uint32_t value)
+		{
+			WriteSiHi(offset, value >> 16);
+			WriteSiLo(offset, value);
+		}
+
+		static uint32_t ReadSiHi(uint32_t offset)
+		{
+			uint32_t value = 0;
+			PIRegRead(PI_REGSPACE_SI + offset, &value);
+			return value & 0xffff;
+		}
+
+		static uint32_t ReadSiLo(uint32_t offset)
+		{
+			uint32_t value = 0;
+			PIRegRead(PI_REGSPACE_SI + offset + 2, &value);
+			return value & 0xffff;
+		}
+
+		static uint32_t ReadSiWord(uint32_t offset)
+		{
+			return (ReadSiHi(offset) << 16) | ReadSiLo(offset);
+		}
+
+		//! Program the poll register with one enabled channel and the given interval / budget.
+		static void SetPoll(GfxTestMachine& m, uint32_t x, uint32_t y, uint32_t channels = 1)
+		{
+			uint32_t poll = PollX(x) | PollY(y);
+			for (uint32_t c = 0; c < 4; c++)
+			{
+				if (channels & (1u << c))
+				{
+					poll |= PollEn((int)c);
+				}
+			}
+			WriteSiWord(PollReg, poll);
+			PIClearAssertedInterrupts();
+		}
+
+		static bool RdstInt(GfxTestMachine& m)
+		{
+			return (ReadSiWord(ComCsr) & SI_COMCSR_RDSTINT) != 0;
+		}
+
+		static bool TcInt(GfxTestMachine& m)
+		{
+			return (ReadSiWord(ComCsr) & SI_COMCSR_TCINT) != 0;
+		}
+
+		static bool SiInterruptAsserted()
+		{
+			return (PIAssertedInterrupts() & PI_INTERRUPT_SI) != 0;
+		}
+
+		//! Read a channel's input buffer, which is the CPU-side acknowledge of a poll.
+		static void ReadInputBuffer(uint32_t channel = 0)
+		{
+			ReadSiWord(ChanInH + channel * ChanStride);
+		}
+
+		// =========================================================================================
+		// 1. The register window
+		// =========================================================================================
+
+		// The poll register is a full 32-bit register; what the CPU writes must read back.
+		TEST_METHOD(SiSpec_PollRegisterRoundTrips)
+		{
+			GfxTestMachine& m = M();
+
+			WriteSiWord(PollReg, PollX(7) | PollY(2) | PollEn(0));
+			uint32_t poll = ReadSiWord(PollReg);
+
+			Assert::AreEqual<uint32_t>(7, (poll >> 16) & 0x3ff, L"SIPOLL[X] is the poll interval");
+			Assert::AreEqual<uint32_t>(2, (poll >> 8) & 0xff, L"SIPOLL[Y] is the polls per frame");
+			Assert::AreEqual<uint32_t>(PollEn(0), poll & PollEn(0), L"channel 0 is enabled");
+			Assert::AreEqual<uint32_t>(0, poll & PollEn(1), L"channel 1 stays disabled");
+		}
+
+		// The high halfword of SIPOLL carries X, the low halfword carries Y and the enables: a
+		// 16-bit write to one half must leave the other half alone.
+		TEST_METHOD(SiSpec_PollHalvesAreIndependent)
+		{
+			GfxTestMachine& m = M();
+
+			WriteSiWord(PollReg, PollX(0x155) | PollY(0x2a) | PollEn(int(3)));
+			Assert::AreEqual<uint32_t>(0x155, (ReadSiWord(PollReg) >> 16) & 0x3ff, L"X came from the high half");
+
+			WriteSiLo(PollReg, 0);
+			uint32_t poll = ReadSiWord(PollReg);
+
+			Assert::AreEqual<uint32_t>(0x155, (poll >> 16) & 0x3ff, L"the low half did not disturb X");
+			Assert::AreEqual<uint32_t>(0, (poll >> 8) & 0xff, L"writing the low half cleared Y");
+		}
+
+		// SICnOUTBUF is read/write, and a write must not disturb the other channels (each channel
+		// owns its own buffer).
+		TEST_METHOD(SiSpec_ChannelOutputBuffersAreIndependent)
+		{
+			GfxTestMachine& m = M();
+
+			for (uint32_t c = 0; c < 4; c++)
+			{
+				WriteSiWord(ChanOut + c * ChanStride, 0x00A00000u + c);
+			}
+
+			for (uint32_t c = 0; c < 4; c++)
+			{
+				Assert::AreEqual<uint32_t>(0x00A00000u + c, ReadSiWord(ChanOut + c * ChanStride),
+					Widen("channel " + std::to_string(c) + " kept its output buffer").c_str());
+			}
+		}
+
+		// The input buffers are read-only: a write is ignored and the response bytes survive it.
+		TEST_METHOD(SiSpec_InputBuffersAreReadOnly)
+		{
+			GfxTestMachine& m = M();
+
+			SetPoll(m, 1, 4, 1);
+			Si(m)->SIPoll(0);			// one poll, so the input buffer holds something
+
+			uint32_t before = ReadSiWord(ChanInH);
+			WriteSiWord(ChanInH, 0xdeadbeef);
+			Assert::AreEqual<uint32_t>(before, ReadSiWord(ChanInH), L"SICnINBUFH is read-only");
+		}
+
+		// COMCSR splits across the two halfwords: the channel, the input length and TSTART live in
+		// the low halfword, the output length and the interrupt/mask bits in the high halfword.
+		TEST_METHOD(SiSpec_ComCsrFieldsSitAtTheDocumentedBitPositions)
+		{
+			GfxTestMachine& m = M();
+
+			uint32_t value = (2u << 1) | (5u << 8) | (9u << 16);
+			WriteSiWord(ComCsr, value);
+			uint32_t csr = ReadSiWord(ComCsr);
+
+			Assert::AreEqual<uint32_t>(2, SI_COMCSR_CHAN(csr), L"CHANNEL is bits 2:1");
+			Assert::AreEqual<uint32_t>(5, SI_COMCSR_INLEN(csr), L"INLNGTH is bits 14:8");
+			Assert::AreEqual<uint32_t>(9, SI_COMCSR_OUTLEN(csr), L"OUTLNGTH is bits 22:16");
+			Assert::AreEqual<uint32_t>(0, csr & SI_COMCSR_TSTART, L"TSTART is clear when not written");
+		}
+
+		// Writing TSTART runs the transfer; TSTART is a pending bit rather than a stored one, so it
+		// reads back clear and the completion flag is raised instead.
+		TEST_METHOD(SiSpec_TstartReadsClearOnceTheTransferRan)
+		{
+			GfxTestMachine& m = M();
+
+			WriteSiWord(ComCsr, (0u << 1) | (1u << 8) | (1u << 16) | SI_COMCSR_TSTART);
+
+			uint32_t csr = ReadSiWord(ComCsr);
+			Assert::AreEqual<uint32_t>(0, csr & SI_COMCSR_TSTART, L"TSTART is a pending bit");
+			Assert::AreEqual<uint32_t>(SI_COMCSR_TCINT, csr & SI_COMCSR_TCINT, L"the transfer completed");
+
+			// TCINT is write-1-to-clear.
+			WriteSiHi(ComCsr, SI_COMCSR_TCINT >> 16);
+			Assert::AreEqual<uint32_t>(0, TcInt(m), L"writing 1 to TCINT clears it");
+		}
+
+		// A fresh SI raises no interrupt: both flags and both masks reset to zero.
+		TEST_METHOD(SiSpec_FreshInterfaceIsQuiet)
+		{
+			GfxTestMachine& m = M();
+
+			Assert::AreEqual<uint32_t>(0, ReadSiWord(ComCsr) & (SI_COMCSR_RDSTINT | SI_COMCSR_TCINT),
+				L"both interrupt flags reset clear");
+			Assert::IsFalse(SiInterruptAsserted(), L"a freshly powered SI asserts nothing");
+		}
+
+		// =========================================================================================
+		// 2. The poll schedule
+		// =========================================================================================
+
+		// `Y == 0` means no polling at all: the schedule must not poll however far the line counter
+		// advances.
+		TEST_METHOD(SiSpec_ZeroPollsPerFrameDisablesPolling)
+		{
+			GfxTestMachine& m = M();
+
+			SetPoll(m, 1, 0);				// a perfectly good interval, but no budget
+			PIClearAssertedInterrupts();
+
+			for (uint32_t line = 0; line <= 64; line++)
+			{
+				Si(m)->SIPoll(line);
+			}
+
+			Assert::IsFalse(RdstInt(m), L"no poll with Y == 0");
+			Assert::IsFalse(SiInterruptAsserted(), L"no SI interrupt with Y == 0");
+		}
+
+		// A channel whose enable bit is clear is never polled, even with a valid X and Y.
+		TEST_METHOD(SiSpec_DisabledChannelIsNeverPolled)
+		{
+			GfxTestMachine& m = M();
+
+			SetPoll(m, 1, 4, 0);			// interval and budget, but every enable bit clear
+			PIClearAssertedInterrupts();
+
+			for (uint32_t line = 0; line <= 64; line++)
+			{
+				Si(m)->SIPoll(line);
+			}
+
+			Assert::IsFalse(RdstInt(m), L"a disabled channel is not polled");
+			Assert::IsFalse(SiInterruptAsserted(), L"and raises no interrupt");
+		}
+
+		// One poll happens at the start of a frame, and the next one only after `X` lines: with
+		// X = 4, lines 11..13 must not poll again after the poll at line 10.
+		TEST_METHOD(SiSpec_PollsAreSpacedByXVideoLines)
+		{
+			GfxTestMachine& m = M();
+
+			SetPoll(m, 4, 8, 1);
+			PIClearAssertedInterrupts();
+
+			Si(m)->SIPoll(10);				// the first poll of the frame
+			Assert::IsTrue(RdstInt(m), L"the first poll of the frame happens at the blank");
+
+			// The guest acknowledges the poll by reading the input buffer, which clears RDSTINT.
+			ReadInputBuffer();
+			Assert::IsFalse(RdstInt(m), L"reading the input buffer clears RDSTINT");
+
+			for (uint32_t line = 11; line < 14; line++)
+			{
+				Si(m)->SIPoll(line);
+			}
+			Assert::IsFalse(RdstInt(m), L"no poll before the interval has elapsed");
+
+			Si(m)->SIPoll(14);				// 10 + 4 lines
+			Assert::IsTrue(RdstInt(m), L"the next poll lands X lines after the first");
+		}
+
+		// The line counter wraps once per frame; a wrap is a new vertical blank, so the budget
+		// resets and the first poll of the new frame becomes due.
+		TEST_METHOD(SiSpec_TheScheduleIsAnchoredToTheVerticalBlank)
+		{
+			GfxTestMachine& m = M();
+
+			SetPoll(m, 100, 1, 1);		// one poll a frame, and an interval longer than the frame
+			PIClearAssertedInterrupts();
+
+			// Frame 1: a mid-frame poll happens once.
+			Si(m)->SIPoll(50);
+			Assert::IsTrue(RdstInt(m), L"the first poll of the frame");
+			ReadInputBuffer();
+
+			// Still inside frame 1: the budget is spent and the interval has not elapsed.
+			Si(m)->SIPoll(60);
+			Si(m)->SIPoll(90);
+			Assert::IsFalse(RdstInt(m), L"the frame budget of one poll is spent");
+
+			// The counter wraps to the next frame, which re-arms the schedule.
+			Si(m)->SIPoll(1);
+			Assert::IsTrue(RdstInt(m), L"a wrap of the line counter is a new frame");
+		}
+
+		// `Y` caps the number of polls a frame: with X = 1 and Y = 2, only two polls may happen
+		// however many lines pass.
+		TEST_METHOD(SiSpec_PollsPerFrameIsTheBudget)
+		{
+			GfxTestMachine& m = M();
+
+			SetPoll(m, 1, 2, 1);
+			PIClearAssertedInterrupts();
+
+			int polls = 0;
+			for (uint32_t line = 0; line <= 20; line++)
+			{
+				bool before = RdstInt(m);
+				Si(m)->SIPoll(line);
+				if (!before && RdstInt(m))
+				{
+					polls++;
+					ReadInputBuffer();
+				}
+			}
+
+			Assert::AreEqual<int>(2, polls, L"a frame issues at most Y polls");
+		}
+
+		// A poll updates only the channel it belongs to: with channels 0 and 1 enabled, channel 2
+		// and 3 stay silent.
+		TEST_METHOD(SiSpec_OnlyEnabledChannelsReceiveData)
+		{
+			GfxTestMachine& m = M();
+
+			SetPoll(m, 1, 4, (1u << 0) | (1u << 1));
+			PIClearAssertedInterrupts();
+
+			Si(m)->SIPoll(0);
+
+			uint32_t sr = ReadSiWord(SrReg);
+			Assert::AreEqual<uint32_t>(SI_SR_RDST0, sr & SI_SR_RDST0, L"channel 0 was polled");
+			Assert::AreEqual<uint32_t>(SI_SR_RDST1, sr & SI_SR_RDST1, L"channel 1 was polled");
+			Assert::AreEqual<uint32_t>(0, sr & SI_SR_RDST2, L"channel 2 was not polled");
+			Assert::AreEqual<uint32_t>(0, sr & SI_SR_RDST3, L"channel 3 was not polled");
+		}
+
+		// =========================================================================================
+		// 3. The read-status interrupt
+		// =========================================================================================
+
+		// A poll raises RDSTINT, but the SI interrupt is raised only when the read-status interrupt
+		// is unmasked.
+		TEST_METHOD(SiSpec_RdstInterruptHonoursItsMask)
+		{
+			GfxTestMachine& m = M();
+
+			SetPoll(m, 1, 4, 1);
+			WriteSiWord(ComCsr, ReadSiWord(ComCsr) & ~SI_COMCSR_RDSTINTMSK);
+			PIClearAssertedInterrupts();
+
+			Si(m)->SIPoll(5);
+
+			Assert::IsTrue(RdstInt(m), L"the poll set the read-status flag");
+			Assert::IsFalse(SiInterruptAsserted(), L"a masked read-status flag raises no interrupt");
+		}
+
+		// With the mask set the poll raises the Processor Interface interrupt.
+		TEST_METHOD(SiSpec_RdstInterruptReachesTheProcessorInterface)
+		{
+			GfxTestMachine& m = M();
+
+			SetPoll(m, 1, 4, 1);
+			WriteSiWord(ComCsr, ReadSiWord(ComCsr) | SI_COMCSR_RDSTINTMSK);
+			PIClearAssertedInterrupts();
+
+			Si(m)->SIPoll(5);
+
+			Assert::IsTrue(SiInterruptAsserted(), L"the poll is reported to the PI");
+		}
+
+		// Reading the input buffer of the polled channel is what clears the flag, and once every
+		// channel's flag is clear the PI interrupt must be dropped as well.
+		TEST_METHOD(SiSpec_ReadingTheInputBufferClearsTheInterrupt)
+		{
+			GfxTestMachine& m = M();
+
+			SetPoll(m, 1, 4, 1);
+			WriteSiWord(ComCsr, ReadSiWord(ComCsr) | SI_COMCSR_RDSTINTMSK);
+			PIClearAssertedInterrupts();
+
+			Si(m)->SIPoll(5);
+			Assert::IsTrue(SiInterruptAsserted(), L"the poll is reported to the PI");
+
+			ReadInputBuffer();
+
+			Assert::IsFalse(RdstInt(m), L"the buffer read cleared the flag");
+			Assert::IsFalse(SiInterruptAsserted(), L"and the PI interrupt went away with it");
+		}
+
+		// The flag is cleared by reading the input buffer, not by acknowledge through COMCSR.
+		TEST_METHOD(SiSpec_ComCsrWriteDoesNotClearThePollFlag)
+		{
+			GfxTestMachine& m = M();
+
+			SetPoll(m, 1, 4, 1);
+			PIClearAssertedInterrupts();
+
+			Si(m)->SIPoll(5);
+			Assert::IsTrue(RdstInt(m), L"the poll set the read-status flag");
+
+			WriteSiWord(ComCsr, ReadSiWord(ComCsr) & ~SI_COMCSR_RDSTINTMSK);
+			Assert::IsTrue(RdstInt(m), L"RDSTINT survives a COMCSR write");
+		}
+	};
+}

--- a/testing/gfx_test_support.cpp
+++ b/testing/gfx_test_support.cpp
@@ -19,6 +19,9 @@
 #include "pch.h"
 #include "gfx_test_common.h"
 
+static Flipper::SerialInterface* serialInterface = nullptr;
+
+
 namespace GfxUnitTest
 {
 	// -------------------------------------------------------------------------------------------
@@ -243,6 +246,8 @@ namespace GfxUnitTest
 		// The CP owns the CPU-visible graphics registers and the display-list FIFO; the tests drive
 		// it through the PI register window (PIRegWrite), exactly like the CPU does.
 		flipper->cp = new Flipper::CommandProcessor(flipper, &config);
+		serialInterface = new Flipper::SerialInterface(flipper, &config);
+		flipper->si = serialInterface;
 
 		started = true;
 		return true;
@@ -272,6 +277,11 @@ namespace GfxUnitTest
 		delete flipper->cp;
 		flipper->cp = nullptr;
 
+		delete serialInterface;
+		serialInterface = nullptr;
+		if (flipper != nullptr) flipper->si = nullptr;
+
+
 		Flipper::HW = nullptr;
 		Core = nullptr;
 
@@ -299,6 +309,13 @@ namespace GfxUnitTest
 		Assert::IsTrue(glOpen, Widen("the OpenGL backend could not be started: " + lastError).c_str());
 
 		gfx->ResetPipelineState();
+
+		// The serial interface is stateful (the poll schedule and the interrupt flags) and is not
+		// part of the pipeline state, so it is rebuilt. Its constructor also reinstalls the SI
+		// register traps, which then point at the new instance.
+		delete serialInterface;
+		serialInterface = new Flipper::SerialInterface(flipper, &config);
+		flipper->si = serialInterface;
 	}
 
 	void GfxTestMachine::BpLoad(unsigned index, uint32_t value)
@@ -758,4 +775,27 @@ namespace Flipper
 	{
 		// The unit tests render into an offscreen window; there is no XFB to disable.
 	}
+}
+
+// -------------------------------------------------------------------------------------------
+// Controller doubles. The SI reads the pad through the PAD plugin interface; the unit tests
+// answer with a neutral pad on every channel, so a test can tell "the channel was polled" from
+// "the channel was skipped" by looking at the read-status bits alone.
+// -------------------------------------------------------------------------------------------
+
+bool PADReadButtons(long padnum, PADState* state)
+{
+	if (padnum < 0 || padnum > 3 || state == nullptr)
+	{
+		return false;
+	}
+
+	// A neutral pad: no buttons, sticks centred and the triggers released.
+	*state = PADState{};
+	return true;
+}
+
+bool PADSetRumble(long padnum, long cmd)
+{
+	return true;
 }


### PR DESCRIPTION
Fixes #361.

The Wind Waker booted, configured the VI, and then sat on a black screen with no GX
work at all. Digging into it (and into Animal Crossing, which hung the same way)
turned up five defects on the path from the DSP/DI up to presentation. Both games now
render: ZWW reaches its title screen, Animal Crossing shows the Nintendo logo.

## Root causes

### 1. The first `PE_FINISH` switched the video output off (`src/pe.cpp`)

`PE_FINISH_ID` called `VIDisableXfb()` on the first finish and `PE_TOKEN_ID` called it
unconditionally. After the first frame there was no XFB left to scan out, so the VI
had nothing to present — the screen stayed black no matter what the guest drew.
The guest owns the XFB; the kill-switch is gone. The same commit audited the Command
Processor against the spec: `CP_FIFO_COUNT` now reports the live occupancy, `CP_BREAK`
is gated on `BPEN` (and raises the PI line only when `BPINTEN` is set), and
`ResetFifoProcessor()` was added.

### 2. The controller poll ran ~10x too fast (`src/si.cpp`, `src/flipper.cpp`)

The SI poll schedule was a fixed tick interval (`SI_POLLING_INTERVAL`, ~1.6 ms, measured
~619 polls/s). Every poll re-raised `RDSTINT` on a channel whose response the guest had
not read yet, so the CPU lived inside the SI handler: Animal Crossing reached only 3.8 s
of emulated time with ~165 000 exception entries and **zero** VI interrupts.

The schedule now follows `serial-interface.md` §5.1: `SIPOLL[X]` is the interval in video
lines, `SIPOLL[Y]` the number of polls per frame, polling is anchored to the vertical
blank (detected as a wrap of the video line counter) and `Y == 0` disables it. The
register file was brought in line with §4.1/§6.1/§11 as well: `SICnOUTBUF` is the
CPU-visible latch that `SISR[WR]` copies into the transfer engine's shadow buffer,
`SICOMCSR` latches `CHANNEL`/`INLNGTH` on an ordinary write, and `TSTART` reads back as a
pending bit. (Exception entry for AC: ~165 000 -> ~2 200.)

### 3. The DSP and DI aggregate interrupt lines were never asserted (`src/dsparam.cpp`, `src/di.cpp`)

Regression from the "re-evaluate the line in one place" refactor earlier on this branch.
Both helpers ANDed the *group* of cause bits with the *group* of mask bits:

```
CDCR:  DSPINT 0x080 / DSPINTMSK 0x100, ARINT 0x020 / ARINTMSK 0x040, AIINT 0x008 / AIINTMSK 0x010
DI_SR: BRKINT 0x40 / BRKINTMSK 0x20, TCINT 0x10 / TCINTMSK 0x08, ...
```

every cause has its **own** mask bit and the pairs are not adjacent, so the AND was always
zero — the PI lines for the whole audio/disk block were dead. With the DSP line dead, an
ARAM-DMA completion never reached the CPU: Animal Crossing posted its first ARQ request
right after `[AX] Audio enabled`, the DMA completed, the interrupt was never delivered and
the game spun forever in the ARQ wait (no GX frame was ever submitted). The lines are now
the OR of the `(cause && its own mask)` pairs, e.g.:

```cpp
bool ar = (CDCR & CDCR_ARINT) != 0 && (CDCR & CDCR_ARINTMSK) != 0;
```

### 4. DSP interrupt vectors were taken from the wrong base (`src/dspcore.cpp`)

The vector base came from the live CDCR "use-rom" bit. That bit only selects where a
*reset* starts: the IROM loader hands control to a downloaded microcode by jumping into the
IRAM window, and that microcode installs its own vector table at `0x0000` and expects it to
be used. Zelda's microcode has a CPU->DSP vector at `0x000E` that reads the mailbox and
dispatches the command (it closes `te3` at entry and opens it a few instructions later).
With the loader's vectors the interrupt ran the loader loop instead, which bounced the
command as "unknown" (`0xFEEE_8000`) and then waited for an acknowledgement — while the CPU
was waiting for its command to be consumed. The base now follows the program that is
running (the IROM window, or IRAM).

### 5. `CDCR` bit 1 is a request, not a pulse (`src/dsp.cpp`, `src/dspcore.cpp`)

`intdsp` is cleared by hardware when the core takes the interrupt through the `TE3`/`ET`
gate (`dsp.md` §4.2). The emulator only pulsed it, so a request that arrived while the
microcode had the interrupt masked (its startup window) was lost and the next mailbox
handshake deadlocked. The request is now latched and retried on every interrupt check until
the core accepts it — which also removes the CPU/DSP thread-timing dependence of the bug
(it used to disappear when logging slowed the CPU thread down).

## Tests

* `testing/gfx_si_spec_test.cpp` (new, 17 tests): SIPOLL layout and independent halves,
  per-channel output buffers, read-only input buffers, `SICOMCSR` field positions and
  `TSTART`, the poll interval / per-frame budget / vertical-blank anchor, per-channel
  enables, and the read-status interrupt with its mask and acknowledgement.
* `testing/dsp_control_test.cpp` (+6 tests): each DSP cause raises the PI line only through
  its own mask, a real ARAM-DMA completion reaches the PI, a masked completion latches but
  holds no line, acknowledging drops the line, the mailbox interrupt reaches the PI, and the
  CPU->DSP request survives a closed `TE3`/`ET` gate. The existing vector-base test was
  corrected: an IRAM program keeps the IRAM vectors whatever the reset-vector bit says, and
  an IROM program vectors at `0x8000 + offset`.

`pureikyubu_test.dll`: **390/390**.

## Verification

* `pureikyubu "C:\Isos\NGC\The Legend Of Zelda The Wind Waker.iso"` (GZLE01) — title screen
  renders; repeatable across runs (29-40 GX frames in ~40 s, dumped with `GFX_DUMP`).
* `pureikyubu "D:\Isos\Animal Crossing.GCM"` (GAFE01) — Nintendo logo renders, no regression from
  fixes 4/5.
* Wave Race was the baseline for fix 1 (the VI blits again instead of presenting nothing).

## Also in this PR (smaller, same branch)

* `pureikyubu <file>` / `--image <file>` loads and runs an image straight away instead of
  going through the game selector, and `--help` prints the accepted options (to the console
  and to the report log). Handy for unattended runs and for bug reports.
* `File -> Reopen` was a dead menu entry; it is now wired to the last image (`LASTFILE`) with
  `F3` as its accelerator.