### PR TITLE
DSP: vector the microcode interrupts from IRAM and latch the CPU->DSP…

### DIFF
--- a/src/dsp.cpp
+++ b/src/dsp.cpp
@@ -748,13 +748,30 @@ namespace DSP
 	{
 		if (val)
 		{
+			// CDCR bit 1 is a *request*, not a pulse: the hardware clears it when the core takes
+			// the interrupt through the TE3/ET gate (dsp.md section 4.2). Latch it so that a
+			// request which arrives while the core has the interrupt masked is delivered as soon
+			// as the gate opens - the loader hands control to a microcode that closes the window
+			// at its entry and opens it again a few instructions later, and both Zelda and the
+			// AX microcode rely on the request surviving that window.
+			intdspRequested = true;
 			core->AssertInterrupt(DspInterrupt::CpuInt);
 		}
 	}
 
 	bool Dsp16::GetIntBit()
 	{
-		return core->IsInterruptPending(DspInterrupt::CpuInt);
+		return intdspRequested || core->IsInterruptPending(DspInterrupt::CpuInt);
+	}
+
+	bool Dsp16::CpuIntRequested() const
+	{
+		return intdspRequested;
+	}
+
+	void Dsp16::ClearCpuIntRequest()
+	{
+		intdspRequested = false;
 	}
 
 	void Dsp16::SetHaltBit(bool val)

--- a/src/dsp.h
+++ b/src/dsp.h
@@ -198,6 +198,9 @@ namespace DSP
 		volatile uint16_t DspToCpuSnapshot = 0;		// DMBL latched with the last valid DMBH read
 		volatile bool DspToCpuSnapshotValid = false;
 
+		//! The CPU->DSP interrupt request (CDCR bit 1), latched until the core takes it.
+		bool intdspRequested = false;
+
 		volatile uint16_t CpuToDspMailbox[2]{};		// CMBH, CMBL
 		SpinLock CpuToDspLock;
 		volatile uint16_t CpuToDspSnapshot = 0;		// CMBL latched with the last valid CMBH read
@@ -258,6 +261,10 @@ namespace DSP
 		void CpuToDspWriteLo(uint16_t value);
 		uint16_t CpuToDspReadHi(bool ReadByDsp);
 		uint16_t CpuToDspReadLo(bool ReadByDsp);
+
+		//! The latched CPU->DSP interrupt request (see SetIntBit).
+		bool CpuIntRequested() const;
+		void ClearCpuIntRequest();
 
 		// DSP->CPU Mailbox
 		void DspToCpuWriteHi(uint16_t value);

--- a/src/dspcore.cpp
+++ b/src/dspcore.cpp
@@ -344,6 +344,18 @@ namespace DSP
 
 	void DspCore::CheckInterrupts()
 	{
+		// The CPU->DSP interrupt request stays latched in CDCR until the core takes it, so a
+		// request that arrived while TE3/ET was clear is retried here and delivered as soon as
+		// the gate opens (see Dsp16::SetIntBit).
+		if (dsp != nullptr && dsp->CpuIntRequested())
+		{
+			AssertInterrupt(DspInterrupt::CpuInt);
+			if (intr.pending[(size_t)DspInterrupt::CpuInt])
+			{
+				dsp->ClearCpuIntRequest();
+			}
+		}
+
 		if (!intr.pendingSomething)
 		{
 			return;
@@ -367,11 +379,16 @@ namespace DSP
 					}
 					regs.psr.et = 0;
 
-					// All vectors are offsets relative to the active program base, which is
-					// selected by the CDCR reset-vector bit: 0x8000 (IROM) after a hardware
-					// reset, 0x0000 (IRAM) once the CPU has cleared the bit and downloaded the
-					// microcode (dsp.md section 2.7).
-					DspAddress programBase = DSPGetResetModifier() ? IROM_START_ADDRESS : 0;
+					// All vectors are offsets relative to the base of the program that is
+					// running: the IROM loader has its vectors at 0x8000+, a downloaded
+					// microcode has its own at 0x0000+ (dsp.md section 2.7). The CDCR use-rom
+					// bit only selects where a *reset* starts - it must not pick the vector
+					// table, because the IROM loader hands control to the microcode by jumping
+					// into the IRAM window, and that microcode expects its own vectors there.
+					// Zelda's microcode installs a CPU->DSP interrupt vector at 0x000E that
+					// reads the mailbox and dispatches the command; with the loader's vectors
+					// the interrupt would bounce the command back as "unknown" instead.
+					DspAddress programBase = (regs.pc >= IROM_START_ADDRESS) ? IROM_START_ADDRESS : 0;
 
 					if (i == (size_t)DspInterrupt::Reset)
 					{

--- a/testing/dsp_control_test.cpp
+++ b/testing/dsp_control_test.cpp
@@ -206,26 +206,68 @@ namespace DspUnitTest
 			Assert::AreEqual(3u, m.core->regs.pc, L"reti must resume after the trap");
 		}
 
-		TEST_METHOD(InterruptVectorsAreRelativeToTheActiveProgramBase)
+		TEST_METHOD(InterruptVectorsFollowTheRunningProgramNotTheResetVectorBit)
 		{
-			// dsp.md section 2.7: the vector offsets are relative to the active program base -
-			// 0x0000 in IRAM, or 0x8000 in IROM while the reset-vector bit is set.
-			m.Run({ Enc::Nop(), Enc::Nop(), Enc::Nop(), Enc::Trap(), Enc::Nop(),
-				Enc::Nop(), Enc::Nop(), Enc::Nop(), Enc::Nop() }, 4);
-			// Taking the interrupt and executing the instruction it vectors to happen in the
-			// same step, so the pc lands on the word after the first instruction of the
-			// handler: 0x0004 + 1 in IRAM, 0x8004 + 1 in the IROM.
+			// dsp.md section 2.7: the vector offsets are relative to the *running* program's
+			// base. The CDCR use-rom bit selects where a reset starts; it does not move the
+			// vectors of a microcode that the IROM loader has already handed control to. Such
+			// a microcode installs its own vector table at 0x0000 and expects it to be used -
+			// Zelda's microcode puts a CPU->DSP interrupt vector at 0x000E that reads the
+			// mailbox, and with the loader's vectors its commands were bounced back instead.
+			const std::vector<uint16_t> program = {
+				Enc::Nop(), Enc::Nop(), Enc::Nop(), Enc::Trap(), Enc::Nop(),
+				Enc::Nop(), Enc::Nop(), Enc::Nop(), Enc::Nop() };
+
+			// IRAM, the reset-vector bit clear: the trap vector is 0x0004.
+			m.Run(program, 4);
 			m.Step();
 			Assert::AreEqual(5u, m.core->regs.pc, L"the trap vector is 0x0004 while running from IRAM");
 
+			// The same IRAM program with the reset-vector bit *set* keeps its own vectors.
 			m.Reset();
 			dsp_ai.cdcr |= CDCR_RESETMOD;
-			m.Run({ Enc::Nop(), Enc::Nop(), Enc::Nop(), Enc::Trap(), Enc::Nop(),
-				Enc::Nop(), Enc::Nop(), Enc::Nop(), Enc::Nop() }, 4);
+			m.Run(program, 4);
 			m.Step();
-			Assert::AreEqual(0x8005u, m.core->regs.pc,
-				L"the same vector is 0x8004 while the program base is the IROM");
+			Assert::AreEqual(5u, m.core->regs.pc,
+				L"a program running from IRAM keeps the IRAM vectors, whatever the reset-vector bit says");
 			dsp_ai.cdcr &= ~CDCR_RESETMOD;
+
+			// A program executing in the IROM window vectors at 0x8000 + offset.
+			m.Reset();
+			Assemble(m.core, DspTestMachine::IROM_BASE, program);
+			m.core->regs.pc = DspTestMachine::IROM_BASE;
+			m.Steps(4);			// nop, nop, nop, trap
+			m.Step();			// takes the trap and runs the handler's first word
+			Assert::AreEqual(0x8005u, m.core->regs.pc,
+				L"the same vector is 0x8004 while the core runs from the IROM");
+		}
+
+		TEST_METHOD(CpuIntRequestIsLatchedUntilTheCoreTakesIt)
+		{
+			// CDCR bit 1 is a *request*: the hardware clears it when the core takes the interrupt
+			// through the TE3/ET gate (dsp.md section 4.2). A request that arrives while the core
+			// has the interrupt masked must survive - the IROM loader hands control to a
+			// microcode that closes te3 at its first instruction and opens it a few instructions
+			// later, and both Zelda's and the AX microcode send mailbox commands right after
+			// asking for the interrupt.
+			m.core->regs.psr.et = 1;
+			m.core->regs.psr.te3 = 0;
+
+			Flipper::DSP->SetIntBit(true);
+
+			Assert::IsTrue(Flipper::DSP->GetIntBit(), L"the request is latched while it cannot be taken");
+			Assert::IsFalse(m.core->IsInterruptPending(DspInterrupt::CpuInt),
+				L"a request behind a closed TE3/ET gate is not delivered yet");
+
+			// The microcode opens the gate; the pending request must be delivered, not lost. The
+			// core takes it after its own two-instruction pending delay (dsp.md section 2.7).
+			m.core->regs.psr.te3 = 1;
+			m.core->regs.pc = DspTestMachine::IRAM_BASE;
+			m.Steps(3);			// delivered, delayed twice, then taken: pc lands on the vector
+
+			Assert::AreEqual(0x000Fu, m.core->regs.pc,
+				L"the CPU->DSP vector is 0x000E while the core runs from IRAM");
+			Assert::IsFalse(Flipper::DSP->GetIntBit(), L"taking the interrupt clears the request");
 		}
 
 		TEST_METHOD(Wait_DoesNotAdvancePc)


### PR DESCRIPTION
… request

Zelda Wind Waker (GZLE01) hung during its first mailbox handshake: the IROM loader booted the microcode, the CPU sent a command and asked for the CPU->DSP interrupt, and then spun forever waiting for the microcode to consume the command. Two defects in the DSP core were behind it.

1. The interrupt vector base was taken from the live CDCR use-rom bit. That bit only selects where a *reset* starts: the IROM loader hands control to the microcode by jumping into the IRAM window, and the microcode expects its own vector table there. Zelda's microcode installs a CPU->DSP vector at 0x000E that reads the mailbox and dispatches the command (and closes te3 at its entry, opening it again a few instructions later). With the loader's vectors the interrupt ran the loader loop instead, which bounced the command as "unknown" and then waited for the CPU to acknowledge the bounce - while the CPU was waiting for its command to be consumed. The base now follows the program that is running (the IROM window, or IRAM).

2. CDCR bit 1 is a *request* that the hardware clears when the core takes the interrupt through the TE3/ET gate. The emulator only pulsed the interrupt, so a request that arrived during the microcode's startup window (te3 closed) was lost, and the following mailbox handshake deadlocked. The request is now latched and re-tried on every interrupt check until the core accepts it, which is also what makes the fix independent of CPU/DSP thread timing.

Both are covered by unit tests (the vector test is corrected: an IRAM program keeps the IRAM vectors whatever the reset-vector bit says, and an IROM program vectors at 0x8000+; plus the latched-request test). Together with the earlier ARAM/DSP interrupt-line fix, Wind Waker boots to its title screen and Animal Crossing still shows the Nintendo logo.